### PR TITLE
Issue 350

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -109,6 +109,10 @@ osf_upload: prepare_release osf_upload_direct
 osf_upload_direct:
 	cd ../.. && $(OSF_UPLOAD) -f -r target/ current/ && $(OSF_UPLOAD) -f -r target/ releases/$(ISODATE)
 
+list_assets:
+	ls -alt $(ASSETS)
+	echo $(GHVERSION)
+
 deploy_assets_direct:
 	ls -alt $(ASSETS)
 	../utils/make-release-assets.py --release $(GHVERSION) $(ASSETS)
@@ -371,7 +375,7 @@ reports/equiv-replaced-by-%.tsv:
 	pl2sparql -e -A void.ttl -i mondo_edit -i equivs -i mirror/$*.owl -c ../plq/mondo_queries.pro -l equivalent_to_replaced_by > $@
 
 reports/proxy-merge.tsv: mondo.owl
-	./mq -i all proxy_merge -f tsv -l > $@.tmp && mv $@.tmp $@
+	./mq -i all proxy_merge -f tsv -l > $@.tmp && sort -u $@.tmp > $@
 #	pl2sparql -f tsv -A void.ttl -e -i all -c ../plq/proxy_merge.pro proxy_merge > $@.tmp && mv $@.tmp $@
 
 # the main OWL file will have 'pseudo-roots' caused by the fact that external classes
@@ -754,6 +758,14 @@ omim2medgen.obo: mim2gene_medgen
 # mondo_queries requires for prefixes
 all_unique.tsv:
 	rdfmatch -p MONDO -l -c  ../plq/mondo_queries.pro  -X tmp -A void.ttl -f tsv -v -i all -i skos.ttl unique_match > $@
+
+lexrules-%.pro:
+	test -d tmp-$* || mkdir -p tmp-$*
+	rdfmatch --ontA MONDO --ontB $(shell echo $* | tr a-z A-Z) -l -c  ../plq/mondo_queries.pro  -X tmp-$* -A void.ttl -f tsv -v -i mondo_edit -i equivs -i mirror/$*.owl -i skos.ttl learn > $@
+.PRECIOUS: lexrules-%.pro
+
+match-%.tsv: lexrules-%.pro
+	rdfmatch -p MONDO -l -c  ../plq/mondo_queries.pro  -X tmp-$* -A void.ttl -f tsv -v -i mondo_edit -i equivs -i mirror/$*.owl -i skos.ttl classify $< > $@
 
 all_unique_fresh: clean_tmp all_unique.tsv
 clean_tmp:

--- a/src/ontology/imports/foodon_import.obo
+++ b/src/ontology/imports/foodon_import.obo
@@ -415,7 +415,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400004
 name: product type, other
 comment: LanguaL curation note: Used only if the product does not fall under any of the major product types listed. [FDA CFSAN 1995]
-xref: LANGUAL:A0004
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0004
 is_a: FOODON:03400361 ! food product type
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -424,7 +424,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400148
 name: milk or milk product (us cfr)
 def: "Milk in all forms, milk-based beverage, cultured milk product, or milk or milk product analog. Index infant formula under *MEAL REPLACEMENT*." []
-xref: LANGUAL:A0148
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0148
 is_a: FOODON:03400164 ! dairy product (us cfr)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -433,7 +433,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400164
 name: dairy product (us cfr)
 def: "Milk, a product derived from milk, or a dairy product analog; includes cheese and frozen dairy desserts. [FDA CFSAN 1995]" []
-xref: LANGUAL:A0164
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0164
 is_a: FOODON:03401270 ! product type,  u.s. code of federal regulations, title 21
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -442,7 +442,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400217
 name: meat, poultry, seafood or related product (us cfr)
 def: "Products of the flesh of animals. [FDA CFSAN 1995]" []
-xref: LANGUAL:A0217
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0217
 is_a: FOODON:03401270 ! product type,  u.s. code of federal regulations, title 21
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -451,7 +451,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400267
 name: seafood or seafood product (us cfr)
 def: "Flesh from fish or shellfish. Includes seafood product analogs and seafood-based sausage or luncheon meat as well as such products as squid ink and clam juice." []
-xref: LANGUAL:A0267
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0267
 is_a: FOODON:03400217 ! meat, poultry, seafood or related product (us cfr)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -461,7 +461,7 @@ id: FOODON:03400289
 name: product type, usa
 def: "Food group having common consumption, functional or manufacturing characteristics, e.g. *FRUIT OR VEGETABLE PRODUCT*, *DAIRY PRODUCT*, *CONFECTIONARY*, *PREPARED FOOD PRODUCT*, etc. [FDA CFSAN 1995]" []
 comment: LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.
-xref: LANGUAL:A0289
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0289
 is_a: FOODON:03400361 ! food product type
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -471,7 +471,7 @@ id: FOODON:03400352
 name: product type, international
 def: "Renamed from *PRODUCT TYPE, CODEX ALIMENTARIUS* in LanguaL 2008." []
 comment: LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.
-xref: LANGUAL:A0352
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0352
 is_a: FOODON:03400361 ! food product type
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -481,7 +481,7 @@ id: FOODON:03400361
 name: food product type
 def: "A food product type is a class of food products that is differentiated by its food composition, processing and/or consumption characteristics. This does not include brand name products but it may include generic food dish categories." []
 comment: LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.
-xref: LANGUAL:A0361
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0361
 is_a: BFO:0000040 ! material entity
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -492,7 +492,7 @@ id: FOODON:03400643
 name: classification of food and feed commodities (codex alimentarius)
 def: "Codex Alimentarius, Volume 2 - 1993, Section 2:  Pesticide Residues in Food.\n\nThe Codex Classification of food and animal feed commodities moving in trade and the description of the various items and groups of food and animal feedstuffs included in the present document have been developed by the Codex Committee on Pesticide Residues. It was first adopted by the 18th Session of the Codex Alimentarius Commission, (1989).\n\nThe Codex Classification includes food commodities and animal feedstuffs for which Codex maximum residue limits will not necessarily be established. The Classification is intended to be as complete a listing of food commodities in trade as possible, classified into groups on the basis of the commodity's similar potential for pesticide residues.\n\nThe Classification may also be appropriate for other purposes such as setting maximum levels for other types of residues or for other contaminants in food. The Codex Classification should be consulted in order to obtain a precise description of the food or animal feed commodities and, especially, in cases where Codex maximum residue limits have been set for groups of food and groups of animal feedstuffs. The Codex Classification is intended to promote harmonization of the terms used to describe commodities which are subject to maximum residue limits and of the approach to grouping commodities with similar potential for residue for which a common group maximum residue limit can be set." []
 comment: LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.
-xref: LANGUAL:A0643
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0643
 is_a: FOODON:03400352 ! product type, international
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -501,7 +501,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400644
 name: a.  primary food commodities of plant origin (ccpr)
 comment: LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.
-xref: LANGUAL:A0644
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0644
 is_a: FOODON:03400643 ! classification of food and feed commodities (codex alimentarius)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -510,7 +510,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400652
 name: 04  nuts and seeds (ccpr)
 def: "TYPE 04  -  NUTS AND SEEDS\n\nNuts and seeds are derived from a large variety of trees, shrubs and herbaceous plants, mostly cultivated.\n\nThe mature seeds or nuts are used as human food, for the production of beverages or edible vegetable oils and for the production of seed meals and cakes for animal feed." []
-xref: LANGUAL:A0652
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0652
 is_a: FOODON:03400644 ! a.  primary food commodities of plant origin (ccpr)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -519,7 +519,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03400685
 name: 022  tree nuts (tn) (ccpr)
 def: "Tree nuts are the seeds of a variety of trees and shrubs which are characterized by a hard inedible shell enclosing an oily seed.\nThe seed is protected from pesticides applied during the growing season by the shell and other parts of the fruit.\nThe edible portion of the nut is consumed in succulent, dried or processed forms." []
-xref: LANGUAL:A0685
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A0685
 is_a: FOODON:03400652 ! 04  nuts and seeds (ccpr)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -529,7 +529,7 @@ id: FOODON:03401270
 name: product type,  u.s. code of federal regulations, title 21
 def: "Food and Drugs, title 21, Code of Federal Regulations. Original  food classification in LanguaL." []
 comment: LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.
-xref: LANGUAL:A1270
+xref: http://www.langual.org/langual_thesaurus.asp?termid=A1270
 is_a: FOODON:03400289 ! product type, usa
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -537,7 +537,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 [Term]
 id: FOODON:03411047
 name: grain or seed-producing plant (food source)
-xref: LANGUAL:B1047
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1047
 is_a: FOODON:03411347 ! plant (food source)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -546,7 +546,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411059
 name: shellfish or crustacean (food source)
 def: "Shellfish is a food source and fisheries term for exoskeleton-bearing aquatic invertebrates used as food, including various species of molluscs, crustaceans, and echinoderms. Although most kinds of shellfish are harvested from saltwater environments, some kinds are found in freshwater. In addition, a few species of land crabs are eaten, for example *Cardisoma guanhumi* in the Caribbean. [https://en.wikipedia.org/wiki/Shellfish]" []
-xref: LANGUAL:B1059
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1059
 is_a: FOODON:00002452
 union_of: FOODON:03411374 ! crustacean (food source)
 union_of: FOODON:03411433 ! shellfish (food source)
@@ -561,7 +561,7 @@ synonym: "Dendrobranchiata Bate, 1888" NARROW []
 synonym: "Natantia" NARROW []
 xref: EC:No 216/2009 DCP
 xref: http://eol.org/pages/7184
-xref: LANGUAL:B1081
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1081
 is_a: FOODON:03411237 ! shrimp (food source)
 property_value: hasSynonym "dendrobranchiata" xsd:string
 property_value: hasSynonym "natantia" xsd:string
@@ -575,7 +575,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 [Term]
 id: FOODON:03411134
 name: animal (mammal) (food source)
-xref: LANGUAL:B1134
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1134
 is_a: FOODON:03411297 ! vertebrate animal (food source)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -586,8 +586,8 @@ name: cattle (food source)
 def: "Cattle (colloquially cows) are the most common type of large domesticated ungulates. They are a prominent modern member of the subfamily *Bovinae*, are the most widespread species of the genus *Bos*, and are most commonly classified collectively as *Bos taurus*... with three subspecies: *Bos taurus primigenius, Bos taurus indicus, Bos taurus taurus*. [https://en.wikipedia.org/wiki/Cattle]" []
 synonym: "Bos taurus Linnaeus, 1758" NARROW []
 xref: http://eol.org/pages/328699
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1161
 xref: ITIS:183838
-xref: LANGUAL:B1161
 xref: MSW3:14200687
 xref: NCBITaxon:9913
 is_a: FOODON:03414374 ! bovine (food source)
@@ -605,8 +605,8 @@ id: FOODON:03411201
 name: cow (food source)
 synonym: "Bos taurus Linnaeus, 1758" NARROW []
 xref: http://eol.org/pages/328699
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1201
 xref: ITIS:183838
-xref: LANGUAL:B1201
 xref: MSW3:14200687
 xref: NCBITaxon:9913
 is_a: FOODON:03411161 ! cattle (food source)
@@ -618,7 +618,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 [Term]
 id: FOODON:03411215
 name: algae, bacteria or fungus (food source)
-xref: LANGUAL:B1215
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1215
 disjoint_from: FOODON:03411297 ! vertebrate animal (food source)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -627,7 +627,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411237
 name: shrimp (food source)
 xref: http://eol.org/pages/2602479
-xref: LANGUAL:B1237
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1237
 is_a: FOODON:03411998 ! decapod (food source)
 property_value: hasSynonym "caridea" xsd:string
 property_value: hasSynonym "crangonidae" xsd:string
@@ -641,7 +641,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411261
 name: fungus (food source)
 def: "A fungus (plural: fungi or funguses) is any member of the group of eukaryotic organisms that includes unicellular microorganisms such as yeasts and molds, as well as multicellular fungi that produce familiar fruiting forms known as mushrooms. These organisms are classified as a kingdom, *Fungi*, which is separate from the other eukaryotic life kingdoms of plants and animals.[https://en.wikipedia.org/wiki/Fungus]" []
-xref: LANGUAL:B1261
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1261
 is_a: FOODON:03411215 ! algae, bacteria or fungus (food source)
 property_value: hasSynonym "fungi" xsd:string
 property_value: hasSynonym "funguses" xsd:string
@@ -653,7 +653,7 @@ id: FOODON:03411297
 name: vertebrate animal (food source)
 def: "Multicellular animal, e.g., fish, meat animal or poultry." []
 comment: LanguaL curation note: For a unicellular animal, use *ALGAE OR FUNGUS USED AS FOOD SOURCE*.
-xref: LANGUAL:B1297
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1297
 is_a: FOODON:03411564 ! food source
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -662,7 +662,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411301
 name: algae (food source)
 def: "Unicellular and multicellular algae." []
-xref: LANGUAL:B1301
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1301
 is_a: FOODON:03411215 ! algae, bacteria or fungus (food source)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -670,7 +670,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 [Term]
 id: FOODON:03411324
 name: grain plant (food source)
-xref: LANGUAL:B1324
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1324
 is_a: FOODON:03411047 ! grain or seed-producing plant (food source)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -680,8 +680,8 @@ id: FOODON:03411328
 name: goat (food source)
 synonym: "Capra hircus Linnaeus, 1758" NARROW []
 xref: http://eol.org/pages/328660
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1328
 xref: ITIS:180715
-xref: LANGUAL:B1328
 xref: MSW3:14200776
 xref: NCBITaxon:9925
 is_a: FOODON:03411134 ! animal (mammal) (food source)
@@ -696,7 +696,7 @@ id: FOODON:03411335
 name: crab (food source)
 def: "Crabs are decapod crustaceans of the infraorder *Brachyura*, which typically have a very short projecting \"tail\", usually entirely hidden under the thorax. They live in all the world's oceans, in fresh water, and on land, are generally covered with a thick exoskeleton and have a single pair of claws. Many other animals with similar names - such as hermit crabs, king crabs, porcelain crabs, horseshoe crabs, and crab lice - are not true crabs. \n Crabs are generally covered with a thick exoskeleton, composed primarily of highly mineralized chitin, and armed with a single pair of chelae (claws). Crabs are found in all of the world's oceans, while many crabs live in fresh water and on land, particularly in tropical regions. [https://en.wikipedia.org/wiki/Crab]" []
 xref: http://eol.org/pages/2604866
-xref: LANGUAL:B1335
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1335
 is_a: FOODON:03411998 ! decapod (food source)
 property_value: hasSynonym "brachyura" xsd:string
 property_value: hasSynonym "short-tailed crabs" xsd:string
@@ -709,7 +709,7 @@ id: FOODON:03411347
 name: plant (food source)
 def: "Multicellular plants." []
 comment: LanguaL curation note: For unicellular plants as well as for algae, mushrooms and yeast, use the appropriate narrower term under *ALGAE OR FUNGUS USED AS FOOD SOURCE*.
-xref: LANGUAL:B1347
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1347
 is_a: FOODON:03411564 ! food source
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -719,7 +719,7 @@ id: FOODON:03411374
 name: crustacean (food source)
 def: "Crustaceans form a large, diverse arthropod taxon which includes such familiar animals as crabs, lobsters, crayfish, shrimp, krill, woodlice, and barnacles. [https://en.wikipedia.org/wiki/Crustacean]" []
 xref: http://eol.org/pages/2598871
-xref: LANGUAL:B1374
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1374
 is_a: FOODON:00002452
 disjoint_from: FOODON:03411433 ! shellfish (food source)
 property_value: hasSynonym "crustacea" xsd:string
@@ -730,7 +730,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411433
 name: shellfish (food source)
 def: "The term shellfish is used both broadly and specifically. For regulatory purposes it is often narrowly defined as filter-feeding molluscs such as clams, mussels, and oyster to the exclusion of crustaceans and all else. Although their shells may differ, all shellfish are invertebrates. [https://en.wikipedia.org/wiki/Shellfish]" []
-xref: LANGUAL:B1433
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1433
 is_a: FOODON:00002452
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -739,7 +739,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411564
 name: food source
 def: "Individual plant or animal from which the food product or its major ingredient is derived; also a chemical food source [FDA CFSAN 1995]." []
-xref: LANGUAL:B1564
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1564
 is_a: ENVO:00010483 ! environmental material
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000412 http://langual.org xsd:string
@@ -748,7 +748,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03411998
 name: decapod (food source)
 def: "The Decapoda or decapods (literally \"ten-footed\") are an order of crustaceans within the class Malacostraca, including many familiar groups, such as crayfish, crabs, lobsters, prawns, and shrimp. Most decapods are scavengers. [https://en.wikipedia.org/wiki/Decapoda]" []
-xref: LANGUAL:B1998
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B1998
 is_a: FOODON:03411374 ! crustacean (food source)
 property_value: hasSynonym "decapoda" xsd:string
 property_value: IAO:0000114 IAO:0000428
@@ -762,7 +762,7 @@ synonym: "Mollusca" NARROW []
 xref: EC:No 216/2009 MOL
 xref: FAO ASFIS:MOL
 xref: http://eol.org/pages/2195
-xref: LANGUAL:B2112
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B2112
 is_a: FOODON:03411433 ! shellfish (food source)
 property_value: hasSynonym "mollusca" xsd:string
 property_value: IAO:0000114 IAO:0000428
@@ -773,7 +773,7 @@ id: FOODON:03412215
 name: mud crab family (food source)
 def: "Mud crab may refer to any crab that lives in or near mud, such as: species from family *Portunidae*, such as *Scylla serrata*; *Scylla tranquebarica*; *Scylla paramamosain*; members of the family *Panopeidae*, such as *Panopeus herbstii*; members of the family *Xanthidae*; *Helice crassa*, the tunnelling mud crab. [https://en.wikipedia.org/wiki/Mud_crab]" []
 xref: http://eol.org/pages/7194
-xref: LANGUAL:B2215
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B2215
 is_a: FOODON:03411335 ! crab (food source)
 property_value: hasSynonym "mud crabs" xsd:string
 property_value: hasSynonym "panopeidae" xsd:string
@@ -789,7 +789,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 id: FOODON:03412345
 name: lichen (food source)
 def: "Lichens are composite organisms consisting of a symbiotic association of a fungus (the mycobiont) with a photosynthetic partner (the photobiont or phycobiont), usually either a green alga (commonly *Trebouxia*) or cyanobacterium (commonly *Nostoc*)." []
-xref: LANGUAL:B2345
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B2345
 is_a: FOODON:03411215 ! algae, bacteria or fungus (food source)
 property_value: IAO:0000114 IAO:0000428
 property_value: IAO:0000119 WIKIPEDIA:Lichen xsd:string
@@ -800,8 +800,8 @@ id: FOODON:03412611
 name: doe (goat) (food source)
 synonym: "Capra hircus Linnaeus, 1758" NARROW []
 xref: http://eol.org/pages/328660
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B2611
 xref: ITIS:180715
-xref: LANGUAL:B2611
 xref: MSW3:14200776
 xref: NCBITaxon:9925
 is_a: FOODON:03411328 ! goat (food source)
@@ -817,8 +817,8 @@ id: FOODON:03412702
 name: kid (food source)
 synonym: "Capra hircus Linnaeus, 1758" NARROW []
 xref: http://eol.org/pages/328660
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B2702
 xref: ITIS:180715
-xref: LANGUAL:B2702
 xref: MSW3:14200776
 xref: NCBITaxon:9925
 is_a: FOODON:03411328 ! goat (food source)
@@ -830,7 +830,7 @@ property_value: IAO:0000412 http://langual.org xsd:string
 [Term]
 id: FOODON:03412846
 name: bacteria (food source)
-xref: LANGUAL:B2846
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B2846
 is_a: FOODON:03411215 ! algae, bacteria or fungus (food source)
 intersection_of: FOODON:00001303 NCBITaxon:2 ! has taxonomic identifier Bacteria
 intersection_of: FOODON:00001303 NCBITaxon:2 {all_only="true"} ! has taxonomic identifier Bacteria
@@ -842,7 +842,7 @@ id: FOODON:03414374
 name: bovine (food source)
 def: "The biological subfamily *Bovinae* includes a diverse group of 10 genera of medium- to large-sized ungulates, including domestic cattle, the bison, African buffalo, the water buffalo, the yak, and the four-horned and spiral-horned antelopes. The evolutionary relationship between the members of the group is obscure, and their classification into loose tribes rather than formal subgroups reflects this uncertainty. General characteristics include cloven hoofs and usually at least one of the sexes of a species having true horns." []
 xref: http://eol.org/pages/2851454
-xref: LANGUAL:B4374
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B4374
 is_a: FOODON:03414381 ! bovid (food source)
 property_value: hasSynonym "bovinae" xsd:string
 property_value: IAO:0000114 IAO:0000428
@@ -854,7 +854,7 @@ id: FOODON:03414381
 name: bovid (food source)
 def: "A bovid (family *Bovidae*) is any of almost 140 species of cloven-hoofed, ruminant mammal which has males with characteristic unbranching horns covered in a permanent sheath of keratin.\n\nThe family is widespread, being native to Asia, Africa, Europe and North America, and diverse: members include bison, African buffalo, water buffalo, antelopes, gazelles, sheep, goats, muskoxen, and domestic cattle." []
 xref: http://eol.org/pages/7687
-xref: LANGUAL:B4381
+xref: http://www.langual.org/langual_thesaurus.asp?termid=B4381
 is_a: FOODON:03411134 ! animal (mammal) (food source)
 property_value: hasSynonym "bovidae" xsd:string
 property_value: IAO:0000114 IAO:0000428

--- a/src/ontology/imports/foodon_import.owl
+++ b/src/ontology/imports/foodon_import.owl
@@ -1588,7 +1588,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03400361"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0004</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0004</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: Used only if the product does not fall under any of the major product types listed. [FDA CFSAN 1995]</rdfs:comment>
         <rdfs:label xml:lang="en">product type, other</rdfs:label>
     </owl:Class>
@@ -1602,7 +1602,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Milk in all forms, milk-based beverage, cultured milk product, or milk or milk product analog. Index infant formula under *MEAL REPLACEMENT*.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0148</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0148</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">milk or milk product (us cfr)</rdfs:label>
     </owl:Class>
     
@@ -1615,7 +1615,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Milk, a product derived from milk, or a dairy product analog; includes cheese and frozen dairy desserts. [FDA CFSAN 1995]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0164</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0164</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">dairy product (us cfr)</rdfs:label>
     </owl:Class>
     
@@ -1628,7 +1628,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Products of the flesh of animals. [FDA CFSAN 1995]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0217</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0217</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">meat, poultry, seafood or related product (us cfr)</rdfs:label>
     </owl:Class>
     
@@ -1641,7 +1641,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Flesh from fish or shellfish. Includes seafood product analogs and seafood-based sausage or luncheon meat as well as such products as squid ink and clam juice.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0267</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0267</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">seafood or seafood product (us cfr)</rdfs:label>
     </owl:Class>
     
@@ -1654,7 +1654,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Food group having common consumption, functional or manufacturing characteristics, e.g. *FRUIT OR VEGETABLE PRODUCT*, *DAIRY PRODUCT*, *CONFECTIONARY*, *PREPARED FOOD PRODUCT*, etc. [FDA CFSAN 1995]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0289</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0289</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.</rdfs:comment>
         <rdfs:label xml:lang="en">product type, usa</rdfs:label>
     </owl:Class>
@@ -1668,7 +1668,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Renamed from *PRODUCT TYPE, CODEX ALIMENTARIUS* in LanguaL 2008.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0352</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0352</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.</rdfs:comment>
         <rdfs:label xml:lang="en">product type, international</rdfs:label>
     </owl:Class>
@@ -1683,7 +1683,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000115 xml:lang="en">A food product type is a class of food products that is differentiated by its food composition, processing and/or consumption characteristics. This does not include brand name products but it may include generic food dish categories.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0361</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0361</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.</rdfs:comment>
         <rdfs:label xml:lang="en">food product type</rdfs:label>
     </owl:Class>
@@ -1703,7 +1703,7 @@ The Codex Classification includes food commodities and animal feedstuffs for whi
 
 The Classification may also be appropriate for other purposes such as setting maximum levels for other types of residues or for other contaminants in food. The Codex Classification should be consulted in order to obtain a precise description of the food or animal feed commodities and, especially, in cases where Codex maximum residue limits have been set for groups of food and groups of animal feedstuffs. The Codex Classification is intended to promote harmonization of the terms used to describe commodities which are subject to maximum residue limits and of the approach to grouping commodities with similar potential for residue for which a common group maximum residue limit can be set.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0643</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0643</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.</rdfs:comment>
         <rdfs:label xml:lang="en">classification of food and feed commodities (codex alimentarius)</rdfs:label>
     </owl:Class>
@@ -1716,7 +1716,7 @@ The Classification may also be appropriate for other purposes such as setting ma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03400643"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0644</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0644</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.</rdfs:comment>
         <rdfs:label xml:lang="en">a.  primary food commodities of plant origin (ccpr)</rdfs:label>
     </owl:Class>
@@ -1734,7 +1734,7 @@ Nuts and seeds are derived from a large variety of trees, shrubs and herbaceous 
 
 The mature seeds or nuts are used as human food, for the production of beverages or edible vegetable oils and for the production of seed meals and cakes for animal feed.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0652</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0652</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">04  nuts and seeds (ccpr)</rdfs:label>
     </owl:Class>
     
@@ -1749,7 +1749,7 @@ The mature seeds or nuts are used as human food, for the production of beverages
 The seed is protected from pesticides applied during the growing season by the shell and other parts of the fruit.
 The edible portion of the nut is consumed in succulent, dried or processed forms.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A0685</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A0685</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">022  tree nuts (tn) (ccpr)</rdfs:label>
     </owl:Class>
     
@@ -1762,7 +1762,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Food and Drugs, title 21, Code of Federal Regulations. Original  food classification in LanguaL.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:A1270</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=A1270</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: This term is for CLASSIFICATION ONLY; DO NOT USE term in indexing. Use a more precise narrower term.</rdfs:comment>
         <rdfs:label xml:lang="en">product type,  u.s. code of federal regulations, title 21</rdfs:label>
     </owl:Class>
@@ -1775,7 +1775,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03411347"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1047</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1047</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">grain or seed-producing plant (food source)</rdfs:label>
     </owl:Class>
     
@@ -1796,7 +1796,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Shellfish is a food source and fisheries term for exoskeleton-bearing aquatic invertebrates used as food, including various species of molluscs, crustaceans, and echinoderms. Although most kinds of shellfish are harvested from saltwater environments, some kinds are found in freshwater. In addition, a few species of land crabs are eaten, for example *Cardisoma guanhumi* in the Caribbean. [https://en.wikipedia.org/wiki/Shellfish]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1059</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1059</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">shellfish or crustacean (food source)</rdfs:label>
     </owl:Class>
     
@@ -1811,8 +1811,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000119>WIKIPEDIA:Penaeus</obo:IAO_0000119>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref>EC:No 216/2009 DCP</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B1081</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/7184</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1081</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Dendrobranchiata Bate, 1888</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>Natantia</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasSynonym xml:lang="en">dendrobranchiata</oboInOwl:hasSynonym>
@@ -1831,7 +1831,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03411297"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1134</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1134</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">animal (mammal) (food source)</rdfs:label>
     </owl:Class>
     
@@ -1861,9 +1861,9 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9913"/>
         <oboInOwl:hasDbXref>ITIS:183838</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B1161</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>MSW3:14200687</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/328699</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1161</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Bos taurus Linnaeus, 1758</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasSynonym xml:lang="en">auroch</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">bos spp.</oboInOwl:hasSynonym>
@@ -1881,9 +1881,9 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9913"/>
         <oboInOwl:hasDbXref>ITIS:183838</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B1201</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>MSW3:14200687</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/328699</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1201</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Bos taurus Linnaeus, 1758</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasSynonym xml:lang="en">bos taurus</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">domesticated cattle</oboInOwl:hasSynonym>
@@ -1912,7 +1912,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         </owl:equivalentClass>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1215</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1215</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">algae, bacteria or fungus (food source)</rdfs:label>
     </owl:Class>
     
@@ -1924,8 +1924,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03411998"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1237</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/2602479</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1237</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">caridea</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">crangonidae</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">palaemondidae</oboInOwl:hasSynonym>
@@ -1943,7 +1943,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">A fungus (plural: fungi or funguses) is any member of the group of eukaryotic organisms that includes unicellular microorganisms such as yeasts and molds, as well as multicellular fungi that produce familiar fruiting forms known as mushrooms. These organisms are classified as a kingdom, *Fungi*, which is separate from the other eukaryotic life kingdoms of plants and animals.[https://en.wikipedia.org/wiki/Fungus]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1261</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1261</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">fungi</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">funguses</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">fungus (food source)</rdfs:label>
@@ -1958,7 +1958,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Multicellular animal, e.g., fish, meat animal or poultry.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1297</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1297</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: For a unicellular animal, use *ALGAE OR FUNGUS USED AS FOOD SOURCE*.</rdfs:comment>
         <rdfs:label xml:lang="en">vertebrate animal (food source)</rdfs:label>
     </owl:Class>
@@ -1972,7 +1972,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Unicellular and multicellular algae.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1301</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1301</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">algae (food source)</rdfs:label>
     </owl:Class>
     
@@ -1984,7 +1984,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03411047"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1324</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1324</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">grain plant (food source)</rdfs:label>
     </owl:Class>
     
@@ -2012,9 +2012,9 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9925"/>
         <oboInOwl:hasDbXref>ITIS:180715</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B1328</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>MSW3:14200776</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/328660</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1328</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Capra hircus Linnaeus, 1758</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasSynonym xml:lang="en">capra hircus</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">goat (food source)</rdfs:label>
@@ -2030,8 +2030,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000115 xml:lang="en">Crabs are decapod crustaceans of the infraorder *Brachyura*, which typically have a very short projecting &quot;tail&quot;, usually entirely hidden under the thorax. They live in all the world&apos;s oceans, in fresh water, and on land, are generally covered with a thick exoskeleton and have a single pair of claws. Many other animals with similar names - such as hermit crabs, king crabs, porcelain crabs, horseshoe crabs, and crab lice - are not true crabs. 
  Crabs are generally covered with a thick exoskeleton, composed primarily of highly mineralized chitin, and armed with a single pair of chelae (claws). Crabs are found in all of the world&apos;s oceans, while many crabs live in fresh water and on land, particularly in tropical regions. [https://en.wikipedia.org/wiki/Crab]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1335</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/2604866</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1335</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">brachyura</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">short-tailed crabs</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">true crabs</oboInOwl:hasSynonym>
@@ -2047,7 +2047,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Multicellular plants.</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1347</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1347</oboInOwl:hasDbXref>
         <rdfs:comment xml:lang="en">LanguaL curation note: For unicellular plants as well as for algae, mushrooms and yeast, use the appropriate narrower term under *ALGAE OR FUNGUS USED AS FOOD SOURCE*.</rdfs:comment>
         <rdfs:label xml:lang="en">plant (food source)</rdfs:label>
     </owl:Class>
@@ -2062,8 +2062,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Crustaceans form a large, diverse arthropod taxon which includes such familiar animals as crabs, lobsters, crayfish, shrimp, krill, woodlice, and barnacles. [https://en.wikipedia.org/wiki/Crustacean]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1374</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/2598871</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1374</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">crustacea</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">crustacean (food source)</rdfs:label>
     </owl:Class>
@@ -2077,7 +2077,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">The term shellfish is used both broadly and specifically. For regulatory purposes it is often narrowly defined as filter-feeding molluscs such as clams, mussels, and oyster to the exclusion of crustaceans and all else. Although their shells may differ, all shellfish are invertebrates. [https://en.wikipedia.org/wiki/Shellfish]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1433</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1433</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">shellfish (food source)</rdfs:label>
     </owl:Class>
     
@@ -2090,7 +2090,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Individual plant or animal from which the food product or its major ingredient is derived; also a chemical food source [FDA CFSAN 1995].</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1564</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1564</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">food source</rdfs:label>
     </owl:Class>
     
@@ -2103,7 +2103,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">The Decapoda or decapods (literally &quot;ten-footed&quot;) are an order of crustaceans within the class Malacostraca, including many familiar groups, such as crayfish, crabs, lobsters, prawns, and shrimp. Most decapods are scavengers. [https://en.wikipedia.org/wiki/Decapoda]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B1998</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B1998</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">decapoda</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">decapod (food source)</rdfs:label>
     </owl:Class>
@@ -2119,8 +2119,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref>EC:No 216/2009 MOL</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>FAO ASFIS:MOL</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B2112</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/2195</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B2112</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Mollusca</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasSynonym xml:lang="en">mollusca</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">molluscs (food source)</rdfs:label>
@@ -2135,8 +2135,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000115 xml:lang="en">Mud crab may refer to any crab that lives in or near mud, such as: species from family *Portunidae*, such as *Scylla serrata*; *Scylla tranquebarica*; *Scylla paramamosain*; members of the family *Panopeidae*, such as *Panopeus herbstii*; members of the family *Xanthidae*; *Helice crassa*, the tunnelling mud crab. [https://en.wikipedia.org/wiki/Mud_crab]</obo:IAO_0000115>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B2215</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/7194</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B2215</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">mud crabs</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">panopeidae</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">pebble crabs</oboInOwl:hasSynonym>
@@ -2157,7 +2157,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000115 xml:lang="en">Lichens are composite organisms consisting of a symbiotic association of a fungus (the mycobiont) with a photosynthetic partner (the photobiont or phycobiont), usually either a green alga (commonly *Trebouxia*) or cyanobacterium (commonly *Nostoc*).</obo:IAO_0000115>
         <obo:IAO_0000119>WIKIPEDIA:Lichen</obo:IAO_0000119>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B2345</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B2345</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">lichen (food source)</rdfs:label>
     </owl:Class>
     
@@ -2185,9 +2185,9 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9925"/>
         <oboInOwl:hasDbXref>ITIS:180715</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B2611</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>MSW3:14200776</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/328660</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B2611</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Capra hircus Linnaeus, 1758</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasSynonym xml:lang="en">capra hircus</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">nanny goat</oboInOwl:hasSynonym>
@@ -2218,9 +2218,9 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
         <oboInOwl:hasDbXref rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9925"/>
         <oboInOwl:hasDbXref>ITIS:180715</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>LANGUAL:B2702</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>MSW3:14200776</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/328660</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B2702</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>Capra hircus Linnaeus, 1758</oboInOwl:hasNarrowSynonym>
         <rdfs:label xml:lang="en">kid (food source)</rdfs:label>
     </owl:Class>
@@ -2247,7 +2247,7 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FOODON_03411215"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B2846</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B2846</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">bacteria (food source)</rdfs:label>
     </owl:Class>
     
@@ -2261,8 +2261,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
         <obo:IAO_0000115 xml:lang="en">The biological subfamily *Bovinae* includes a diverse group of 10 genera of medium- to large-sized ungulates, including domestic cattle, the bison, African buffalo, the water buffalo, the yak, and the four-horned and spiral-horned antelopes. The evolutionary relationship between the members of the group is obscure, and their classification into loose tribes rather than formal subgroups reflects this uncertainty. General characteristics include cloven hoofs and usually at least one of the sexes of a species having true horns.</obo:IAO_0000115>
         <obo:IAO_0000119>WIKIPEDIA:Bovinae</obo:IAO_0000119>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B4374</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/2851454</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B4374</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">bovinae</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">bovine (food source)</rdfs:label>
     </owl:Class>
@@ -2279,8 +2279,8 @@ The edible portion of the nut is consumed in succulent, dried or processed forms
 The family is widespread, being native to Asia, Africa, Europe and North America, and diverse: members include bison, African buffalo, water buffalo, antelopes, gazelles, sheep, goats, muskoxen, and domestic cattle.</obo:IAO_0000115>
         <obo:IAO_0000119>WIKIPEDIA:Bovidae</obo:IAO_0000119>
         <obo:IAO_0000412>http://langual.org</obo:IAO_0000412>
-        <oboInOwl:hasDbXref>LANGUAL:B4381</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>http://eol.org/pages/7687</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://www.langual.org/langual_thesaurus.asp?termid=B4381</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonym xml:lang="en">bovidae</oboInOwl:hasSynonym>
         <rdfs:label xml:lang="en">bovid (food source)</rdfs:label>
     </owl:Class>

--- a/src/ontology/imports/hgnc_import.owl
+++ b/src/ontology/imports/hgnc_import.owl
@@ -15690,6 +15690,15 @@
     
 
 
+    <!-- http://identifiers.org/hgnc/2515 -->
+
+    <owl:Class rdf:about="http://identifiers.org/hgnc/2515">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001217"/>
+        <rdfs:label>CTNND1</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://identifiers.org/hgnc/25151 -->
 
     <owl:Class rdf:about="http://identifiers.org/hgnc/25151">

--- a/src/ontology/imports/hp_import.obo
+++ b/src/ontology/imports/hp_import.obo
@@ -4004,6 +4004,15 @@ xref: UMLS:C1845977
 is_a: HP:0001417 ! X-linked inheritance
 
 [Term]
+id: HP:0001423
+name: X-linked dominant inheritance
+namespace: human_phenotype
+def: "A mode of inheritance that is observed for dominant traits related to a gene encoded on the X chromosome. In the context of medical genetics, X-linked dominant disorders tend to manifest very severely in affected males. The severity of manifestation in females may depend on the degree of skewed X inactivation." [HPO:curators]
+synonym: "X-linked dominant" EXACT [HPO:skoehler]
+xref: UMLS:C1847879
+is_a: HP:0001417 ! X-linked inheritance
+
+[Term]
 id: HP:0001433
 name: Hepatosplenomegaly
 namespace: human_phenotype
@@ -7580,6 +7589,23 @@ synonym: "Underdeveloped breasts" EXACT layperson []
 xref: SNOMEDCT_US:8915006
 xref: UMLS:C0266013
 is_a: HP:0010311 ! Aplasia/Hypoplasia of the breasts
+
+[Term]
+id: HP:0003198
+name: Myopathy
+namespace: human_phenotype
+alt_id: HP:0003569
+alt_id: HP:0003705
+alt_id: HP:0003742
+alt_id: HP:0003802
+def: "A disorder of muscle unrelated to impairment of innervation or neuromuscular junction." [HPO:probinson]
+comment: The diagnosis of myopathy is often confirmed on the basis of myopathic changes in muscle biopsy.
+synonym: "Muscle tissue disease" EXACT layperson [ORCID:0000-0001-5208-3432]
+synonym: "Myopathic changes" EXACT []
+xref: MSH:D009135
+xref: SNOMEDCT_US:129565002
+xref: UMLS:C0026848
+is_a: HP:0011805 ! Abnormality of muscle morphology
 
 [Term]
 id: HP:0003202
@@ -12480,6 +12506,19 @@ xref: UMLS:C1513302
 is_a: HP:0012824 ! Severity
 created_by: peter
 creation_date: 2014-06-06T06:41:33Z
+
+[Term]
+id: HP:0012828
+name: Severe
+namespace: human_phenotype
+def: "Having a high degree of severity. For quantitative traits, a deviation of between four and five standard deviations from the appropriate population mean." [HPO:probinson]
+comment: PATO:0000396, severe.
+synonym: "Severe" EXACT layperson []
+xref: SNOMEDCT_US:24484000
+xref: UMLS:C0205082
+is_a: HP:0012824 ! Severity
+created_by: peter
+creation_date: 2014-06-06T07:03:17Z
 
 [Term]
 id: HP:0012862

--- a/src/ontology/imports/hp_import.owl
+++ b/src/ontology/imports/hp_import.owl
@@ -10557,6 +10557,32 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/HP_0001423 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001423">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0001417"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mode of inheritance that is observed for dominant traits related to a gene encoded on the X chromosome. In the context of medical genetics, X-linked dominant disorders tend to manifest very severely in affected males. The severity of manifestation in females may depend on the degree of skewed X inactivation.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C1847879</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">X-linked dominant</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0001423</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">X-linked dominant inheritance</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001423"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mode of inheritance that is observed for dominant traits related to a gene encoded on the X chromosome. In the context of medical genetics, X-linked dominant disorders tend to manifest very severely in affected males. The severity of manifestation in females may depend on the degree of skewed X inactivation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HPO:curators</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001423"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">X-linked dominant</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HPO:skoehler</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/HP_0001433 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001433">
@@ -13324,18 +13350,6 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001962"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Palpitations</owl:annotatedTarget>
-        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001962"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Skipped heart beat</owl:annotatedTarget>
-        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001962"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A sensation that the heart is pounding or racing, which is a non-specific sign but may be a manifestation of arrhythmia.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HPO:probinson</oboInOwl:hasDbXref>
@@ -13344,6 +13358,18 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001962"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Missed heart beat</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001962"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Palpitations</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0001962"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Skipped heart beat</owl:annotatedTarget>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
     </owl:Axiom>
     
@@ -19055,6 +19081,41 @@ Dysfunction leads to weakness, impairment of fine motor movements, spasticity, h
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0003187"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Underdeveloped breasts</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0003198 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0003198">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0011805"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A disorder of muscle unrelated to impairment of innervation or neuromuscular junction.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0003569</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0003705</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0003742</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0003802</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MSH:D009135</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SNOMEDCT_US:129565002</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0026848</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muscle tissue disease</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myopathic changes</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0003198</oboInOwl:id>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The diagnosis of myopathy is often confirmed on the basis of myopathic changes in muscle biopsy.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myopathy</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0003198"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A disorder of muscle unrelated to impairment of innervation or neuromuscular junction.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HPO:probinson</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0003198"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muscle tissue disease</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORCID:0000-0001-5208-3432</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
     </owl:Axiom>
     
@@ -29750,6 +29811,36 @@ and two otolith organs that are sensitive to linear acceleration.</rdfs:comment>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0012825"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mild</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0012828 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0012828">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HP_0012824"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Having a high degree of severity. For quantitative traits, a deviation of between four and five standard deviations from the appropriate population mean.</obo:IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peter</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014-06-06T07:03:17Z</oboInOwl:creation_date>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SNOMEDCT_US:24484000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0205082</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">human_phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HP:0012828</oboInOwl:id>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PATO:0000396, severe.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0012828"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Having a high degree of severity. For quantitative traits, a deviation of between four and five standard deviations from the appropriate population mean.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HPO:probinson</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HP_0012828"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe</owl:annotatedTarget>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/hp#layperson"/>
     </owl:Axiom>
     

--- a/src/ontology/imports/hp_terms.txt
+++ b/src/ontology/imports/hp_terms.txt
@@ -266,6 +266,7 @@ http://purl.obolibrary.org/obo/HP_0001396
 http://purl.obolibrary.org/obo/HP_0001397
 http://purl.obolibrary.org/obo/HP_0001417
 http://purl.obolibrary.org/obo/HP_0001419
+http://purl.obolibrary.org/obo/HP_0001423
 http://purl.obolibrary.org/obo/HP_0001433
 http://purl.obolibrary.org/obo/HP_0001438
 http://purl.obolibrary.org/obo/HP_0001450
@@ -531,6 +532,7 @@ http://purl.obolibrary.org/obo/HP_0003125
 http://purl.obolibrary.org/obo/HP_0003128
 http://purl.obolibrary.org/obo/HP_0003133
 http://purl.obolibrary.org/obo/HP_0003187
+http://purl.obolibrary.org/obo/HP_0003198
 http://purl.obolibrary.org/obo/HP_0003202
 http://purl.obolibrary.org/obo/HP_0003225
 http://purl.obolibrary.org/obo/HP_0003231
@@ -907,6 +909,7 @@ http://purl.obolibrary.org/obo/HP_0012795
 http://purl.obolibrary.org/obo/HP_0012823
 http://purl.obolibrary.org/obo/HP_0012824
 http://purl.obolibrary.org/obo/HP_0012825
+http://purl.obolibrary.org/obo/HP_0012828
 http://purl.obolibrary.org/obo/HP_0012862
 http://purl.obolibrary.org/obo/HP_0012863
 http://purl.obolibrary.org/obo/HP_0012864

--- a/src/ontology/reports/proxy-merge.tsv
+++ b/src/ontology/reports/proxy-merge.tsv
@@ -1,1642 +1,1644 @@
-MONDO:0000166	encephalopathy, acute, infection-induced	OMIMPS:601551		OMIMPS:610551	Encephalopathy, acute, infection-induced	OMIMPS	
-MONDO:0000181	microcephaly and chorioretinopathy	OMIMPS:251270	Microcephaly and chorioretinopathy	OMIMPS:251279		OMIMPS	
-MONDO:0000304	penicilliosis	SCTID:372936000	infection caused by penicillium marneffei (disorder)	SCTID:713315007	disseminated infection caused by penicillium marneffei (disorder)	SCTID	
-MONDO:0000503	lung adenocarcinoma in situ	NCIT:C136486	Lung Adenocarcinoma In Situ	NCIT:C8748	Stage 0 Adenosquamous Lung Carcinoma AJCC v6 and v7	NCIT	
-MONDO:0000651	thoracic disease	SCTID:118946009	disorder of thorax (disorder)	SCTID:609622007	disorder of thoracic segment of trunk (disorder)	SCTID	
-MONDO:0001147	meningocele (disease)	NCIT:C101209	Spinal Meningocele	NCIT:C105595	Meningocele	NCIT	
-MONDO:0001292	autonomic nervous system disease	SCTID:128123007	disorder of peripheral autonomic nervous system (disorder)	SCTID:15241006	disorder of autonomic nervous system (disorder)	SCTID	
-MONDO:0001318	functional gastric disease	SCTID:150541000119104	functional disorder of gastrointestinal tract (disorder)	SCTID:386211005	disorder of function of stomach (disorder)	SCTID	
-MONDO:0001748	maxillary sinus carcinoma	NCIT:C3540	Malignant Maxillary Sinus Neoplasm	NCIT:C9332	Maxillary Sinus Carcinoma	NCIT	
-MONDO:0001834	visual pathway disease	SCTID:54767005	disorder of visual pathways (disorder)	SCTID:95776004	disorder of optic tract (disorder)	SCTID	
-MONDO:0001874	toxic labyrinthitis	SCTID:3344003	toxic labyrinthitis (disorder)	SCTID:9062008	ototoxicity (disorder)	SCTID	
-MONDO:0002142	undifferentiated pleomorphic sarcoma	NCIT:C114541	Adult Undifferentiated Pleomorphic Sarcoma	NCIT:C4247	Undifferentiated Pleomorphic Sarcoma	NCIT	
-MONDO:0002181	exostosis	SCTID:235231000119100	osteophyte of bone (disorder)	SCTID:416189003	exostosis (disorder)	SCTID	
-MONDO:0002277	arteriosclerosis disorder	NCIT:C34398	Arteriosclerosis	NCIT:C34403	Arteriosclerotic Cardiovascular Disease	NCIT	
-MONDO:0003050	lung large cell carcinoma	EFO:0003050	large cell lung carcinoma	EFO:1000016		EFO	
-MONDO:0003219	gastroesophageal junction adenocarcinoma	ONCOTREE:EGC	esophagogastric adenocarcinoma	ONCOTREE:GEJ	adenocarcinoma of the gastroesophageal junction	ONCOTREE	
-MONDO:0003749	esophageal disease	SCTID:30811009	ulcer of esophagus (disorder)	SCTID:37657006	disorder of esophagus (disorder)	SCTID	
-MONDO:0004225	monoclonal gammopathy of uncertain significance	SCTID:277577000	monoclonal gammopathy of uncertain significance (disorder)	SCTID:58648008	benign monoclonal gammopathy (disorder)	SCTID	
-MONDO:0004241	Osgood-Schlatter disease	SCTID:430506003	osteochondritis of tibial tubercle (disorder)	SCTID:72047008	juvenile osteochondrosis of tibial tubercle (disorder)	SCTID	
-MONDO:0004379	female breast carcinoma	SCTID:372064008	malignant neoplasm of female breast (disorder)	SCTID:447782002	malignant epithelial neoplasm of female breast (disorder)	SCTID	
-MONDO:0004473	epiglottis cancer	NCIT:C35697	Epiglottic Carcinoma	NCIT:C4836	Malignant Epiglottis Neoplasm	NCIT	
-MONDO:0004769	orbital plasma cell granuloma	SCTID:72789009	inflammatory pseudotumor of orbit proper (disorder)	SCTID:80698001	orbital myositis (disorder)	SCTID	
-MONDO:0004790	fatty liver disease	SCTID:197321007	steatosis of liver (disorder)	SCTID:371330000		SCTID	
-MONDO:0004957	mucinous adenocarcinoma	EFO:0000197	mucinous carcinoma	EFO:1000387		EFO	
-MONDO:0005010	coronary artery disease	EFO:0000378	coronary artery disease	EFO:0001645	coronary heart disease	EFO	
-MONDO:0005061	lung adenocarcinoma	EFO:0000571	lung adenocarcinoma	EFO:0005288	non-small cell lung adenocarcinoma	EFO	
-MONDO:0005244	peripheral neuropathy	NCIT:C119734	Peripheral Neuropathy	NCIT:C4731	Neuropathy	NCIT	
-MONDO:0005244	peripheral neuropathy	EFO:0003100	peripheral neuropathy	EFO:0004149	neuropathy	EFO	
-MONDO:0005296	sleep apnea syndrome	SCTID:111489007	breathing-related sleep disorder (disorder)	SCTID:73430006	sleep apnea (disorder)	SCTID	
-MONDO:0005311	atherosclerosis	NCIT:C35768	Atherosclerosis	NCIT:C35771	Atherosclerotic Cardiovascular Disease	NCIT	
-MONDO:0005338	open-angle glaucoma	SCTID:46168003	pigmentary glaucoma (disorder)	SCTID:84494001	open-angle glaucoma (disorder)	SCTID	
-MONDO:0005387	primary ovarian failure	SCTID:370999003	primary hypogonadism (disorder)	SCTID:65846009	primary ovarian failure (disorder)	SCTID	
-MONDO:0005508	hereditary multiple osteochondromas	SCTID:254044004	multiple congenital exostosis (disorder)	SCTID:716742001	multiple osteochondroma of long bone (disorder)	SCTID	
-MONDO:0005526	tetanus	SCTID:276202003	infection caused by clostridium tetani (disorder)	SCTID:76902006	tetanus (disorder)	SCTID	
-MONDO:0005543	autoimmune hepatitis type 1	SCTID:197284004	chronic active hepatitis (disorder)	SCTID:721711009	autoimmune hepatitis type 1 (disorder)	SCTID	
-MONDO:0005590	breast ductal adenocarcinoma	EFO:0000430	ductal adenocarcinoma	EFO:0006318	breast ductal adenocarcinoma	EFO	
-MONDO:0005689	cannabis dependence	SCTID:37344009	cannabis abuse (disorder)	SCTID:85005007	cannabis dependence (disorder)	SCTID	
-MONDO:0005689	cannabis dependence	EFO:0004218	obsolete_marijuana dependence	EFO:0007191		EFO	
-MONDO:0005812	influenza	EFO:0001669	influenza infection	EFO:0007328		EFO	
-MONDO:0005853	malignant mixed neoplasm	EFO:0007373		EFO:1000356		EFO	
-MONDO:0006055	sex cord-stromal tumor	EFO:0007483		EFO:1000052		EFO	
-MONDO:0006238	growth hormone-producing pituitary gland adenoma	EFO:0004125	growth hormone-secreting pituitary adenoma	EFO:1000287		EFO	
-MONDO:0006280	lung sclerosing hemangioma	EFO:1000337		EFO:1001136		EFO	
-MONDO:0006345	palmar fibromatosis	EFO:0004229	Dupuytren Contracture	EFO:1000438		EFO	
-MONDO:0006639	adrenal cortex carcinoma	EFO:0003093	adrenocortical carcinoma	EFO:1000796		EFO	
-MONDO:0006646	angioleiomyoma	EFO:1000084		EFO:1000806		EFO	
-MONDO:0006873	nutritional deficiency disease	SCTID:363246002	nutritional deficiency associated condition (disorder)	SCTID:70241007	nutritional deficiency disorder (disorder)	SCTID	
-MONDO:0006956	rickettsiosis	SCTID:37246009	disease caused by rickettsiae (disorder)	SCTID:416829003	disease caused by genus rickettsia (disorder)	SCTID	
-MONDO:0007667	subependymoma	EFO:1000553		EFO:1001197		EFO	
-MONDO:0007947	Marfan syndrome	Orphanet:284963	Marfan syndrome type 1	Orphanet:558	Marfan syndrome	Orphanet	
-MONDO:0008384	rheumatoid nodulosis	SCTID:402426007	rheumatoid nodulosis (disorder)	SCTID:402427003	accelerated rheumatoid nodulosis (disorder)	SCTID	
-MONDO:0008583	inherited torticollis (disease)	SCTID:268240006	congenital torticollis (disorder)	SCTID:70070008	torticollis (disorder)	SCTID	
-MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	SCTID:720854004	cerebroretinal vasculopathy (disorder)	SCTID:721141004	hereditary vascular retinopathy (disorder)	SCTID	
-MONDO:0008728	classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	SCTID:124221007	deficiency of steroid 21-monooxygenase (disorder)	SCTID:717261006	classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency (disorder)	SCTID	
-MONDO:0008947	bilateral striopallidodentate calcinosis	SCTID:110997000	fahr's syndrome (disorder)	SCTID:230311004	basal ganglia degeneration with calcification (disorder)	SCTID	
-MONDO:0008982	central areolar choroidal dystrophy	SCTID:231996009	central areolar choroidal sclerosis (disorder)	SCTID:312918002	choroidal dystrophy (disorder)	SCTID	
-MONDO:0009465	multiple intestinal atresia	Orphanet:2300	Multiple intestinal atresia	Orphanet:436252	Combined immunodeficiency-enteropathy spectrum	Orphanet	
-MONDO:0009477	Stromme syndrome	Orphanet:444069	Lethal fetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	Orphanet:506307	Stromme syndrome	Orphanet	
-MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	SCTID:73843004	cobalamin a disease (disorder)	SCTID:82245003	cobalamin b disease (disorder)	SCTID	
-MONDO:0009666	holocarboxylase synthetase deficiency	SCTID:15307001	biotin-(propionyl-coenzyme a-carboxylase) ligase deficiency (disorder)	SCTID:360369003	holocarboxylase synthase deficiency (disorder)	SCTID	
-MONDO:0009925	inherited pseudoxanthoma elasticum	SCTID:402782006	inherited pseudoxanthoma elasticum (disorder)	SCTID:72744008	gronblad-strandberg syndrome (disorder)	SCTID	
-MONDO:0009968	renal tubular acidosis, distal, with progressive nerve deafness	SCTID:236532003	renal tubular acidosis with progressive nerve deafness (disorder)	SCTID:722468005	distal renal tubular acidosis co-occurrent with sensorineural deafness (disorder)	SCTID	
-MONDO:0010403	albinism-deafness syndrome	SCTID:722285005	albinism with deafness syndrome (disorder)	SCTID:74320008	woolf's syndrome (disorder)	SCTID	
-MONDO:0011057	cerebrovascular disorder	SCTID:230690007	cerebrovascular accident (disorder)	SCTID:62914000	cerebrovascular disease (disorder)	SCTID	
-MONDO:0011655	alveolar soft part sarcoma (disease)	NCIT:C3750	Alveolar Soft Part Sarcoma	NCIT:C7943	Adult Alveolar Soft Part Sarcoma	NCIT	
-MONDO:0012756	proximal 16p11.2 microdeletion syndrome	SCTID:699307007	chromosome 16p11.2 deletion syndrome (disorder)	SCTID:718227006	proximal 16p11.2 microdeletion syndrome (disorder)	SCTID	
-MONDO:0013209	non-alcoholic fatty liver disease	EFO:0003095	non-alcoholic fatty liver disease	EFO:1001248	non-alcoholic fatty liver	EFO	
-MONDO:0014225	hemochromatosis type 5	Orphanet:247790	FTH1-related iron overload	Orphanet:447792	Hemochromatosis type 5	Orphanet	
-MONDO:0015540	hemophagocytic syndrome	NCIT:C34792	Hemophagocytic Lymphohistiocytosis	NCIT:C35439	Hemophagocytic Syndrome	NCIT	
-MONDO:0015629	von willebrand disease type 2B	SCTID:359717002	hereditary von willebrand disease type 2b (disorder)	SCTID:359721009	von willebrand disease type 2b (disorder)	SCTID	
-MONDO:0015630	von willebrand disease type 2M	SCTID:359725000	hereditary von willebrand disease type 2m (disorder)	SCTID:359729006	von willebrand disease type 2m (disorder)	SCTID	
-MONDO:0016575	primary ciliary dyskinesia	SCTID:42402006	kartagener syndrome (disorder)	SCTID:86204009	immotile cilia syndrome (disorder)	SCTID	
-MONDO:0016982	angiosarcoma (disease)	EFO:0003967	vascular sarcoma	EFO:0003968	angiosarcoma	EFO	
-MONDO:0017178	osteochondritis dissecans (disease)	Orphanet:251262	Familial osteochondritis dissecans	Orphanet:2764	Osteochondritis dissecans	Orphanet	
-MONDO:0017198	osteopetrosis (disease)	OMIMPS:259700	Osteopetrosis, autosomal recessive	OMIMPS:607634	Osteopetrosis, autosomal dominant	OMIMPS	
-MONDO:0017278	autoimmune polyendocrinopathy	NCIT:C129726	Autoimmune Polyglandular Syndrome	NCIT:C84576	Autoimmune Polyendocrinopathy Syndrome	NCIT	
-MONDO:0017851	erythrokeratodermia variabilis	Orphanet:316	Progressive symmetric erythrokeratodermia	Orphanet:317	Erythrokeratodermia variabilis	Orphanet	
-MONDO:0017884	papillary renal cell carcinoma	Orphanet:319298	Papillary renal cell carcinoma	Orphanet:47044	Familial papillary renal cell carcinoma	Orphanet	
-MONDO:0017991	Takayasu arteritis	NCIT:C34391	Aortic Arch Syndrome	NCIT:C35062	Takayasu Arteritis	NCIT	
-MONDO:0018301	interstitial cystitis	SCTID:111409009	ulcerative cystitis (disorder)	SCTID:197834003	chronic interstitial cystitis (disorder)	SCTID	
-MONDO:0018612	congenital hypothyroidism	SCTID:190268003	congenital hypothyroidism (disorder)	SCTID:217710005	congenital iodine deficiency syndrome (disorder)	SCTID	
-MONDO:0018984	Oroya fever	SCTID:240453002	oroya fever (disorder)	SCTID:262461007	infection caused by bartonella bacilliformis (disorder)	SCTID	
-MONDO:0019118	inherited retinal dystrophy	NCIT:C35194	Hereditary Retinal Dystrophy	NCIT:C35625	Retinal Dystrophy	NCIT	
-MONDO:0019118	inherited retinal dystrophy	SCTID:314407005	retinal dystrophy (disorder)	SCTID:41799005	hereditary retinal dystrophy (disorder)	SCTID	
-MONDO:0019136	Zygomycosis	SCTID:59277005	zygomycosis (disorder)	SCTID:76627001	mucormycosis (disorder)	SCTID	
-MONDO:0019313	hereditary lymphedema	SCTID:254199006	hereditary lymphedema (disorder)	SCTID:399889006	hereditary lymphedema type i (disorder)	SCTID	
-MONDO:0019355	adult-onset Still disease	SCTID:239920006	adult onset still's disease (disorder)	SCTID:68190001	wissler-fanconi syndrome (disorder)	SCTID	
-MONDO:0019468	T-cell prolymphocytic leukemia	NCIT:C4752	T-Cell Prolymphocytic Leukemia	NCIT:C70649	T-Cell Chronic Lymphocytic Leukemia	NCIT	
-MONDO:0019468	T-cell prolymphocytic leukemia	SCTID:277545003	t-cell chronic lymphocytic leukemia (disorder)	SCTID:277567002	t-cell prolymphocytic leukemia (disorder)	SCTID	
-MONDO:0019490	progressive familial heart block	SCTID:698249005	progressive familial heart block (disorder)	SCTID:93130009		SCTID	
-MONDO:0020076	myeloproliferative neoplasm	EFO:0002428	chronic myeloproliferative disorder	EFO:0004251	myeloproliferative disorder	EFO	
-MONDO:0020528	ACTH-dependent Cushing syndrome	SCTID:190502001	pituitary-dependent cushing's disease (disorder)	SCTID:237734007	adrenocorticotropic hormone-dependent cushing syndrome (disorder)	SCTID	
-MONDO:0021097	intraductal breast papilloma	SCTID:254848002	duct papilloma of breast (disorder)	SCTID:99571000119102	papilloma of breast (disorder)	SCTID	
-MONDO:0024472	boutonneuse fever	Orphanet:101334	African tick typhus	Orphanet:83313	Boutonneuse fever	Orphanet	
-MONDO:0043373	sudden sensorineural hearing loss	SCTID:715239002	sudden sensorineural hearing loss (disorder)	SCTID:79471008	sudden hearing loss (disorder)	SCTID	
-MONDO:0018177	glioblastoma (disease)	ONCOTREE:GB	glioblastoma	ONCOTREE:GBM	glioblastoma multiforme	ONCOTREE	
-MONDO:0006515	acute pancreatitis	UMLS:C0001339	Acute pancreatitis	UMLS:C0267941	Acute necrotizing pancreatitis	UMLS	
-MONDO:0002512	papillary adenocarcinoma	UMLS:C0001420	Papillary adenocarcinoma	UMLS:C1321863	Infiltrating papillary adenocarcinoma	UMLS	
-MONDO:0000261	adenoiditis	UMLS:C0001427	Adenoiditis	UMLS:C0396023	Chronic adenoiditis	UMLS	
-MONDO:0006640	adrenal gland hyperfunction	UMLS:C0001622	Adrenal Gland Hyperfunction	UMLS:CN205287	Hypercortisolism	UMLS	
-MONDO:0018479	congenital adrenal hyperplasia	UMLS:C0001627	Congenital adrenal hyperplasia	UMLS:C0701163	Adrenogenital disorder	UMLS	
-MONDO:0009692	primary myelofibrosis	UMLS:C0001815	Primary myelofibrosis	UMLS:C0948968	Osteomyelofibrosis	UMLS	
-MONDO:0009692	primary myelofibrosis	UMLS:C0001815	Primary myelofibrosis	UMLS:C2355576	Megakaryocytic myelosclerosis	UMLS	
-MONDO:0008753	alkaptonuria	UMLS:C0002066	Alkaptonuria	UMLS:C2931645	Hereditary ochronosis	UMLS	
-MONDO:0017795	ameloblastoma	UMLS:C0002448	Ameloblastoma	UMLS:C0563212	Ameloblastoma of jaw	UMLS	
-MONDO:0006021	Prinzmetal angina	UMLS:C0002963	Variant angina pectoris	UMLS:C2931193	Prinzmetal's variant angina	UMLS	
-MONDO:0003143	angiokeratoma	UMLS:C0002985	Angiokeratoma	UMLS:C0346075	Angiokeratoma of skin	UMLS	
-MONDO:0006717	cutaneous fibrous histiocytoma	UMLS:C0002991	Cutaneous Fibrous Histiocytoma	UMLS:C0346049	Fibrohistiocytic tumor	UMLS	
-MONDO:0002519	anus disease	UMLS:C0003462	Diseases, Anus	UMLS:C0016167	Anal fissure	UMLS	
-MONDO:0002519	anus disease	UMLS:C0003462	Diseases, Anus	UMLS:C1301262	Disorder of anal region	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C0741160	Ruptured aortic aneurysm	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS	
-MONDO:0005648	aortic valve insufficiency	UMLS:C0003504	Aortic valve insufficiency	UMLS:C0155568	Rheumatic aortic regurgitation	UMLS	
-MONDO:0019496	neuroendocrine neoplasm	UMLS:C0003650	Apudoma	UMLS:C0206754	Neuroendocrine tumor	UMLS	
-MONDO:0019496	neuroendocrine neoplasm	UMLS:C0003650	Apudoma	UMLS:CN206284	APUDoma	UMLS	
-MONDO:0015304	arachnoiditis	UMLS:C0003708	Arachnoiditis	UMLS:C0270617	Adhesive arachnoiditis	UMLS	
-MONDO:0002277	arteriosclerosis disorder	UMLS:C0003850	Arteriosclerosis	UMLS:C3665365	Arteriosclerotic Cardiovascular Disease	UMLS	
-MONDO:0005393	gout	UMLS:C0003868	Gouty arthritis	UMLS:C0018099	Gout	UMLS	
-MONDO:0007416	Balkan nephropathy	UMLS:C0004698	Balkan nephropathy	UMLS:C4049993	Aristolochic acid nephropathy	UMLS	
-MONDO:0015231	Bartter syndrome	UMLS:C0004775	Salt-wasting tubulopathy, Henle's loop type	UMLS:C0085570	Hypokalemic alkalosis	UMLS	
-MONDO:0005672	blastomycosis	UMLS:C0005716	Blastomycosis	UMLS:C0005717	Gilchrist's disease	UMLS	
-MONDO:0000728	ptosis (disease)	UMLS:C0005745	Blepharoptosis	UMLS:C0033377	Ptosis	UMLS	
-MONDO:0005560	brain disease	UMLS:C0006111	Brain Diseases	UMLS:C0085584	Encephalopathy	UMLS	
-MONDO:0006687	burning mouth syndrome	UMLS:C0006430	Burning mouth syndrome	UMLS:C2930806	Stomatodynia	UMLS	
-MONDO:0006687	burning mouth syndrome	UMLS:C0006430	Burning mouth syndrome	UMLS:CN242089	Stomatopyrosis	UMLS	
-MONDO:0006688	byssinosis	UMLS:C0006542	Byssinosis	UMLS:C2242894	Flax-dressers' disease	UMLS	
-MONDO:0001984	candidal paronychia	UMLS:C0006842	Candidiasis of skin and nails	UMLS:C1282977	Candidal paronychia	UMLS	
-MONDO:0005341	skin basal cell carcinoma	UMLS:C0007117	Basal cell carcinoma	UMLS:C0206710	Basal cell neoplasm	UMLS	
-MONDO:0005341	skin basal cell carcinoma	UMLS:C0007117	Basal cell carcinoma	UMLS:C0751676	Basal Cell Cancer	UMLS	
-MONDO:0004957	mucinous adenocarcinoma	UMLS:C0007130	Mucinous adenocarcinoma	UMLS:C0334368	Mucin-producing adenocarcinoma	UMLS	
-MONDO:0002928	carcinosarcoma	UMLS:C0007140	Carcinosarcoma	UMLS:C0206627	Mullerian mixed tumor	UMLS	
-MONDO:0002928	carcinosarcoma	UMLS:C0007140	Carcinosarcoma	UMLS:C1334603	Malignant Mixed Mesodermal (Mullerian) Tumor	UMLS	
-MONDO:0005692	cat-scratch disease	UMLS:C0007361	Cat scratch disease	UMLS:CN205187	Bartonellosis due to Bartonella henselae infection	UMLS	
-MONDO:0000751	cervical polyp (disease)	UMLS:C0007855	Cervical polyp	UMLS:C0347493	Adenomatous polyp of cervix	UMLS	
-MONDO:0001280	choroiditis	UMLS:C0008526	Choroiditis	UMLS:C0042167	Posterior uveitis	UMLS	
-MONDO:0015908	chromomycosis	UMLS:C0008582	Chromoblastomycosis	UMLS:C3245522	Mossy foot disease	UMLS	
-MONDO:0005706	coccidioidomycosis	UMLS:C0009186	Coccidioidomycosis	UMLS:C0700644	Primary extrapulmonary coccidioidomycosis	UMLS	
-MONDO:0005706	coccidioidomycosis	UMLS:C0009186	Coccidioidomycosis	UMLS:CN201384	Valley fever	UMLS	
-MONDO:0001703	color vision disorder	UMLS:C0009398	Color vision defects	UMLS:C0242225	Color blindness	UMLS	
-MONDO:0001703	color vision disorder	UMLS:C0009398	Color vision defects	UMLS:CN207064	Color-vision disease	UMLS	
-MONDO:0007404	Cri-du-chat syndrome	UMLS:C0010314	Cri du chat syndrome	UMLS:CN776901	Deletion 5p	UMLS	
-MONDO:0009044	Crigler-Najjar syndrome	UMLS:C0010324	UGT deficiency type 1	UMLS:CN119421	UGT deficiency	UMLS	
-MONDO:0015474	cryptosporidiosis	UMLS:C0010418	Cryptosporidiosis	UMLS:C0520796	Cryptosporidial gastroenteritis	UMLS	
-MONDO:0015484	cysticercosis	UMLS:C0010678	Cysticercosis	UMLS:C0338437	Neurocysticercosis	UMLS	
-MONDO:0016239	cystinosis	UMLS:C0010690		UMLS:CN035091	Protein defect of cystin transport	UMLS	
-MONDO:0002967	dermatophytosis of scalp or beard	UMLS:C0011640	Dermatophytosis of scalp or beard	UMLS:C1274426	Tinea capitis due to Trichophyton rubrum	UMLS	
-MONDO:0002378	dermoid cyst	UMLS:C0011649	Dermoid cyst	UMLS:C2355625	Dermoid choristoma	UMLS	
-MONDO:0002378	dermoid cyst	UMLS:C0011649	Dermoid cyst	UMLS:C2700593	Cystic dermoid choristoma	UMLS	
-MONDO:0005015	diabetes mellitus (disease)	UMLS:C0011847	Diabetes	UMLS:C0011849	Diabetes mellitus	UMLS	
-MONDO:0000960	diabetic peripheral angiopathy	UMLS:C0011871	Diabetic peripheral angiopathy	UMLS:C0011875	Diabetic Angiopathy	UMLS	
-MONDO:0005729	dicrocoeliasis	UMLS:C0012102	Dicroceliasis	UMLS:C1737210	Disease due to Dicrocoeliidae	UMLS	
-MONDO:0001243	disseminated intravascular coagulation	UMLS:C0012739	Disseminated intravascular coagulation	UMLS:C4321305	Consumptive Coagulopathy	UMLS	
-MONDO:0007492	early-onset generalized limb-onset dystonia	UMLS:C0013423	Dystonia musculorum deformans	UMLS:C3888090	EARLY-ONSET TORSION DYSTONIA	UMLS	
-MONDO:0001754	eclampsia	UMLS:C0013537	Eclampsia	UMLS:C0156678	Eclampsia in puerperium	UMLS	
-MONDO:0009162	Ellis-van Creveld syndrome	UMLS:C0013903	Ellis-van Creveld syndrome	UMLS:CN239258	Ellis-van Creveld Syndrome	UMLS	
-MONDO:0019378	la Crosse encephalitis	UMLS:C0014053	California encephalitis	UMLS:C0276379	La Crosse encephalitis	UMLS	
-MONDO:0008145	Ollier disease	UMLS:C0014084	Enchondromatosis	UMLS:C0206641	Osteochondromatosis	UMLS	
-MONDO:0008145	Ollier disease	UMLS:C0014084	Enchondromatosis	UMLS:CN203308	Dyschondroplasia	UMLS	
-MONDO:0016698	ependymoma	UMLS:C0014474	Ependymoma	UMLS:CN201941	Ependymoma	UMLS	
-MONDO:0016022	early myoclonic encephalopathy	UMLS:C0014550	Myoclonic epilepsy	UMLS:C0270855	Early myoclonic encephalopathy	UMLS	
-MONDO:0019759	epispadias (disease)	UMLS:C0014588		UMLS:CN227686	Epispadias	UMLS	
-MONDO:0002885	erythrasma	UMLS:C0014752	Erythrasma	UMLS:C2364003	Infection due to Corynebacterium minutissimum	UMLS	
-MONDO:0008698	achalasia (disease)	UMLS:C0014848	Esophageal achalasia	UMLS:C1321756	Achalasia	UMLS	
-MONDO:0008698	achalasia (disease)	UMLS:C0014848	Esophageal achalasia	UMLS:C2939435	Hypertensive lower esophageal sphincter	UMLS	
-MONDO:0001409	esophagitis (disease)	UMLS:C0014868	Esophagitis	UMLS:C0149882	Acute esophagitis	UMLS	
-MONDO:0000337	exanthema subitum	UMLS:C0015231	Exanthema subitum	UMLS:C0595993	Roseola Infantum	UMLS	
-MONDO:0004668	fascioliasis	UMLS:C0015652	Fascioliasis	UMLS:C1331532	Fasciola hepatica infection	UMLS	
-MONDO:0021104	alcoholic fatty liver disease	UMLS:C0015696	Alcoholic fatty liver	UMLS:C2718067	Alcoholic Steatohepatitis	UMLS	
-MONDO:0015137	periodic fever syndrome	UMLS:C0015974	Periodic fever syndrome	UMLS:C3889979	Periodic Fever Syndrome	UMLS	
-MONDO:0002519	anus disease	UMLS:C0016167	Anal fissure	UMLS:C1301262	Disorder of anal region	UMLS	
-MONDO:0018695	avian influenza	UMLS:C0016627	Influenza in Bird	UMLS:CN237762	Avian influenza	UMLS	
-MONDO:0005321	Fuchs' endothelial dystrophy	UMLS:C0016781	Fuchs' endothelial dystrophy	UMLS:CN207231	Late hereditary endothelial dystrophy	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C0267112	Acute gastric mucosal erosion	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C2243088	Erosive Gastritis	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C2243090	Erosive gastropathy	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C3854048	Erosive gastritis	UMLS	
-MONDO:0005769	geniculate herpes zoster	UMLS:C0017409	Herpes zoster oticus	UMLS:C0458220	Nervus intermedius neuralgia	UMLS	
-MONDO:0001268	gingival recession	UMLS:C0017572	Gingival recession	UMLS:C0266916	Localized gingival recession	UMLS	
-MONDO:0018177	glioblastoma (disease)	UMLS:C0017636	Glioblastoma	UMLS:C1621958	Glioblastoma multiforme	UMLS	
-MONDO:0018177	glioblastoma (disease)	UMLS:C0017636	Glioblastoma	UMLS:CN227279	Glioblastoma multiforme	UMLS	
-MONDO:0009290	glycogen storage disease II	UMLS:C0017921	Glycogenosis type II	UMLS:C1968741	GLYCOGEN STORAGE DISEASE IIIc	UMLS	
-MONDO:0009290	glycogen storage disease II	UMLS:C0017921	Glycogenosis type II	UMLS:C3695005	GLYCOGEN STORAGE DISEASE, TYPE IIIc	UMLS	
-MONDO:0009291	glycogen storage disease III	UMLS:C0017922	Glycogen storage disease type III	UMLS:CN204781	Glycogenosis type III	UMLS	
-MONDO:0009292	glycogen storage disease due to glycogen branching enzyme deficiency	UMLS:C0017923	Glycogen storage disease type IV	UMLS:CN204783	Glycogenosis type IV	UMLS	
-MONDO:0009297	familial renal glucosuria	UMLS:C0017980	Renal glycosuria	UMLS:C3245525	Familial renal glucosuria	UMLS	
-MONDO:0010765	46,XY complete gonadal dysgenesis	UMLS:C0018054	46,XY Gonadal Dysgenesis	UMLS:C2936694	Swyer syndrome	UMLS	
-MONDO:0020540	ovarian gynandroblastoma	UMLS:C0018413	Gynandroblastoma	UMLS:C0346178	Ovarian Gynandroblastoma	UMLS	
-MONDO:0002917	disease of pilosebaceous unit	UMLS:C0018500	Hair Disease	UMLS:C0554472	Hair and hair follicle diseases	UMLS	
-MONDO:0000745	cardiac arrest	UMLS:C0018790	Cardiac arrest	UMLS:C0444720	Circulatory arrest	UMLS	
-MONDO:0005267	heart disease	UMLS:C0018799	Heart disease	UMLS:CN236661	Heart Diseases	UMLS	
-MONDO:0005267	heart disease	UMLS:C0018799	Heart disease	UMLS:CN239852	Cardiac disease	UMLS	
-MONDO:0001495	hematocele of tunica vaginalis testis	UMLS:C0018931	Hematocele of tunica vaginalis testis	UMLS:C1456400	Hematocele	UMLS	
-MONDO:0005570	hematological system disease	UMLS:C0018939	Hematological Diseases	UMLS:CN882913	hematological disorders and malignancies	UMLS	
-MONDO:0019050	inherited hemoglobinopathy	UMLS:C0019045	Hemoglobinopathy	UMLS:C1960031	Hereditary hemoglobinopathy	UMLS	
-MONDO:0018641	paroxysmal nocturnal hemoglobinuria	UMLS:C0019050	Paroxysmal Hemoglobinuria	UMLS:C0024790	Paroxysmal nocturnal hemoglobinuria	UMLS	
-MONDO:0015542	secondary hemophagocytic lymphohistiocytosis	UMLS:C0019068	Reactive Hemophagocytic Syndrome	UMLS:C4054044	Secondary Hemophagocytic Lymphohistiocytosis	UMLS	
-MONDO:0015542	secondary hemophagocytic lymphohistiocytosis	UMLS:C0019068	Reactive Hemophagocytic Syndrome	UMLS:CN199700	Reactive hemophagocytic syndrome	UMLS	
-MONDO:0010602	hemophilia A	UMLS:C0019069	Hemophilia A	UMLS:CN239112	AUTOSOMAL HEMOPHILIA A	UMLS	
-MONDO:0020501	Crimean-Congo hemorrhagic fever	UMLS:C0019099	Crimean hemorrhagic fever	UMLS:C1304456	Congo hemorrhagic fever	UMLS	
-MONDO:0018087	viral hemorrhagic fever	UMLS:C0019104	Viral hemorrhagic fever	UMLS:CN204409	Viral hemorrhagic fever	UMLS	
-MONDO:0019623	hereditary angioedema	UMLS:C0019243	Hereditary angioedema	UMLS:CN239191	Hereditary Angioedema	UMLS	
-MONDO:0015288	herpes simplex virus keratitis	UMLS:C0019357	Herpetic keratitis	UMLS:C0022570	Dendritic Keratitis	UMLS	
-MONDO:0018309	Hirschsprung disease	UMLS:C0019569	Hirschsprung's disease	UMLS:C3661523	Congenital Intestinal Aganglionosis	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS	
-MONDO:0009971	newborn respiratory distress syndrome	UMLS:C0020192	Hyaline membrane disease	UMLS:C0035220	Respiratory distress syndrome of newborn	UMLS	
-MONDO:0009971	newborn respiratory distress syndrome	UMLS:C0020192	Hyaline membrane disease	UMLS:C1968593	Neonatal respiratory distress syndrome	UMLS	
-MONDO:0005802	hymenolepiasis	UMLS:C0020413	Hymenolepiosis	UMLS:C0277045	Dwarf tapeworm infection	UMLS	
-MONDO:0021187	hyperlipidemia (disease)	UMLS:C0020473	Hyperlipidemia	UMLS:CN236649	Hyperlipidemias	UMLS	
-MONDO:0018473	hyperlipoproteinemia type 3	UMLS:C0020479	Remnant disease	UMLS:C1862561	BROAD-BETALIPOPROTEINEMIA	UMLS	
-MONDO:0006846	malignant hypertension	UMLS:C0020540	Malignant hypertension	UMLS:C0745136	Hypertensive emergency	UMLS	
-MONDO:0009650	inclusion-cell disease	UMLS:C0020725	Mucolipidosis type II	UMLS:C2673377	N-acetylglucosamine 1-phosphotransferase deficiency	UMLS	
-MONDO:0016985	nevus of Ito	UMLS:C0022283		UMLS:CN202288	Nevus fuscocaeruleus acromiodeltoideus	UMLS	
-MONDO:0005173	actinic keratosis (disease)	UMLS:C0022602	Actinic keratosis	UMLS:C4282032	Senile hyperkeratosis	UMLS	
-MONDO:0007864	angioosteohypertrophic syndrome	UMLS:C0022739	KLIPPEL-TRENAUNAY-WEBER SYNDROME	UMLS:CN201567	Klippel-Trénaunay-Weber syndrome	UMLS	
-MONDO:0019260	adult neuronal ceroid lipofuscinosis	UMLS:C0022797	Adult neuronal ceroid lipofuscinosis	UMLS:CN205864	Kufs disease	UMLS	
-MONDO:0005823	legionellosis	UMLS:C0023240	Legionellosis	UMLS:CN205282	Legionnaires disease	UMLS	
-MONDO:0005125	borderline leprosy	UMLS:C0023346	Borderline leprosy	UMLS:C3251797	Midborderline leprosy	UMLS	
-MONDO:0010298	Lesch-Nyhan syndrome	UMLS:C0023374	Lesch-Nyhan syndrome	UMLS:CN205196	Hypoxanthine guanine phosphoribosyltransferase deficiency, grade IV	UMLS	
-MONDO:0004948	B-cell chronic lymphocytic leukemia	UMLS:C0023434	Chronic lymphocytic leukemia	UMLS:C0855095	Small lymphocytic lymphoma	UMLS	
-MONDO:0019458	acute basophilic leukemia	UMLS:C0023437	Acute basophilic leukemia	UMLS:C0221292	Basophilic leukemia	UMLS	
-MONDO:0007896	acute monocytic leukemia	UMLS:C0023465	Acute monocytic leukemia	UMLS:C1318544	Acute Monocytic Leukemia	UMLS	
-MONDO:0019451	chronic neutrophilic leukemia	UMLS:C0023481	Chronic neutrophilic leukemia	UMLS:C0474856	Neutrophilic leukemia	UMLS	
-MONDO:0019468	T-cell prolymphocytic leukemia	UMLS:C0023494	Chronic T-Cell Leukemia	UMLS:C2363142	T-cell prolymphocytic leukemia	UMLS	
-MONDO:0019046	leukodystrophy	UMLS:C0023520	Leukodystrophy	UMLS:CN228461	Hypomyelinating leukodystrophy	UMLS	
-MONDO:0005116	Whipple disease	UMLS:C0023788	Whipple's disease	UMLS:C2930851	Intestinal lipophagic granulomatosis	UMLS	
-MONDO:0005116	Whipple disease	UMLS:C0023788	Whipple's disease	UMLS:CN204440	Secondary non-tropical sprue	UMLS	
-MONDO:0007908	multiple symmetric lipomatosis	UMLS:C0023804	Multiple symmetrical lipomatosis	UMLS:C0024445	LIPOMATOSIS, FAMILIAL BENIGN CERVICAL	UMLS	
-MONDO:0007908	multiple symmetric lipomatosis	UMLS:C0023804	Multiple symmetrical lipomatosis	UMLS:CN201658	Launois-Bensaude lipomatosis	UMLS	
-MONDO:0019346	sialidosis type 1	UMLS:C0023806	Lipomucopolysaccharidosis	UMLS:CN206021	Normomorphic sialidosis	UMLS	
-MONDO:0006644	alcoholic liver cirrhosis	UMLS:C0023891	Alcoholic cirrhosis of liver	UMLS:C1622502	Portal cirrhosis	UMLS	
-MONDO:0007174	Lown-Ganong-Levine syndrome	UMLS:C0024054	Lown-Ganong-Levine syndrome	UMLS:C1862387	Lown-Ganong-Levine syndrome	UMLS	
-MONDO:0006576	Ludwig's angina	UMLS:C0024081	Ludwig's angina	UMLS:C3247204	Cellulitis of floor of mouth	UMLS	
-MONDO:0019557	chilblain lupus	UMLS:C0024145	Chilblain lupus	UMLS:CN239336	Chilblain Lupus	UMLS	
-MONDO:0004387	luteoma of pregnancy	UMLS:C0024167	Luteoma	UMLS:C1517842	Leuteoma of Pregnancy	UMLS	
-MONDO:0002052	lymphadenitis (disease)	UMLS:C0024205	Lymphadenitis	UMLS:C0154304	Chronic lymphadenitis	UMLS	
-MONDO:0002052	lymphadenitis (disease)	UMLS:C0024205	Lymphadenitis	UMLS:C0157705	Acute lymphadenitis	UMLS	
-MONDO:0015540	hemophagocytic syndrome	UMLS:C0024291	Hemophagocytic lymphohistiocytosis	UMLS:C3887558	Hemophagocytic syndrome	UMLS	
-MONDO:0007935	cystoid macular edema	UMLS:C0024440	Cystoid macular edema	UMLS:C0730317	Autosomal dominant cystoid macular edema	UMLS	
-MONDO:0007908	multiple symmetric lipomatosis	UMLS:C0024445	LIPOMATOSIS, FAMILIAL BENIGN CERVICAL	UMLS:CN201658	Launois-Bensaude lipomatosis	UMLS	
-MONDO:0002691	liver cancer	UMLS:C0024620	Primary malignant neoplasm of liver	UMLS:C0345904	Malignant neoplasm of liver	UMLS	
-MONDO:0002691	liver cancer	UMLS:C0024620	Primary malignant neoplasm of liver	UMLS:C0854795	Resectable Malignant Neoplasm of Liver	UMLS	
-MONDO:0007947	Marfan syndrome	UMLS:C0024796	Marfan's syndrome	UMLS:CN202883	MFS1	UMLS	
-MONDO:0006849	mastitis	UMLS:C0024894	Mastitis	UMLS:C0392317	Breast infection	UMLS	
-MONDO:0007959	medulloblastoma	UMLS:C0025149	Medulloblastoma	UMLS:C1334410	Localized Primitive Neuroectodermal Tumor	UMLS	
-MONDO:0005105	melanoma (disease)	UMLS:C0025202	Melanoma	UMLS:CN971653	Malignant melanoma	UMLS	
-MONDO:0017775	melioidosis	UMLS:C0025229	Melioidosis	UMLS:C0348970	Acute and fulminating melioidosis	UMLS	
-MONDO:0017775	melioidosis	UMLS:C0025229	Melioidosis	UMLS:C0348971	Subacute and chronic melioidosis	UMLS	
-MONDO:0003767	mitral valve disease	UMLS:C0026265	Mitral valve disease	UMLS:C2939153	Chronic rheumatic mitral valve	UMLS	
-MONDO:0001600	mucocele of salivary gland	UMLS:C0026686	Mucocele of salivary gland	UMLS:C2242813	Ranula	UMLS	
-MONDO:0018937	mucopolysaccharidosis type 3	UMLS:C0026706	Mucopolysaccharidosis IIIs	UMLS:CN205330	MPS3	UMLS	
-MONDO:0002380	myoepithelial tumor	UMLS:C0027070	Myoepithelioma	UMLS:C1947949	Benign myoepithelioma	UMLS	
-MONDO:0005864	muscle cancer	UMLS:C0027095	Myosarcoma	UMLS:C0684743	Malignant Neoplasm of the Muscle	UMLS	
-MONDO:0001040	nasopharyngitis	UMLS:C0027441	Nasopharyngitis	UMLS:C0155826	Chronic nasopharyngitis	UMLS	
-MONDO:0015356	hereditary neoplastic syndrome	UMLS:C0027672	Hereditary neoplastic syndrome	UMLS:CN199448	Inherited cancer-predisposing syndrome	UMLS	
-MONDO:0015356	hereditary neoplastic syndrome	UMLS:C0027672	Hereditary neoplastic syndrome	UMLS:CN882908	Hereditary Cancer Syndrome	UMLS	
-MONDO:0001085	interstitial nephritis	UMLS:C0027707	IN - Interstitial nephritis	UMLS:C0041349	Tubulointerstitial nephritis	UMLS	
-MONDO:0002546	schwannoma	UMLS:C0027809	Neurilemoma	UMLS:CN202001	Peripheral fibroblastoma	UMLS	
-MONDO:0005072	neuroblastoma	UMLS:C0027819	Neuroblastoma	UMLS:CN205405	Neuroblastoma	UMLS	
-MONDO:0006585	neurodermatitis	UMLS:C0027822	Neurodermatitis	UMLS:C0149922	Lichen simplex chronicus	UMLS	
-MONDO:0003608	optic atrophy	UMLS:C0029124	Optic atrophy	UMLS:C1744705	Atrophy of optic disc	UMLS	
-MONDO:0018166	oral submucous fibrosis	UMLS:C0029171	Oral Cavity Submucous Fibrosis	UMLS:C0029172	Oral submucous fibrosis	UMLS	
-MONDO:0018984	Oroya fever	UMLS:C0029307	Oroya fever	UMLS:CN205422	Carrion disease	UMLS	
-MONDO:0024623	otorhinolaryngologic disease	UMLS:C0029896	Otorhinolaryngologic Disease	UMLS:C0395797	Ear, nose and throat disorder	UMLS	
-MONDO:0005746	enterobiasis	UMLS:C0030100	Oxyuriasis	UMLS:C0086227	Enterobiasis	UMLS	
-MONDO:0005659	atrophic rhinitis	UMLS:C0030105	Ozenas	UMLS:C0035459	Atrophic rhinitis	UMLS	
-MONDO:0018626	paratyphoid fever	UMLS:C0030528	Paratyphoid fever	UMLS:C0343375	Paratyphoid A fever	UMLS	
-MONDO:0018626	paratyphoid fever	UMLS:C0030528	Paratyphoid fever	UMLS:C0343376	Paratyphoid B fever	UMLS	
-MONDO:0018626	paratyphoid fever	UMLS:C0030528	Paratyphoid fever	UMLS:C0343377	Paratyphoid C fever	UMLS	
-MONDO:0003472	lice infestation	UMLS:C0030756	Louse infestation	UMLS:C0153317	Pediculosis and phthirus infections	UMLS	
-MONDO:0003472	lice infestation	UMLS:C0030756	Louse infestation	UMLS:C0277351	Mixed pediculosis	UMLS	
-MONDO:0019975	pellagra	UMLS:C0030783	Pellagra	UMLS:C4317126	Niacin deficiency	UMLS	
-MONDO:0004260	peptic ulcer perforation	UMLS:C0030925	Peptic ulcer with perforation	UMLS:C0267291	Acute peptic ulcer with perforation	UMLS	
-MONDO:0005076	periodontitis	UMLS:C0031099	Periodontitis	UMLS:C0600298	Periodontosis	UMLS	
-MONDO:0008280	Peutz-Jeghers syndrome	UMLS:C0031269	Peutz-Jeghers syndrome	UMLS:C1333088	Colonic hamartomatous polyps	UMLS	
-MONDO:0000265	aspiration pneumonia (disease)	UMLS:C0032290	Aspiration pneumonia	UMLS:C0085740	Mendelson Syndrome	UMLS	
-MONDO:0019735	polymyalgia rheumatica	UMLS:C0032533	Polymyalgia rheumatica	UMLS:C1527406	Rhizomelic pseudopolyarthritis	UMLS	
-MONDO:0021055	classic familial adenomatous polyposis	UMLS:C0032580	Adenomatous polyposis coli	UMLS:CN240755	Familial adenomatous polyposis	UMLS	
-MONDO:0000276	Powassan encephalitis	UMLS:C0032858	Powassan encephalitis	UMLS:C1563215	Powassan encephalitis virus infection	UMLS	
-MONDO:0018881	myelodysplastic syndrome	UMLS:C0033027	Preleukemias	UMLS:C3463824	Myelodysplastic syndrome	UMLS	
-MONDO:0008310	progeria	UMLS:C0033300	Progeria	UMLS:CN236401	Progeria	UMLS	
-MONDO:0000497	pyometritis	UMLS:C0034215	Pyometra	UMLS:C0686163	Pyometritis	UMLS	
-MONDO:0009949	pyruvate carboxylase deficiency disease	UMLS:C0034341	Pyruvate Carboxylase Deficiency Disease	UMLS:C2931141	LEIGH NECROTIZING ENCEPHALOPATHY DUE TO PYRUVATE CARBOXYLASE DEFICIENCY	UMLS	
-MONDO:0009949	pyruvate carboxylase deficiency disease	UMLS:C0034341	Pyruvate Carboxylase Deficiency Disease	UMLS:CN203409	Leigh syndrome due to pyruvate carboxylase deficiency	UMLS	
-MONDO:0017376	reactive arthritis	UMLS:C0035012	Reiter's syndrome	UMLS:C0085435	Reactive arthritis	UMLS	
-MONDO:0017376	reactive arthritis	UMLS:C0035012	Reiter's syndrome	UMLS:CN203069	Reiter disease	UMLS	
-MONDO:0001106	kidney failure	UMLS:C0035078	Kidney Failure	UMLS:C1565489	Renal insufficiency	UMLS	
-MONDO:0009971	newborn respiratory distress syndrome	UMLS:C0035220	Respiratory distress syndrome of newborn	UMLS:C1968593	Neonatal respiratory distress syndrome	UMLS	
-MONDO:0019200	retinitis pigmentosa	UMLS:C0035334	Retinitis pigmentosa	UMLS:C4072872	obsolete Rod-cone dystrophy	UMLS	
-MONDO:0006963	sebaceous gland neoplasm	UMLS:C0036503	Neoplasm of sebaceous gland	UMLS:C3805742	Sebaceous gland tumors	UMLS	
-MONDO:0007803	multiple system atrophy	UMLS:C0037019	Shy-Drager syndrome	UMLS:C0393571		UMLS	
-MONDO:0019350	hereditary spherocytosis	UMLS:C0037889	Hereditary spherocytosis	UMLS:CN206031		UMLS	
-MONDO:0004842	stomatitis	UMLS:C0038362	Stomatitis	UMLS:C1568868	Oral Mucositis	UMLS	
-MONDO:0005974	strongyloidiasis	UMLS:C0038463	Strongyloidiasis	UMLS:C0085810	Anguilluliasis	UMLS	
-MONDO:0005974	strongyloidiasis	UMLS:C0038463	Strongyloidiasis	UMLS:C0348996	Disseminated strongyloidiasis	UMLS	
-MONDO:0019037	progressive supranuclear palsy	UMLS:C0038868	Progressive supranuclear palsy	UMLS:CN205522	PSP syndrome	UMLS	
-MONDO:0000651	thoracic disease	UMLS:C0039978	Thoracic Disease	UMLS:C3661979	Disorder of thoracic segment of trunk	UMLS	
-MONDO:0002049	thrombocytopenia	UMLS:C0040034	Thrombocytopenia	UMLS:CN130080	Thrombocytopenia	UMLS	
-MONDO:0001461	tinea corporis	UMLS:C0040252	Tinea corporis	UMLS:C0546826	Dermatophytosis of the body	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157691	Cellulitis and abscess of finger	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157696	Cellulitis and abscess of face	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS	
-MONDO:0018983	tolosa-Hunt syndrome	UMLS:C0040381	Tolosa-Hunt syndrome	UMLS:C0392060	Painful ophthalmoplegia	UMLS	
-MONDO:0018983	tolosa-Hunt syndrome	UMLS:C0040381	Tolosa-Hunt syndrome	UMLS:CN205421	Painful ophthalmoplegia	UMLS	
-MONDO:0007655	fissured tongue	UMLS:C0040412	Fissured tongue	UMLS:C1842051	Geographic Tongue and Fissured Tongue	UMLS	
-MONDO:0001039	tonsillitis	UMLS:C0040425	Tonsillitis	UMLS:C0149517	Chronic tonsillitis	UMLS	
-MONDO:0005990	tracheitis	UMLS:C0040584	Tracheitis	UMLS:C0149513	Acute tracheitis	UMLS	
-MONDO:0005990	tracheitis	UMLS:C0040584	Tracheitis	UMLS:C0264322	Chronic tracheitis	UMLS	
-MONDO:0010148	Mounier-Kuhn syndrome	UMLS:C0040587	Tracheobronchomegaly	UMLS:C2713583	Congenital tracheobronchomegaly	UMLS	
-MONDO:0019168	pyomyositis	UMLS:C0041188	Tropical pyomyositis	UMLS:C1704275	Pyomyositis	UMLS	
-MONDO:0001444	Chagas disease	UMLS:C0041234	Chagas' disease	UMLS:C0348781	Chagas' disease with digestive system involvement	UMLS	
-MONDO:0001444	Chagas disease	UMLS:C0041234	Chagas' disease	UMLS:C0348782	Chagas' disease with nervous system involvement	UMLS	
-MONDO:0001444	Chagas disease	UMLS:C0041234	Chagas' disease	UMLS:C0153125	Chagas' disease with other organ involvement	UMLS	
-MONDO:0018076	tuberculosis	UMLS:C0041296	Tuberculosis	UMLS:C0151332	Active tuberculosis	UMLS	
-MONDO:0005768	gastrointestinal tuberculosis	UMLS:C0041312	Gastrointestinal Tuberculosis	UMLS:C0152717	Tuberculosis of intestines, peritoneum and mesenteric glands	UMLS	
-MONDO:0005848	miliary tuberculosis	UMLS:C0041321	Miliary tuberculosis	UMLS:C0152915	Acute miliary tuberculosis	UMLS	
-MONDO:0001246	typhus	UMLS:C0041471	Typhus	UMLS:C0041472	Endemic Flea-Borne Typhus	UMLS	
-MONDO:0007886	uterine corpus leiomyoma	UMLS:C0042133	Uterine fibroids	UMLS:C2242776	Plexiform leiomyoma	UMLS	
-MONDO:0001244	vitamin K deficiency hemorrhagic disease	UMLS:C0042880	Vitamin K deficiency	UMLS:C0272348	Vitamin K deficiency coagulation disorder	UMLS	
-MONDO:0018105	Wolfram syndrome	UMLS:C0043207	Wolfram syndrome	UMLS:CN184630	Wolfram syndrome	UMLS	
-MONDO:0019148	Wolman disease	UMLS:C0043208	Wolman disease	UMLS:CN438428	Wolman disease	UMLS	
-MONDO:0000948	xerophthalmia	UMLS:C0043349	Xerophthalmia	UMLS:C3665609	Conjunctival xerosis	UMLS	
-MONDO:0020502	yellow fever	UMLS:C0043395	Yellow fever	UMLS:C0043397	Jungle yellow fever	UMLS	
-MONDO:0020502	yellow fever	UMLS:C0043395	Yellow fever	UMLS:C0043398	Urban yellow fever	UMLS	
-MONDO:0020502	yellow fever	UMLS:C0043397	Jungle yellow fever	UMLS:C0043398	Urban yellow fever	UMLS	
-MONDO:0007608	desmoid tumor	UMLS:C0079218	Aggressive fibromatosis	UMLS:C1851124	DESMOID DISEASE, HEREDITARY	UMLS	
-MONDO:0007608	desmoid tumor	UMLS:C0079218	Aggressive fibromatosis	UMLS:CN072436	Desmoid type fibromatosis	UMLS	
-MONDO:0002561	lysosomal storage disease	UMLS:C0085078	Lysosomal Storage Disease	UMLS:CN205533	Lysosomal disease	UMLS	
-MONDO:0019355	adult-onset Still disease	UMLS:C0085253	Adult onset Still's disease	UMLS:CN206037	AOSD	UMLS	
-MONDO:0005696	central nervous system tuberculosis	UMLS:C0085388	Intracranial Tuberculoma	UMLS:C2607948	Tuberculous abscess of brain	UMLS	
-MONDO:0017278	autoimmune polyendocrinopathy	UMLS:C0085409	Autoimmune polyendocrinopathy	UMLS:C4316913	Autoimmune Polyglandular Syndrome	UMLS	
-MONDO:0017376	reactive arthritis	UMLS:C0085435	Reactive arthritis	UMLS:CN203069	Reiter disease	UMLS	
-MONDO:0005974	strongyloidiasis	UMLS:C0085810	Anguilluliasis	UMLS:C0348996	Disseminated strongyloidiasis	UMLS	
-MONDO:0005990	tracheitis	UMLS:C0149513	Acute tracheitis	UMLS:C0264322	Chronic tracheitis	UMLS	
-MONDO:0005568	cholesterol embolism	UMLS:C0149649	Cholesterol Embolism	UMLS:C0585266	Trash foot	UMLS	
-MONDO:0002897	secondary syphilis	UMLS:C0149985	Secondary syphilis	UMLS:C0343676	Secondary syphilis of viscera or bone	UMLS	
-MONDO:0005012	cutaneous melanoma (disease)	UMLS:C0151779	Cutaneous melanoma	UMLS:C0153535	Malignant melanoma of skin of upper limb	UMLS	
-MONDO:0005012	cutaneous melanoma (disease)	UMLS:C0151779	Cutaneous melanoma	UMLS:C0153536	Malignant melanoma of skin of lower limb	UMLS	
-MONDO:0020533	streptobacillary rat-bite fever	UMLS:C0152063	Streptobacillary fever	UMLS:CN207435	Streptobacillary rat-bite fever	UMLS	
-MONDO:0017282	alveolar echinococcosis	UMLS:C0152069	Echinococcus multilocularis infection	UMLS:C0948954		UMLS	
-MONDO:0002204	transient arthritis	UMLS:C0152083	Transient arthropathy	UMLS:C3887596	Transient arthritis	UMLS	
-MONDO:0001333	Patau syndrome	UMLS:C0152095	Patau syndrome	UMLS:CN204386	Patau syndrome	UMLS	
-MONDO:0009672	juvenile spinal muscular atrophy	UMLS:C0152109	Juvenile spinal muscular atrophy	UMLS:C0700595	Spinal Muscular Atrophy of Childhood	UMLS	
-MONDO:0000916	intestinal infectious disease	UMLS:C0152516	Bacterial enteritis	UMLS:C0178238	Intestinal infectious disease	UMLS	
-MONDO:0002896	primary syphilis	UMLS:C0153139	Early symptomatic syphilis	UMLS:C2931317	Primary syphilis	UMLS	
-MONDO:0004264	acute gonococcal endometritis	UMLS:C0153196	Acute gonococcal endometritis	UMLS:C0341829	Gonococcal endometritis	UMLS	
-MONDO:0018408	cystic echinococcosis	UMLS:C0153290	Echinococcus granulosus infection of lung	UMLS:C0153291	Echinococcus granulosus infection of thyroid	UMLS	
-MONDO:0018408	cystic echinococcosis	UMLS:C0153290	Echinococcus granulosus infection of lung	UMLS:C4303092	Cystic echinococcosis	UMLS	
-MONDO:0018408	cystic echinococcosis	UMLS:C0153291	Echinococcus granulosus infection of thyroid	UMLS:C4303092	Cystic echinococcosis	UMLS	
-MONDO:0003472	lice infestation	UMLS:C0153317	Pediculosis and phthirus infections	UMLS:C0277351	Mixed pediculosis	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS	
-MONDO:0021315	malignant tumor of nasopharynx	UMLS:C0153392	Malignant neoplasm of nasopharynx	UMLS:C0238301	Cancer of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0005012	cutaneous melanoma (disease)	UMLS:C0153535	Malignant melanoma of skin of upper limb	UMLS:C0153536	Malignant melanoma of skin of lower limb	UMLS	
-MONDO:0002158	fallopian tube cancer	UMLS:C0153579	Neoplasm, Fallopian Tube, Malignant	UMLS:CN200469	Tubal cancer	UMLS	
-MONDO:0005519	renal pelvis carcinoma	UMLS:C0153618	Malignant Renal Pelvis Neoplasm	UMLS:C1335749	Carcinoma of the Renal Pelvis	UMLS	
-MONDO:0004709	occipital lobe neoplasm	UMLS:C0153638	Malignant neoplasm of occipital lobe	UMLS:C1263889	Neoplasm of Occipital Lobe	UMLS	
-MONDO:0004707	anal canal carcinoma in situ	UMLS:C0154064	Carcinoma in situ of anus	UMLS:C2242854	Carcinoma in situ of anal canal	UMLS	
-MONDO:0002052	lymphadenitis (disease)	UMLS:C0154304	Chronic lymphadenitis	UMLS:C0157705	Acute lymphadenitis	UMLS	
-MONDO:0001452	pseudoretinitis pigmentosa	UMLS:C0154858	Secondary pigmentary retinal degeneration	UMLS:C2053820	Pseudoretinitis pigmentosa	UMLS	
-MONDO:0019118	inherited retinal dystrophy	UMLS:C0154860	Hereditary retinal dystrophy	UMLS:C0854723	Retinal dystrophy	UMLS	
-MONDO:0001921	chronic atticoantral disease	UMLS:C0155441	Chronic suppurative otitis media - atticoantral	UMLS:C0565831	Chronic atticoantral disease	UMLS	
-MONDO:0001114	bacterial myocarditis	UMLS:C0155690	Septic myocarditis	UMLS:C1384588	Bacterial myocarditis	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS	
-MONDO:0001155	gastrojejunal ulcer	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS	
-MONDO:0001410	postmenopausal atrophic vaginitis	UMLS:C0156409	Postmenopausal atrophic vaginitis	UMLS:C0221392	Atrophic vaginitis	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157691	Cellulitis and abscess of finger	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157696	Cellulitis and abscess of face	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C0157696	Cellulitis and abscess of face	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157696	Cellulitis and abscess of face	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157696	Cellulitis and abscess of face	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157696	Cellulitis and abscess of face	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS	
-MONDO:0001628	tinea unguium	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS	
-MONDO:0044343	cervical disc degenerative disorder	UMLS:C0158262	Degeneration of cervical intervertebral disc	UMLS:C0410606	Cervical Disc Degenerative Disorder	UMLS	
-MONDO:0016086	osteochondritis of tarsal/metatarsal bone	UMLS:C0158444	Juvenile osteochondrosis of foot	UMLS:CN200840	Osteochondrosis of the tarsal bone	UMLS	
-MONDO:0006581	miliaria rubra	UMLS:C0162423	Miliaria rubra	UMLS:C3241961	Miliaria crystallina	UMLS	
-MONDO:0010913	Caroli disease	UMLS:C0162510	Caroli disease	UMLS:C1833541	Caroli disease	UMLS	
-MONDO:0002520	acute hepatic porphyria	UMLS:C0162533	Hepatic porphyria	UMLS:CN552491	Acute Porphyria	UMLS	
-MONDO:0001341	selective IgA deficiency disease	UMLS:C0162538	IgA deficiency	UMLS:C4049006	Selective immunoglobulin A deficiency	UMLS	
-MONDO:0000297	baylisascariasis	UMLS:C0162626	Infections, Ascaridida	UMLS:C0277150	Infection by Baylisascaris	UMLS	
-MONDO:0019349	Sotos syndrome	UMLS:C0175695	Sotos syndrome	UMLS:CN239475	Sotos Syndrome	UMLS	
-MONDO:0007893	Noonan syndrome with multiple lentigines	UMLS:C0175704	Leopard syndrome	UMLS:CN074218	LPRD1	UMLS	
-MONDO:0002056	breast fibroadenoma	UMLS:C0178421	Fibroadenoma of breast	UMLS:C0346158	Juvenile fibroadenoma	UMLS	
-MONDO:0002056	breast fibroadenoma	UMLS:C0178421	Fibroadenoma of breast	UMLS:C0206650	Fibroadenoma	UMLS	
-MONDO:0006451	thymic carcinoma	UMLS:C0205969	Thymic carcinoma	UMLS:C1322286	Thymoma, type C	UMLS	
-MONDO:0006451	thymic carcinoma	UMLS:C0205969	Thymic carcinoma	UMLS:CN207411	Malignant thymoma	UMLS	
-MONDO:0008681	WAGR syndrome	UMLS:C0206115	WAGR syndrome	UMLS:C2931803	Deletion 11p13	UMLS	
-MONDO:0007100	familial amyloid neuropathy	UMLS:C0206245	Familial amyloid polyneuropathy type I (Portuguese-Swedish-Japanese Type)	UMLS:C2751492	AMYLOIDOSIS, HEREDITARY, TRANSTHYRETIN-RELATED	UMLS	
-MONDO:0002928	carcinosarcoma	UMLS:C0206627	Mullerian mixed tumor	UMLS:C1334603	Malignant Mixed Mesodermal (Mullerian) Tumor	UMLS	
-MONDO:0006745	endometrioid stromal sarcoma	UMLS:C0206630	Endometrial stromal sarcoma	UMLS:C2239246	Endometrial stromal sarcoma, high grade	UMLS	
-MONDO:0008145	Ollier disease	UMLS:C0206641	Osteochondromatosis	UMLS:CN203308	Dyschondroplasia	UMLS	
-MONDO:0011655	alveolar soft part sarcoma (disease)	UMLS:C0206657	Alveolar soft part sarcoma	UMLS:C0279544	Adult Alveolar Soft-Part Sarcoma	UMLS	
-MONDO:0005026	endometrioid adenocarcinoma	UMLS:C0206687	Endometrioid carcinoma	UMLS:C1569637	Endometrioid adenocarcinoma	UMLS	
-MONDO:0005051	invasive lobular breast carcinoma	UMLS:C0206692	Lobular carcinoma	UMLS:C0279565	Invasive Lobular Carcinoma of the Breast	UMLS	
-MONDO:0015277	medullary thyroid gland carcinoma	UMLS:C0206693	Medullary carcinoma	UMLS:C0238462	Medullary thyroid carcinoma	UMLS	
-MONDO:0006275	lung giant cell carcinoma	UMLS:C0206703	Giant cell carcinoma	UMLS:C0345960	Giant cell carcinoma of lung	UMLS	
-MONDO:0005341	skin basal cell carcinoma	UMLS:C0206710	Basal cell neoplasm	UMLS:C0751676	Basal Cell Cancer	UMLS	
-MONDO:0007564	pilomatrixoma	UMLS:C0206711	Pilomatrixoma	UMLS:C0853031	Benign Hair Follicle Neoplasm	UMLS	
-MONDO:0006055	sex cord-stromal tumor	UMLS:C0206724	Sex cord-stromal tumor	UMLS:C1515289	Malignant Testicular Sex Cord-Stromal Tumor	UMLS	
-MONDO:0019496	neuroendocrine neoplasm	UMLS:C0206754	Neuroendocrine tumor	UMLS:CN206284	APUDoma	UMLS	
-MONDO:0015240	digitotalar dysmorphism	UMLS:C0220662	Distal arthrogryposis type 1	UMLS:C1852085	DIGITOTALAR DYSMORPHISM	UMLS	
-MONDO:0015240	digitotalar dysmorphism	UMLS:C0220662	Distal arthrogryposis type 1	UMLS:CN197602	Distal arthrogryposis type 1	UMLS	
-MONDO:0008642	VACTERL/vater association	UMLS:C0220708	VATER association	UMLS:C1735591		UMLS	
-MONDO:0008642	VACTERL/vater association	UMLS:C0220708	VATER association	UMLS:CN206312	VATER association	UMLS	
-MONDO:0009665	biotinidase deficiency	UMLS:C0220754	Deficiency of biotinidase	UMLS:CN043572	Biotin-Responsive Multiple Carboxylase Deficiencies	UMLS	
-MONDO:0009058	cystathioninuria (disease)	UMLS:C0220993	Cystathioninuria	UMLS:C0268616	Gamma-cystathionase deficiency	UMLS	
-MONDO:0009058	cystathioninuria (disease)	UMLS:C0220993	Cystathioninuria	UMLS:C3495552	CYSTATHIONASE DEFICIENCY	UMLS	
-MONDO:0019439	AA amyloidosis	UMLS:C0221014	Reactive systemic amyloidosis	UMLS:C3536715	AA amyloidosis	UMLS	
-MONDO:0008006	Mobius syndrome	UMLS:C0221060	Möbius syndrome	UMLS:C0853240	Congenital facial diplegia	UMLS	
-MONDO:0000741	angular cheilitis	UMLS:C0221237	Angular cheilitis	UMLS:C0221264	Cheilosis	UMLS	
-MONDO:0009050	Cushing disease due to pituitary adenoma	UMLS:C0221406	Pituitary-dependent Cushing's disease	UMLS:C1306214	ACTH-secreting pituitary adenoma	UMLS	
-MONDO:0008094	familial multiple nevi flammei	UMLS:C0235752		UMLS:CN205384	Familial multiple port-wine stains	UMLS	
-MONDO:0015681	childhood disintegrative disorder	UMLS:C0236791		UMLS:CN072151	Childhood disintegrative disorder	UMLS	
-MONDO:0005628	male breast carcinoma	UMLS:C0238033	Carcinoma of male breast	UMLS:C0242787	Malignant neoplasm of male breast	UMLS	
-MONDO:0005628	male breast carcinoma	UMLS:C0238033	Carcinoma of male breast	UMLS:C0242788	Neoplasm of male breast	UMLS	
-MONDO:0011719	gastrointestinal stromal tumor	UMLS:C0238198	Gastrointestinal stromal tumor	UMLS:C3179349	Gastrointestinal stromal sarcoma	UMLS	
-MONDO:0009653	mucolipidosis type IV	UMLS:C0238286	Mucolipidosis type IV	UMLS:CN716584	MLIV	UMLS	
-MONDO:0008224	hyperkalemic periodic paralysis	UMLS:C0238357	Hyperkalemic periodic paralysis	UMLS:CN074266	HYPP	UMLS	
-MONDO:0009197	transient erythroblastopenia of childhood	UMLS:C0238478	Transient erythroblastopenia of childhood	UMLS:C0451688	Transient acquired pure red cell aplasia	UMLS	
-MONDO:0019640	posterior urethral valve	UMLS:C0238506		UMLS:CN227669	PUV	UMLS	
-MONDO:0008716	Acrogeria	UMLS:C0238590	Acrogeria	UMLS:C0406584	Gottron syndrome	UMLS	
-MONDO:0016264	autoimmune hepatitis	UMLS:C0241910	Autoimmune hepatitis	UMLS:C1332355	Autoimmune Hepatitis with Centrilobular Necrosis	UMLS	
-MONDO:0001703	color vision disorder	UMLS:C0242225	Color blindness	UMLS:CN207064	Color-vision disease	UMLS	
-MONDO:0019122	idiopathic acute eosinophilic pneumonia	UMLS:C0242459	Simple pulmonary eosinophilia	UMLS:C4518469	Idiopathic acute eosinophilic pneumonia	UMLS	
-MONDO:0019122	idiopathic acute eosinophilic pneumonia	UMLS:C0242459	Simple pulmonary eosinophilia	UMLS:CN227574	Loffler syndrome	UMLS	
-MONDO:0007650	MALT lymphoma	UMLS:C0242647	Mucosa-Associated Lymphoid Tissue Lymphoma	UMLS:C1850900	Mucosa-associated lymphoid tissue lymphoma	UMLS	
-MONDO:0005628	male breast carcinoma	UMLS:C0242787	Malignant neoplasm of male breast	UMLS:C0242788	Neoplasm of male breast	UMLS	
-MONDO:0008485	Sebocystomatosis	UMLS:C0259771	Steatocystoma multiplex	UMLS:C3671377	Sebocystomatosis	UMLS	
-MONDO:0018201	extragonadal germ cell tumor	UMLS:C0262963	Tumor of the Extragonadal Germ Cell	UMLS:CN204711	Extragonadal germ cell tumor	UMLS	
-MONDO:0019322	pemphigus vegetans	UMLS:C0263316	Pemphigus vegetans	UMLS:CN205981	Pemphigus vegetans	UMLS	
-MONDO:0015665	scleromyxedema	UMLS:C0263390	Scleromyxedema	UMLS:CN200092	Generalized papular and sclerodermoid lichen myxedematosus	UMLS	
-MONDO:0013688	linear and whorled nevoid hypermelanosis	UMLS:C0263579	Pigmented hairy epidermal nevus	UMLS:C1304501	Linear and whorled nevoid hypermelanosis	UMLS	
-MONDO:0001557	olecranon bursitis	UMLS:C0263962	Olecranon bursitis	UMLS:C3887895	Bursitis of elbow	UMLS	
-MONDO:0000471	tricuspid valve disease	UMLS:C0264776	Rheumatic disease of tricuspid valve	UMLS:C0264882	Tricuspid valve disorder	UMLS	
-MONDO:0000467	second-degree atrioventricular block	UMLS:C0264906	Second degree atrioventricular block	UMLS:C1621824	Incomplete atrioventricular block	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS:C0741160	Ruptured aortic aneurysm	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS:C0741160	Ruptured aortic aneurysm	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS	
-MONDO:0010217	de Sanctis-Cacchione syndrome	UMLS:C0265201	De Sanctis-Cacchione syndrome	UMLS:CN199649	De Sanctis-Cacchione syndrome	UMLS	
-MONDO:0019978	Robinow syndrome	UMLS:C0265205	Robinow syndrome	UMLS:CN776872	Robinow-Silverman-Smith syndrome	UMLS	
-MONDO:0010193	Weaver syndrome	UMLS:C0265210	Weaver syndrome	UMLS:CN036342	Mental retardation, microcephaly, weight deficiency, unusual facies, clinodactyly, bone hypoplasia, and cleft palate	UMLS	
-MONDO:0007029	branchio-oto-renal syndrome	UMLS:C0265234	Branchio-oto-renal syndrome	UMLS:CN043574	Branchiootorenal Spectrum Disorders	UMLS	
-MONDO:0007142	Townes-Brocks syndrome	UMLS:C0265246	Townes syndrome	UMLS:CN034849	TBS1	UMLS	
-MONDO:0015253	Diamond-Blackfan anemia	UMLS:C0265265	Aase syndrome	UMLS:C1260899	Diamond-Blackfan anemia	UMLS	
-MONDO:0010159	constitutional mismatch repair deficiency syndrome	UMLS:C0265325	CMMR-D syndrome	UMLS:C4321324	Constitutional Mismatch Repair Deficiency Syndrome	UMLS	
-MONDO:0018781	KID syndrome	UMLS:C0265336	Senter syndrome	UMLS:CN205136	Keratitis-ichthyosis-deafness/Hystrix-like ichthyosis-deafness syndrome	UMLS	
-MONDO:0015431	ring chromosome 10	UMLS:C0265438	Ring chromosome 10 syndrome	UMLS:CN037257	Chromosome 10, ring	UMLS	
-MONDO:0008272	polysyndactyly	UMLS:C0265553		UMLS:C1868111	Preaxial polydactyly type 4	UMLS	
-MONDO:0016829	familial visceral myopathy	UMLS:C0266833	Familial visceral myopathy	UMLS:C1835084	MEGADUODENUM AND/OR MEGACYSTIS	UMLS	
-MONDO:0016829	familial visceral myopathy	UMLS:C0266833	Familial visceral myopathy	UMLS:CN202146	Megaduodenum and/or megacystis	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0267112	Acute gastric mucosal erosion	UMLS:C2243088	Erosive Gastritis	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0267112	Acute gastric mucosal erosion	UMLS:C2243090	Erosive gastropathy	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C0267112	Acute gastric mucosal erosion	UMLS:C3854048	Erosive gastritis	UMLS	
-MONDO:0007916	primary intestinal lymphangiectasia	UMLS:C0267372	Primary intestinal lymphangiectasia	UMLS:CN206410	Waldmann disease	UMLS	
-MONDO:0006633	acalculous cholecystitis	UMLS:C0267841	Acalculous cholecystitis	UMLS:C0267842	Acute cholecystitis without calculus	UMLS	
-MONDO:0007749	autosomal recessive infantile hypercalcemia	UMLS:C0268080	Idiopathic hypercalcemia of infancy	UMLS:C4329374	Autosomal Recessive Infantile Hypercalcemia	UMLS	
-MONDO:0007749	autosomal recessive infantile hypercalcemia	UMLS:C0268080	Idiopathic hypercalcemia of infancy	UMLS:CN203398	Familial infantile hypercalcemia with suppressed intact parathyroid hormone	UMLS	
-MONDO:0009529	pyruvate dehydrogenase E3 deficiency	UMLS:C0268193	E3-deficient maple syrup urine disease	UMLS:CN043137	Dihydrolipoamide Dehydrogenase E3 Deficiency	UMLS	
-MONDO:0008810	familial apolipoprotein C-II deficiency	UMLS:C0268199	Familial apolipoprotein C-II deficiency	UMLS:C1720779	Familial apoC-II deficiency	UMLS	
-MONDO:0009296	glycoprotein storage disease	UMLS:C0268220	Glycoprotein storage disorder	UMLS:C1856275	GLYCOPROTEIN STORAGE DISEASE	UMLS	
-MONDO:0019681	juvenile sialidosis type 2	UMLS:C0268229	Dysmorphic sialidosis, juvenile form	UMLS:CN206605	Juvenile sialidosis type 2	UMLS	
-MONDO:0009218	Farber lipogranulomatosis	UMLS:C0268255	Farber lipogranulomatosis	UMLS:CN204335		UMLS	
-MONDO:0016002	Ehlers-Danlos syndrome, kyphoscoliotic type	UMLS:C0268342	Ehlers-Danlos syndrome, oculoscoliotic type	UMLS:CN202461	Nevo syndrome	UMLS	
-MONDO:0017816	primary systemic amyloidosis	UMLS:C0268380	Systemic amyloidosis	UMLS:C0281479	Primary Systemic Amyloidosis	UMLS	
-MONDO:0008633	Muckle-Wells syndrome	UMLS:C0268390	Muckle-Wells syndrome	UMLS:C1304205	Neutrophilic urticaria	UMLS	
-MONDO:0009196	ermine phenotype	UMLS:C0268501	BADS syndrome	UMLS:C1856899	Pigmentary disorder with hearing loss	UMLS	
-MONDO:0002012	methylmalonic acidemia	UMLS:C0268583	Methylmalonic acidemia	UMLS:C1855119	Methylmalonic aciduria	UMLS	
-MONDO:0018950	3-methylcrotonyl-CoA carboxylase deficiency	UMLS:C0268600	MCCD	UMLS:CN239165	3-MCC Deficiency	UMLS	
-MONDO:0009520	3-hydroxy-3-methylglutaric aciduria	UMLS:C0268601	HMG-CoA lyase deficiency	UMLS:C1533587	Hydroxymethylglutaric aciduria	UMLS	
-MONDO:0009058	cystathioninuria (disease)	UMLS:C0268616	Gamma-cystathionase deficiency	UMLS:C3495552	CYSTATHIONASE DEFICIENCY	UMLS	
-MONDO:0009351	homocarnosinosis	UMLS:C0268632	Homocarnosinase deficiency	UMLS:C3495554	Homocarnosinase deficiency	UMLS	
-MONDO:0002286	renal artery disease	UMLS:C0268790	Renal vascular disorder	UMLS:C3640053	Renal Artery Disease	UMLS	
-MONDO:0016971	limb-girdle muscular dystrophy	UMLS:C0270950	Erb's muscular dystrophy	UMLS:C0686353	Limb-girdle muscular dystrophy	UMLS	
-MONDO:0016033	Cornelia de Lange syndrome	UMLS:C0270972	Cornelia de Lange syndrome	UMLS:CN239271	Cornelia de Lange Syndrome	UMLS	
-MONDO:0005417	wet macular degeneration	UMLS:C0271084	Exudative senile macular retinal degeneration	UMLS:C2237660	Wet Macular Degeneration	UMLS	
-MONDO:0019353	Stargardt disease	UMLS:C0271093	Stargardt's disease	UMLS:C1855465	STARGARDT DISEASE	UMLS	
-MONDO:0020371	essential iris atrophy	UMLS:C0271111	Essential iris atrophy	UMLS:CN207238	Essential iris atrophy	UMLS	
-MONDO:0001175	immature cataract	UMLS:C0271163	Incipient cataract	UMLS:C2939157	Incipient senile cataract	UMLS	
-MONDO:0001175	immature cataract	UMLS:C0271163	Incipient cataract	UMLS:C2960113	Immature cataract	UMLS	
-MONDO:0024330	infectious otitis media	UMLS:C0271429	Acute otitis media	UMLS:C2827407	Infectious Otitis Media	UMLS	
-MONDO:0002738	acute transudative otitis media	UMLS:C0271432	Acute transudative otitis media	UMLS:C2939185	Acute otitis media with effusion	UMLS	
-MONDO:0015892	growth hormone insensitivity syndrome	UMLS:C0271568	Short stature due to growth hormone resistance	UMLS:C4318479	Growth Hormone Insensitivity Syndromes	UMLS	
-MONDO:0015892	growth hormone insensitivity syndrome	UMLS:C0271568	Short stature due to growth hormone resistance	UMLS:CN200504	Short stature due to a defect in growth hormone receptor or post-receptor pathway	UMLS	
-MONDO:0043370	secondary adrenal insufficiency	UMLS:C0271738	Hypocortisolism secondary to another disorder	UMLS:C0948387	Secondary Adrenal Insufficiency	UMLS	
-MONDO:0010139	isolated thyroid-stimulating hormone deficiency	UMLS:C0271789	Isolated TSH deficiency	UMLS:C4082174	Isolated thyrotropin deficiency	UMLS	
-MONDO:0004135	subacute lymphocytic thyroiditis	UMLS:C0271814	Silent thyroiditis	UMLS:C1306804	Subacute lymphocytic thyroiditis	UMLS	
-MONDO:0015663	diencephalic syndrome	UMLS:C0271889	Diencephalic syndrome of infancy	UMLS:C0342436	Diencephalic syndrome	UMLS	
-MONDO:0015663	diencephalic syndrome	UMLS:C0271889	Diencephalic syndrome of infancy	UMLS:CN200089	Russell syndrome	UMLS	
-MONDO:0008786	pyridoxine-responsive sideroblastic anemia	UMLS:C0272027	Pyridoxine-responsive sideroblastic anemia	UMLS:C1859787	ANEMIA, SIDEROBLASTIC, PYRIDOXINE-RESPONSIVE, AUTOSOMAL RECESSIVE	UMLS	
-MONDO:0019107	Rh deficiency syndrome	UMLS:C0272052	Rh deficiency syndrome	UMLS:C1849387	Rh-null syndrome	UMLS	
-MONDO:0009974	familial hemophagocytic lymphohistiocytosis type 1	UMLS:C0272199	Lymphocytosis, Familial Hemophagocytic	UMLS:CN034020	FHL1	UMLS	
-MONDO:0009974	familial hemophagocytic lymphohistiocytosis type 1	UMLS:C0272199	Lymphocytosis, Familial Hemophagocytic	UMLS:CN205265	Familial HLH	UMLS	
-MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0272258	Primary cryoglobulinemia	UMLS:C0340992	Cryoglobulinemic vasculitis	UMLS	
-MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0272258	Primary cryoglobulinemia	UMLS:C0343208	Essential mixed cryoglobulinemia	UMLS	
-MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0272258	Primary cryoglobulinemia	UMLS:C1852456	Primary cryoglobulinemia	UMLS	
-MONDO:0007686	gray platelet syndrome	UMLS:C0272302	Grey platelet syndrome	UMLS:C2717750	Platelet alpha-Granule Deficiency	UMLS	
-MONDO:0007686	gray platelet syndrome	UMLS:C0272302	Grey platelet syndrome	UMLS:CN205641	Platelet alpha-granule deficiency	UMLS	
-MONDO:0001720	gonococcal synovitis	UMLS:C0275662	Gonococcal synovitis	UMLS:C0343714	Gonococcal synovitis or tenosynovitis	UMLS	
-MONDO:0001066	late yaws	UMLS:C0276007	Gummatous frambeside	UMLS:C1517744	Late Yaws	UMLS	
-MONDO:0018661	Zika virus disease	UMLS:C0276289	Zika Virus Infection	UMLS:CN237724	Zika virus infection	UMLS	
-MONDO:0006001	urinary schistosomiasis	UMLS:C0276926	Schistosoma haematobium infection	UMLS:C1704430	Urinary schistosomiasis	UMLS	
-MONDO:0000294	mesocestoidiasis	UMLS:C0277108	Infection by Mesocestoides	UMLS:C0277110	Infection by Mesocestoides lineatus	UMLS	
-MONDO:0006292	malignant mesothelioma (disease)	UMLS:C0278752	Advanced Malignant Mesothelioma	UMLS:C0345967	Malignant mesothelioma	UMLS	
-MONDO:0006292	malignant mesothelioma (disease)	UMLS:C0278752	Advanced Malignant Mesothelioma	UMLS:C1332338	Asbestos-Related Malignant Mesothelioma	UMLS	
-MONDO:0002794	adult medulloblastoma	UMLS:C0278876	Adult Medulloblastoma	UMLS:C1332188	Adult Brain Medulloblastoma	UMLS	
-MONDO:0006270	lobular breast carcinoma in situ	UMLS:C0279563	Lobular carcinoma in situ of breast	UMLS:C0334381	Non-infiltrating lobular carcinoma	UMLS	
-MONDO:0016216	adult hepatocellular carcinoma	UMLS:C0279607	Adult Hepatocellular Carcinoma	UMLS:CN200978	Adult HCC	UMLS	
-MONDO:0005461	endometrium adenocarcinoma	UMLS:C0279763	Endometrial Adenoacanthoma	UMLS:C1153706	Endometrial adenocarcinoma	UMLS	
-MONDO:0018270	extraskeletal Ewing sarcoma	UMLS:C0279980	Extraosseous Ewing's Sarcoma	UMLS:CN204849	Extraskeletal Ewing tumor	UMLS	
-MONDO:0015692	refractory anemia with excess blasts in transformation	UMLS:C0280028	Refractory anemia with excess blasts in transformation	UMLS:CN200189	RAEB-t	UMLS	
-MONDO:0020321	acute undifferentiated leukemia	UMLS:C0280141	Acute Undifferentiated Leukemia	UMLS:C0856823		UMLS	
-MONDO:0020321	acute undifferentiated leukemia	UMLS:C0280141	Acute Undifferentiated Leukemia	UMLS:C1282947	Acute myeloid leukemia, minimal differentiation, FAB M0	UMLS	
-MONDO:0018301	interstitial cystitis	UMLS:C0282488	Interstitial cystitis	UMLS:C0600040	Chronic interstitial cystitis	UMLS	
-MONDO:0018301	interstitial cystitis	UMLS:C0282488	Interstitial cystitis	UMLS:C1720830	Painful Bladder Syndrome	UMLS	
-MONDO:0018301	interstitial cystitis	UMLS:C0282488	Interstitial cystitis	UMLS:CN204884	Interstitial cystitis/painful bladder syndrome	UMLS	
-MONDO:0000290	primary amebic meningoencephalitis	UMLS:C0300934	Primary Amebic Meningoencephalitis	UMLS:C4303098	Naegleria fowleri infection	UMLS	
-MONDO:0015898	adrenogenital syndrome	UMLS:C0302280	Adrenogenital syndrome	UMLS:CN200506	Adrenogenital syndrome	UMLS	
-MONDO:0024892	soft tissue amyloid neoplasm	UMLS:C0333572	Amyloid tumor	UMLS:C1706802	Soft Tissue Amyloid Neoplasm	UMLS	
-MONDO:0018308	liver mesenchymal hamartoma	UMLS:C0334091	Biliary hamartoma	UMLS:C1333971	Mesenchymal hamartoma of liver	UMLS	
-MONDO:0003487	pseudoglandular squamous cell carcinoma	UMLS:C0334250	Adenoid squamous cell carcinoma	UMLS:C0334393	Adenocarcinoma with squamous metaplasia	UMLS	
-MONDO:0004083	Borst-Jadassohn intraepidermal carcinoma	UMLS:C0334260	Bowen's disease, clonal	UMLS:C2937231	Intraepidermal epithelioma of Jadassohn	UMLS	
-MONDO:0003701	thyroid gland diffuse sclerosing papillary carcinoma	UMLS:C0334330	Nonencapsulated sclerosing carcinoma	UMLS:C1321862	Nonencapsulated sclerosing tumor	UMLS	
-MONDO:0003214	apocrine adenocarcinoma	UMLS:C0334346	Apocrine adenocarcinoma	UMLS:C1706827	Apocrine Carcinoma	UMLS	
-MONDO:0004276	ceruminoma	UMLS:C0334352	Ceruminous adenoma	UMLS:C1333488	Ceruminous Adenoma of the External Auditory Canal	UMLS	
-MONDO:0003741	juvenile type testicular granulosa cell tumor	UMLS:C0334403	Juvenile granulosa cell tumor	UMLS:C1515285	Juvenile Type Testicular Granulosa Cell Tumor	UMLS	
-MONDO:0016440	elastofibroma dorsi	UMLS:C0334460	Elastofibroma	UMLS:CN226932	Elastofibroma dorsi	UMLS	
-MONDO:0002863	rhabdomyosarcoma with mixed embryonal and alveolar features	UMLS:C0334481	Mixed type rhabdomyosarcoma	UMLS:C1709053	Rhabdomyosarcoma with Mixed Embryonal and Alveolar Features	UMLS	
-MONDO:0005006	clear cell sarcoma of kidney	UMLS:C0334488	Clear cell sarcoma of kidney	UMLS:CN242113	CCSK	UMLS	
-MONDO:0004150	breast giant fibroadenoma	UMLS:C0334500	Giant fibroadenoma	UMLS:C0346157	Giant fibroadenoma of breast	UMLS	
-MONDO:0002422	adamantinoma	UMLS:C0334556	Adamantinoma of long bone	UMLS:C1367554	Adamantinoma of long bones	UMLS	
-MONDO:0016682	giant cell glioblastoma	UMLS:C0334588	Giant cell glioblastoma	UMLS:C0334593	Monstrocellular sarcoma	UMLS	
-MONDO:0017276	frontotemporal dementia	UMLS:C0338451	Frontotemporal dementia	UMLS:C0520716	Pallidopontonigral degeneration	UMLS	
-MONDO:0011599	birdshot chorioretinopathy	UMLS:C0339402	Birdshot chorioretinitis	UMLS:C1853959	Vitiliginous choroiditis	UMLS	
-MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0340992	Cryoglobulinemic vasculitis	UMLS:C0343208	Essential mixed cryoglobulinemia	UMLS	
-MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0340992	Cryoglobulinemic vasculitis	UMLS:C1852456	Primary cryoglobulinemia	UMLS	
-MONDO:0003652	acute urate nephropathy	UMLS:C0341712	Acute urate nephropathy	UMLS:C0403719	Uric acid urolithiasis	UMLS	
-MONDO:0010785	maternally-inherited diabetes and deafness	UMLS:C0342289	Mitochondrial diabetes	UMLS:C4330695	Mitochondrial Diabetes	UMLS	
-MONDO:0015663	diencephalic syndrome	UMLS:C0342436	Diencephalic syndrome	UMLS:CN200089	Russell syndrome	UMLS	
-MONDO:0020542	malignant Sertoli-Leydig cell tumor of ovary	UMLS:C0342515	Virilizing ovarian tumor	UMLS:CN207443	Ovarian malignant Sertoli-Leydig cell tumor	UMLS	
-MONDO:0018018	wild type ATTR amyloidosis	UMLS:C0342623	Senile systemic amyloidosis	UMLS:CN204235	Wild type ATTR-related amyloidosis	UMLS	
-MONDO:0018458	familial hypocalciuric hypercalcemia	UMLS:C0342637	Familial benign hypocalciuric hypercalcemia	UMLS:C1809471	Familial benign hypercalcemia	UMLS	
-MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	UMLS:C0342721	Cobalamin A disease	UMLS:C0342722	Cobalamin B disease	UMLS	
-MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	UMLS:C0342721	Cobalamin A disease	UMLS:C1855109	Vitamin B12-responsive methylmalonic aciduria type cblA	UMLS	
-MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	UMLS:C0342722	Cobalamin B disease	UMLS:C1855109	Vitamin B12-responsive methylmalonic aciduria type cblA	UMLS	
-MONDO:0009610	3-methylglutaconic aciduria type 1	UMLS:C0342727	MGA1	UMLS:C0342728	3-Methylglutaconic aciduria type 1	UMLS	
-MONDO:0009414	glycogen storage disease due to hepatic glycogen synthase deficiency	UMLS:C0342748	Glycogen synthase deficiency	UMLS:C1855861	Glycogenosis type 0a	UMLS	
-MONDO:0018485	glycogen storage disease due to acid maltase deficiency, late-onset	UMLS:C0342753	Alpha-1,4-glucosidase acid deficiency, late onset	UMLS:C3888925	Pompe disease, late onset	UMLS	
-MONDO:0009070	D-glyceric aciduria	UMLS:C0342765	D-Glyceric aciduria	UMLS:C1291386	D-glyceric acidemia	UMLS	
-MONDO:0009855	d-bifunctional protein deficiency	UMLS:C0342870		UMLS:C1533628	Pseudo-Zellweger syndrome	UMLS	
-MONDO:0009855	d-bifunctional protein deficiency	UMLS:C0342870		UMLS:CN203333	Pseudo-Zellweger syndrome	UMLS	
-MONDO:0018768	familial cold autoinflammatory syndrome	UMLS:C0343068	Familial cold urticaria	UMLS:CN230757	Familial cold autoinflammatory syndrome	UMLS	
-MONDO:0018592	cutaneous polyarteritis nodosa	UMLS:C0343190	Cutaneous polyarteritis nodosa	UMLS:CN242143	Cutaneous periarteritis nodosa	UMLS	
-MONDO:0018227	hypocomplementemic urticarial vasculitis	UMLS:C0343206	Hypocomplementemic urticarial vasculitis	UMLS:CN204757	McDuffie syndrome	UMLS	
-MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0343208	Essential mixed cryoglobulinemia	UMLS:C1852456	Primary cryoglobulinemia	UMLS	
-MONDO:0018626	paratyphoid fever	UMLS:C0343375	Paratyphoid A fever	UMLS:C0343376	Paratyphoid B fever	UMLS	
-MONDO:0018626	paratyphoid fever	UMLS:C0343375	Paratyphoid A fever	UMLS:C0343377	Paratyphoid C fever	UMLS	
-MONDO:0018626	paratyphoid fever	UMLS:C0343376	Paratyphoid B fever	UMLS:C0343377	Paratyphoid C fever	UMLS	
-MONDO:0015185	intestinal polyposis syndrome	UMLS:C0345891	Intestinal polyposis syndrome	UMLS:CN197525	Intestinal polyposis syndrome	UMLS	
-MONDO:0002691	liver cancer	UMLS:C0345904	Malignant neoplasm of liver	UMLS:C0854795	Resectable Malignant Neoplasm of Liver	UMLS	
-MONDO:0006292	malignant mesothelioma (disease)	UMLS:C0345967	Malignant mesothelioma	UMLS:C1332338	Asbestos-Related Malignant Mesothelioma	UMLS	
-MONDO:0018471	generalized eruptive keratoacanthoma	UMLS:C0345985	Generalized eruptive keratoacanthoma	UMLS:CN237455	Grzybowski syndrome	UMLS	
-MONDO:0018850	proliferating trichilemmal cyst	UMLS:C0345992	Pilar tumor	UMLS:C2959585	Proliferating trichilemmal tumor	UMLS	
-MONDO:0003805	malignant pericardial mesothelioma	UMLS:C0346110	Malignant mesothelioma of pericardium	UMLS:C1335381	Pericardial Mesothelioma	UMLS	
-MONDO:0020541	maligant granulosa cell tumor of ovary	UMLS:C0346175	Malignant Ovarian Granulosa Cell Tumor	UMLS:CN207442	Granulosa cell malignant tumor	UMLS	
-MONDO:0018369	immature ovarian teratoma	UMLS:C0346182	Immature teratoma of ovary	UMLS:CN205036	Ovarian malignant teratoma	UMLS	
-MONDO:0019957	PPoma	UMLS:C0346407	Pancreatic polypeptidoma	UMLS:C1882278	Pancreatic Polypeptide Tumor	UMLS	
-MONDO:0019957	PPoma	UMLS:C0346407	Pancreatic polypeptidoma	UMLS:CN206879	Pancreatic polypeptidoma	UMLS	
-MONDO:0004332	lung hilum cancer	UMLS:C0346601	Primary malignant neoplasm of hilus of lung	UMLS:C2607931	Malignant Neoplasm of the Lung Hilum	UMLS	
-MONDO:0004636	lip carcinoma in situ	UMLS:C0347082	Stage 0 Lip Carcinoma	UMLS:C4316815	Carcinoma in situ of lip	UMLS	
-MONDO:0021297	carcinoma in situ of nasopharynx	UMLS:C0347096	Carcinoma in situ of nasopharynx	UMLS:C4331312		UMLS	
-MONDO:0021288	carcinoma in situ of hypopharynx	UMLS:C0347100	Carcinoma in situ of hypopharynx	UMLS:C4331310		UMLS	
-MONDO:0001444	Chagas disease	UMLS:C0348781	Chagas' disease with digestive system involvement	UMLS:C0348782	Chagas' disease with nervous system involvement	UMLS	
-MONDO:0017775	melioidosis	UMLS:C0348970	Acute and fulminating melioidosis	UMLS:C0348971	Subacute and chronic melioidosis	UMLS	
-MONDO:0002073	malignant pineal area germ cell neoplasm	UMLS:C0349621	Pineal germ cell tumor	UMLS:C1334612	Malignant Pineal Region Germ Cell Tumor	UMLS	
-MONDO:0016747	primary melanoma of the central nervous system	UMLS:C0349626	Malignant melanoma of meninges	UMLS:CN201994	Primary melanoma of the central nervous system	UMLS	
-MONDO:0003661	breast lymphoma	UMLS:C0349669	Malignant lymphoma of breast	UMLS:C1704251	Breast Lymphoma	UMLS	
-MONDO:0016587	arrhythmogenic right ventricular cardiomyopathy	UMLS:C0349788	Arrhythmogenic right ventricular dysplasia	UMLS:CN221565	Arrhythmogenic right ventricular dysplasia/cardiomyopathy	UMLS	
-MONDO:0016587	arrhythmogenic right ventricular cardiomyopathy	UMLS:C0349788	Arrhythmogenic right ventricular dysplasia	UMLS:CN239850		UMLS	
-MONDO:0024298	vitamin deficiency disorder	UMLS:C0376286	Avitaminosis	UMLS:C1510471	Vitamin deficiency	UMLS	
-MONDO:0005663	Barre-Lieou syndrome	UMLS:C0376378	Posterior cervical sympathetic syndrome	UMLS:C2355645	Cervicocranial syndrome	UMLS	
-MONDO:0007295	rolandic epilepsy	UMLS:C0376532	Rolandic epilepsy	UMLS:C2363129	Benign Rolandic epilepsy	UMLS	
-MONDO:0007295	rolandic epilepsy	UMLS:C0376532	Rolandic epilepsy	UMLS:CN200685	Centrotemporal epilepsy	UMLS	
-MONDO:0002334	hematopoietic and lymphoid system neoplasm	UMLS:C0376544	Hematopoietic neoplasm	UMLS:C0376545	Hematologic neoplasm	UMLS	
-MONDO:0002334	hematopoietic and lymphoid system neoplasm	UMLS:C0376544	Hematopoietic neoplasm	UMLS:C1512393	Hematopoietic and Lymphoid System Neoplasm	UMLS	
-MONDO:0002334	hematopoietic and lymphoid system neoplasm	UMLS:C0376545	Hematologic neoplasm	UMLS:C1512393	Hematopoietic and Lymphoid System Neoplasm	UMLS	
-MONDO:0006095	atypical carcinoid tumor	UMLS:C0391970	Malignant carcinoid tumor	UMLS:C1266032	Atypical carcinoid tumor	UMLS	
-MONDO:0018983	tolosa-Hunt syndrome	UMLS:C0392060	Painful ophthalmoplegia	UMLS:CN205421	Painful ophthalmoplegia	UMLS	
-MONDO:0008171	nephrolithiasis	UMLS:C0392525	Nephrolithiasis	UMLS:C1833683	Nephrolithiasis, calcium oxalate	UMLS	
-MONDO:0015150	complex hereditary spastic paraplegia	UMLS:C0393556	Complicated hereditary spastic paraplegia	UMLS:CN197491	Complicated hereditary spastic paraplegia	UMLS	
-MONDO:0008947	bilateral striopallidodentate calcinosis	UMLS:C0393589	Basal ganglia degeneration with calcification	UMLS:CN852731	Primary Familial Brain Calcification	UMLS	
-MONDO:0013229	hot water reflex epilepsy	UMLS:C0393729	Immersion-related epilepsy	UMLS:CN200053	Hot water reflex epilepsy	UMLS	
-MONDO:0018608	pure autonomic failure	UMLS:C0393911	Pure autonomic failure	UMLS:C2931939	Idiopathic orthostatic hypotension	UMLS	
-MONDO:0018608	pure autonomic failure	UMLS:C0393911	Pure autonomic failure	UMLS:CN205091	Pure idiopatic dysautonomia	UMLS	
-MONDO:0009009	hypoplasminogenemia	UMLS:C0398621	Hypoplasminogenemia	UMLS:C1968804	Plasminogen deficiency type 1	UMLS	
-MONDO:0007929	Epstein syndrome	UMLS:C0398641	Epstein Syndrome	UMLS:CN226018	Epstein syndrome	UMLS	
-MONDO:0009623	Nijmegen breakage syndrome	UMLS:C0398791	Nijmegen breakage syndrome	UMLS:CN860323	Nijmegen Breakage Syndrome	UMLS	
-MONDO:0008071	autosomal dominant progressive nephropathy with hypertension	UMLS:C0403443	Autosomal dominant progressive nephropathy with hypertension	UMLS:C3839782	Autosomal dominant progressive nephropathy with hypertension	UMLS	
-MONDO:0007928	Fechtner syndrome	UMLS:C0403445	Fechtner Syndrome	UMLS:CN226030	Fechtner syndrome	UMLS	
-MONDO:0009968	renal tubular acidosis, distal, with progressive nerve deafness	UMLS:C0403554	RENAL TUBULAR ACIDOSIS, DISTAL, WITH PROGRESSIVE NERVE DEAFNESS	UMLS:C4302514	Distal renal tubular acidosis co-occurrent with sensorineural deafness	UMLS	
-MONDO:0015633	Bazex syndrome	UMLS:C0406355	Acrokeratosis paraneoplastica of Bazex	UMLS:CN200039	Acrokeratosis paraneoplastica of Bazex	UMLS	
-MONDO:0010004	EEC syndrome	UMLS:C0406704	Rudiger syndrome 1	UMLS:CN776907	Ectrodactyly-ectodermal dysplasia-cleft lip/palate syndrome	UMLS	
-MONDO:0009522	Leukomelanoderma-infantilism-intellectual disability-hypodontia-hypotrichosis syndrome	UMLS:C0406729	Berlin syndrome	UMLS:C1855504	Ectodermal dysplasia, Berlin type	UMLS	
-MONDO:0008959	CHAND syndrome	UMLS:C0406733	Curly hair, ankyloblepharon, nail dysplasia syndrome	UMLS:CN199447	CHAND syndrome	UMLS	
-MONDO:0016443	papular elastorrhexis	UMLS:C0406816	Eruptive collagenoma	UMLS:C0473584	Nevus anelasticus	UMLS	
-MONDO:0007669	renal cysts and diabetes syndrome	UMLS:C0431693	Renal cysts and diabetes syndrome	UMLS:CN206512	Renal dysfunction-early-onset diabetes syndrome	UMLS	
-MONDO:0009032	cranioectodermal dysplasia	UMLS:C0432235	Cranioectodermal dysplasia	UMLS:CN016627	Sensenbrenner syndrome	UMLS	
-MONDO:0009032	cranioectodermal dysplasia	UMLS:C0432235	Cranioectodermal dysplasia	UMLS:CN119432	Sensenbrenner syndrome	UMLS	
-MONDO:0011108	StC<ve-Wiedemann syndrome	UMLS:C0432240	Stuve-Wiedemann dysplasia	UMLS:C0796176	Stüve-Wiedemann/Schwartz-Jampel type 2 syndrome	UMLS	
-MONDO:0015426	Desbuquois dysplasia	UMLS:C0432242	Desbuquois syndrome	UMLS:CN239270	Desbuquois Dysplasia	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0004817	non-secretory plasma cell myeloma	UMLS:C0456845	Non-secretory myeloma	UMLS:C3898125	Non-Secretory Plasma Cell Myeloma	UMLS	
-MONDO:0024246	syringofibroadenoma	UMLS:C0473578	Acrosyringeal nevus	UMLS:C1266060	Syringofibroadenoma	UMLS	
-MONDO:0016729	mixed neuronal-glial tumor	UMLS:C0474844	Neuronal and mixed neuronal-glial tumor	UMLS:CN201977	Mixed neuronal-glial tumor	UMLS	
-MONDO:0007716	alpha thalassemia-intellectual disability syndrome type 1	UMLS:C0475813	Alpha thalassemia-mental retardation syndrome	UMLS:C0795917	Alpha thalassemia-mental retardation syndrome	UMLS	
-MONDO:0002100	cardiovascular cancer	UMLS:C0497243	Cardiovascular Neoplasm	UMLS:C3898472	Malignant Cardiovascular Neoplasm	UMLS	
-MONDO:0016570	primary pulmonary lymphoma	UMLS:C0519063	Primary pulmonary lymphoma	UMLS:C4273669	Primary pulmonary lymphoma	UMLS	
-MONDO:0005313	necrotizing enterocolitis	UMLS:C0520459	Necrotizing enterocolitis	UMLS:C4082937	Necrotizing enterocolitis in fetus OR newborn	UMLS	
-MONDO:0009664	mulibrey nanism	UMLS:C0524582	Pericardial constriction-growth failure syndrome	UMLS:C2931895	Pericardial Constriction And Growth Failure	UMLS	
-MONDO:0019538	Gaisbock syndrome	UMLS:C0541719	Stress polycythemia	UMLS:C2242785	Gaisbock's syndrome	UMLS	
-MONDO:0019538	Gaisbock syndrome	UMLS:C0541719	Stress polycythemia	UMLS:CN206365	Stress polycythemia	UMLS	
-MONDO:0005710	composite lymphoma	UMLS:C0545080	Composite Lymphoma	UMLS:C1266191	Composite Hodgkin and non-Hodgkin lymphoma	UMLS	
-MONDO:0015302	nodular cutaneous amyloidosis	UMLS:C0546394	Primary localized cutaneous nodular amyloidosis	UMLS:C4274331	Primary localized cutaneous nodular amyloidosis	UMLS	
-MONDO:0001260	cercarial dermatitis	UMLS:C0546996	Cutaneous schistosomiasis	UMLS:C4282208	Cercarial Dermatitis	UMLS	
-MONDO:0009611	3-methylglutaconic aciduria type 4	UMLS:C0574085	3-Methylglutaconic aciduria type 4	UMLS:C1855126	MGA4	UMLS	
-MONDO:0018301	interstitial cystitis	UMLS:C0600040	Chronic interstitial cystitis	UMLS:C1720830	Painful Bladder Syndrome	UMLS	
-MONDO:0018301	interstitial cystitis	UMLS:C0600040	Chronic interstitial cystitis	UMLS:CN204884	Interstitial cystitis/painful bladder syndrome	UMLS	
-MONDO:0001881	toxic shock syndrome	UMLS:C0600327	Toxic shock syndrome	UMLS:CN204669	Bacterial TSS	UMLS	
-MONDO:0018271	peripheral primitive neuroectodermal tumor	UMLS:C0684337	Peripheral PNET	UMLS:C3489398	Peripheral neuroepithelioma	UMLS	
-MONDO:0017312	Perrault syndrome	UMLS:C0685838	XX gonodal dysgenesis-deafness syndrome	UMLS:CN239459		UMLS	
-MONDO:0010311	Becker muscular dystrophy	UMLS:C0699741	Benign congenital myopathy	UMLS:C3490459	Benign Pseudohypertrophic Muscular Dystrophy	UMLS	
-MONDO:0005706	coccidioidomycosis	UMLS:C0700644	Primary extrapulmonary coccidioidomycosis	UMLS:CN201384	Valley fever	UMLS	
-MONDO:0001713	inherited aplastic anemia	UMLS:C0702159	Constitutional aplastic anemia	UMLS:C0949116	Congenital hypoplastic anemia	UMLS	
-MONDO:0005160	aortic aneurysm (disease)	UMLS:C0741160	Ruptured aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS	
-MONDO:0018334	chronic hiccup	UMLS:C0744898	Chronic hiccups	UMLS:CN205022	Chronic hiccup	UMLS	
-MONDO:0019092	infantile apnea	UMLS:C0745261	Infantile apnea	UMLS:CN205590	Apnea of infancy	UMLS	
-MONDO:0007390	coumarin resistance	UMLS:C0750384	COUMARIN RESISTANCE	UMLS:CN078029		UMLS	
-MONDO:0010680	X-linked Emery-Dreifuss muscular dystrophy	UMLS:C0751337	EMERY-DREIFUSS MUSCULAR DYSTROPHY, X-LINKED	UMLS:CN069573	Emerinopathy	UMLS	
-MONDO:0002977	autoimmune disease of the nervous system	UMLS:C0751871	Autoimmune Nervous System Diseases	UMLS:C0751872	Immune Disorders, Nervous System	UMLS	
-MONDO:0019399	Isaac syndrome	UMLS:C0751919	Acquired Neuromyotonia	UMLS:CN206101	Quantal squander syndrome	UMLS	
-MONDO:0005695	central nervous system AIDS arteritis	UMLS:C0752329	Cerebral Aneurysmal Arteriopathy, AIDS-Associated	UMLS:C0752330	Central Nervous System AIDS Arteritis	UMLS	
-MONDO:0005695	central nervous system AIDS arteritis	UMLS:C0752329	Cerebral Aneurysmal Arteriopathy, AIDS-Associated	UMLS:C0752331	HIV-Associated Vasculitis of the Central Nervous System	UMLS	
-MONDO:0005695	central nervous system AIDS arteritis	UMLS:C0752330	Central Nervous System AIDS Arteritis	UMLS:C0752331	HIV-Associated Vasculitis of the Central Nervous System	UMLS	
-MONDO:0008915	dilated cardiomyopathy-hypergonadotropic hypogonadism syndrome	UMLS:C0796031	Malouf syndrome	UMLS:C0796083	Najjar syndrome	UMLS	
-MONDO:0012049	orofaciodigital syndrome VII	UMLS:C0796100	OROFACIODIGITAL SYNDROME VII	UMLS:CN206429	Orofaciodigital syndrome type 7	UMLS	
-MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796117	PITT-ROGERS-DANKS SYNDROME	UMLS:C0796202	WITTWER SYNDROME	UMLS	
-MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796117	PITT-ROGERS-DANKS SYNDROME	UMLS:C1956097	Wolf Hirschhorn syndrome	UMLS	
-MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796117	PITT-ROGERS-DANKS SYNDROME	UMLS:CN207113	Pitt-Rogers-Danks syndrome	UMLS	
-MONDO:0007780	hypertelorism, Teebi type	UMLS:C0796179	Teebi syndrome	UMLS:CN199596	Teebi syndrome	UMLS	
-MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796202	WITTWER SYNDROME	UMLS:C1956097	Wolf Hirschhorn syndrome	UMLS	
-MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796202	WITTWER SYNDROME	UMLS:CN207113	Pitt-Rogers-Danks syndrome	UMLS	
-MONDO:0005345	hypospadias (disease)	UMLS:C0848558		UMLS:CN205090	Familial hypospadias	UMLS	
-MONDO:0003604	functioning pituitary gland neoplasm	UMLS:C0851693	Functioning Pituitary Gland Neoplasm	UMLS:C3163678	Functioning pituitary neoplasm	UMLS	
-MONDO:0020321	acute undifferentiated leukemia	UMLS:C0856823		UMLS:C1282947	Acute myeloid leukemia, minimal differentiation, FAB M0	UMLS	
-MONDO:0019635	idiopathic achalasia	UMLS:C0859976	Idiopathic achalasia of esophagus	UMLS:C1860213	Idiopathic achalasia of esophagus	UMLS	
-MONDO:0015612	Dent disease	UMLS:C0878681	Dent's disease	UMLS:CN239269	Dent Disease	UMLS	
-MONDO:0005184	pancreatic ductal adenocarcinoma	UMLS:C0887833	Pancreatic Ductal Carcinoma	UMLS:C1335302	Pancreatic ductal adenocarcinoma	UMLS	
-MONDO:0007057	acroosteolysis dominant type	UMLS:C0917715	Hajdu-Cheney syndrome	UMLS:C2930971	Acroosteolysis dominant type	UMLS	
-MONDO:0009692	primary myelofibrosis	UMLS:C0948968	Osteomyelofibrosis	UMLS:C2355576	Megakaryocytic myelosclerosis	UMLS	
-MONDO:0008682	Denys-Drash syndrome	UMLS:C0950121	Wilms tumor and pseudohermaphroditism	UMLS:C3151568	NEPHROTIC SYNDROME TYPE 4	UMLS	
-MONDO:0000425	X-linked disease	UMLS:C1138434	X-Linked Genetic Diseases	UMLS:C2828000	X-Linked Inherited Disorder	UMLS	
-MONDO:0019668	adenoma of pancreas	UMLS:C1142432	Pancreatic adenoma	UMLS:C4076724	Adenoma of pancreas	UMLS	
-MONDO:0007080	glucocorticoid-remediable aldosteronism	UMLS:C1260386	Glucocorticoid-sensitive hypertension	UMLS:C3838731	Familial hyperaldosteronism type 1	UMLS	
-MONDO:0014452	familial dysfibrinogenemia	UMLS:C1260903	Dysfibrinogenemia	UMLS:CN207171	Familial dysfibrinogenemia	UMLS	
-MONDO:0000554	endocervical adenocarcinoma	UMLS:C1263762	Endocervical adenocarcinoma	UMLS:C4289591	Endocervical Adenocarcinoma, Usual Type	UMLS	
-MONDO:0018922	cold agglutinin disease	UMLS:C1264008	Chronic cold agglutinin disease	UMLS:CN205305	Cold agglutinin syndrome	UMLS	
-MONDO:0017885	chromophobe renal cell carcinoma	UMLS:C1266042	Chromophobe cell renal carcinoma	UMLS:C3887514	Chromophobe carcinoma	UMLS	
-MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	UMLS:C1266047	Fetal adenocarcinoma	UMLS:C1708045	Fetal Lung Adenocarcinoma	UMLS	
-MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	UMLS:C1266047	Fetal adenocarcinoma	UMLS:CN202865	WDFA	UMLS	
-MONDO:0024240	eccrine carcinoma	UMLS:C1266066	Eccrine adenocarcinoma	UMLS:C1302864	Eccrine carcinoma of skin	UMLS	
-MONDO:0024240	eccrine carcinoma	UMLS:C1266066	Eccrine adenocarcinoma	UMLS:C1707878	Eccrine Carcinoma	UMLS	
-MONDO:0011014	pleuropulmonary blastoma	UMLS:C1266144	Pleuropulmonary blastoma	UMLS:CN072455	PPB	UMLS	
-MONDO:0020560	atypical teratoid rhabdoid tumor	UMLS:C1266184	Atypical teratoid/rhabdoid tumor	UMLS:CN207484	ATRT	UMLS	
-MONDO:0019012	Carpenter syndrome	UMLS:C1275078	Acrocephalopolysyndactyly type 2	UMLS:CN229565	Carpenter syndrome	UMLS	
-MONDO:0008295	sporadic porphyria cutanea tarda	UMLS:C1276127	Sporadic porphyria cutanea tarda	UMLS:C1867968	Porphyria cutanea tarda type I	UMLS	
-MONDO:0016122	periodic paralysis (disease)	UMLS:C1279412	Periodic paralysis	UMLS:CN231077	Periodic paralysis	UMLS	
-MONDO:0008546	thanatophoric dysplasia type 1	UMLS:C1300256	Thanatophoric dysplasia, type 1	UMLS:C1868678	Thanatophoric dwarfism type 1	UMLS	
-MONDO:0008547	thanatophoric dysplasia type 2	UMLS:C1300257	Thanatophoric dysplasia, type 2	UMLS:CN206542	Thanatophoric dwarfism-cloverleaf skull syndrome	UMLS	
-MONDO:0019467	CD4+/CD56+ hematodermic neoplasm	UMLS:C1301363	Blastic plasmacytoid dendritic cell neoplasm	UMLS:CN206246	Monomorphic NK-cell lymphoma	UMLS	
-MONDO:0019755	developmental defect during embryogenesis	UMLS:C1302790	Congenital malformation syndrome	UMLS:CN206687	Malformation syndrome	UMLS	
-MONDO:0024240	eccrine carcinoma	UMLS:C1302864	Eccrine carcinoma of skin	UMLS:C1707878	Eccrine Carcinoma	UMLS	
-MONDO:0007614	congenital fibrosis of extraocular muscles	UMLS:C1302995	Congenital fibrosis of extraocular muscles	UMLS:CN043677	Congenital fibrosis of the extraocular muscles	UMLS	
-MONDO:0018713	retiform hemangioendothelioma	UMLS:C1304512	Retiform hemangioendothelioma	UMLS:CN242097	Retiform hemangioendothelioma	UMLS	
-MONDO:0018712	composite hemangioendothelioma	UMLS:C1304513	Composite hemangioendothelioma	UMLS:CN242120	Composite hemangioendothelioma	UMLS	
-MONDO:0000736	dyschromatosis universalis hereditaria	UMLS:C1306229	Dyschromatosis universalis	UMLS:C2930995	Dyschromatosis universalis hereditaria	UMLS	
-MONDO:0017884	papillary renal cell carcinoma	UMLS:C1306837	Papillary renal cell carcinoma	UMLS:C1336078	Sporadic Papillary Renal Cell Carcinoma	UMLS	
-MONDO:0017884	papillary renal cell carcinoma	UMLS:C1306837	Papillary renal cell carcinoma	UMLS:CN205129	HPRCC	UMLS	
-MONDO:0044792	large congenital melanocytic nevus	UMLS:C1318558	Congenital melanocytic nevus	UMLS:C1842036	LCMN	UMLS	
-MONDO:0008698	achalasia (disease)	UMLS:C1321756	Achalasia	UMLS:C2939435	Hypertensive lower esophageal sphincter	UMLS	
-MONDO:0006451	thymic carcinoma	UMLS:C1322286	Thymoma, type C	UMLS:CN207411	Malignant thymoma	UMLS	
-MONDO:0016974	thymoma type B	UMLS:C1328042	Thymoma Type B	UMLS:CN202276	Primary thymic epithelial tumor type B	UMLS	
-MONDO:0005859	mucocutaneous leishmaniasis	UMLS:C1328252	Mucocutaneous leishmaniasis	UMLS:C3495436	American cutaneous leishmaniasis	UMLS	
-MONDO:0003945	bone epithelioid hemangioma	UMLS:C1332575	Bone Epithelioid Hemangioma	UMLS:C1332578	Bone Hemangioma	UMLS	
-MONDO:0013417	complement component 3 deficiency	UMLS:C1332655	C3 DEFICIENCY	UMLS:C3151071	C3 deficiency	UMLS	
-MONDO:0016740	choriocarcinoma of the central nervous system	UMLS:C1332876	Central Nervous System Choriocarcinoma	UMLS:CN201988	Choriocarcinoma of the central nervous system	UMLS	
-MONDO:0002877	cervical carcinosarcoma	UMLS:C1332917	Cervical Carcinosarcoma	UMLS:C1516420	Cervical Mixed Epithelial and Mesenchymal Neoplasm	UMLS	
-MONDO:0002877	cervical carcinosarcoma	UMLS:C1332917	Cervical Carcinosarcoma	UMLS:CN201068	Malignant Müllerian mixed tumor of the cervix uteri	UMLS	
-MONDO:0018513	squamous cell carcinoma of colon	UMLS:C1333100	Squamous Cell Colon Carcinoma	UMLS:CN237518	Squamous cell carcinoma of colon	UMLS	
-MONDO:0003266	ependymal tumor	UMLS:C1333407	Ependymal Tumor	UMLS:CN203416	Ependymal tumor	UMLS	
-MONDO:0003649	esophageal neuroendocrine tumor	UMLS:C1333462	Esophageal Neuroendocrine Neoplasm	UMLS:C2987260	Esophageal Neuroendocrine Tumor	UMLS	
-MONDO:0003112	malignant gastric germ cell tumor	UMLS:C1333769	Gastric Germ Cell Tumor	UMLS:C1334584	Malignant Gastric Germ Cell Tumor	UMLS	
-MONDO:0006230	gastric squamous cell carcinoma	UMLS:C1333789	Gastric Squamous Cell Carcinoma	UMLS:CN237470	Gastric squamous cell carcinoma	UMLS	
-MONDO:0019728	heavy chain deposition disease	UMLS:C1333947	Heavy Chain Deposition Disease	UMLS:CN206635	HCDD	UMLS	
-MONDO:0006247	histiocytic and dendritic cell neoplasm	UMLS:C1334030	Histiocytic and Dendritic Cell Neoplasms	UMLS:CN206982	Histiocytic and dendritic cell tumor	UMLS	
-MONDO:0003857	adult intracranial malignant hemangiopericytoma	UMLS:C1334558	Adult Intracranial Solitary Fibrous Tumor/Hemangiopericytoma, Grade 3	UMLS:C4331858	Central Nervous System Solitary Fibrous Tumor/Hemangiopericytoma, Grade 3	UMLS	
-MONDO:0018172	malignant sex cord stromal tumor of ovary	UMLS:C1334609	Malignant Ovarian Sex Cord-Stromal Tumor	UMLS:CN204631	Malignant ovarian sex cord-stromal tumor	UMLS	
-MONDO:0016742	mixed germ cell tumor of central nervous system	UMLS:C1334785	Central Nervous System Mixed Germ Cell Tumor	UMLS:CN201989	Mixed germ cell tumor of CNS	UMLS	
-MONDO:0002038	head and neck carcinoma	UMLS:C1334927	Carcinoma of the Neck	UMLS:C3887461	Carcinoma of the Head and Neck	UMLS	
-MONDO:0008348	pulmonary nodular lymphoid hyperplasia	UMLS:C1334969	Pulmonary nodular lymphoid hyperplasia	UMLS:C1867419	Pulmonary pseudolymphoma	UMLS	
-MONDO:0016710	medulloblastoma with extensive nodularity	UMLS:C1334970	Medulloblastoma with extensive nodularity	UMLS:CN201957	MBEN	UMLS	
-MONDO:0018744	oligodendroglial tumor	UMLS:C1335110	Oligodendroglial Neoplasm	UMLS:CN205116	Oligodendroglial tumor	UMLS	
-MONDO:0005601	ovarian mucinous adenocarcinoma	UMLS:C1335167	Mucinous Adenocarcinoma of the Ovary	UMLS:CN205033	Ovarian mucinous adenocarcinoma	UMLS	
-MONDO:0018510	small intestine neuroendocrine neoplasm	UMLS:C1336005	Small Intestinal Neuroendocrine Neoplasm	UMLS:CN237515	Neuroendocrine neoplasm of the small intestine	UMLS	
-MONDO:0003532	breast papillary carcinoma	UMLS:C1336027	Solid Papillary Carcinoma of the Breast	UMLS:C3812899	Papillary carcinoma of the breast	UMLS	
-MONDO:0017884	papillary renal cell carcinoma	UMLS:C1336078	Sporadic Papillary Renal Cell Carcinoma	UMLS:CN205129	HPRCC	UMLS	
-MONDO:0006447	testicular non-seminomatous germ cell tumor	UMLS:C1336724	Testicular Non-Seminomatous Germ Cell Tumor	UMLS:CN204702	Testicular non seminomatous germ cell tumor	UMLS	
-MONDO:0018504	undifferentiated carcinoma of stomach	UMLS:C1336858	Undifferentiated Carcinoma of the Stomach	UMLS:CN237509	Undifferentiated gastric carcinoma	UMLS	
-MONDO:0017340	juvenile nasopharyngeal angiofibroma (disease)	UMLS:C1367536	Nasopharyngeal angiofibroma	UMLS:CN202999	JNA	UMLS	
-MONDO:0002181	exostosis	UMLS:C1442903	Exostosis	UMLS:C1956089	Osteophyte	UMLS	
-MONDO:0011642	carnitine acetyltransferase deficiency	UMLS:C1443228	Deficiency of carnitine acetyltransferase	UMLS:CN035113	CRAT	UMLS	
-MONDO:0010870	tibial muscular dystrophy	UMLS:C1450052	Tibial muscular dystrophy	UMLS:C1838244	Tardive tibial muscular dystrophy	UMLS	
-MONDO:0020520	adult pulmonary Langerhans cell histiocytosis	UMLS:C1455705	Pulmonary histiocytosis X	UMLS:C3161104	Adult pulmonary Langerhans cell histiocytosis	UMLS	
-MONDO:0019371	narcolepsy without cataplexy	UMLS:C1456240	Narcolepsy without cataplexy	UMLS:CN206062	Narcolepsy without cataplexy	UMLS	
-MONDO:0012089	ichthyosis prematurity syndrome	UMLS:C1504431	Idiopathic pneumonia syndrome	UMLS:C1837610	IPS	UMLS	
-MONDO:0010702	orofaciodigital syndrome I	UMLS:C1510460	OROFACIODIGITAL SYNDROME I	UMLS:C2698658	Orofaciodigital Syndrome Type 1	UMLS	
-MONDO:0004278	infiltrating bladder urothelial carcinoma sarcomatoid variant	UMLS:C1512743	Infiltrating Bladder Urothelial Carcinoma Sarcomatoid Variant	UMLS:C1512744	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant with Heterologous Elements	UMLS	
-MONDO:0004278	infiltrating bladder urothelial carcinoma sarcomatoid variant	UMLS:C1512743	Infiltrating Bladder Urothelial Carcinoma Sarcomatoid Variant	UMLS:C1512745	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant without Heterologous Elements	UMLS	
-MONDO:0004278	infiltrating bladder urothelial carcinoma sarcomatoid variant	UMLS:C1512744	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant with Heterologous Elements	UMLS:C1512745	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant without Heterologous Elements	UMLS	
-MONDO:0004526	mixed endometrial stromal and smooth muscle tumor	UMLS:C1513364	Mixed Endometrial Stromal and Smooth Muscle Neoplasm	UMLS:C1519865	Uterine Corpus Soft Tissue Neoplasm	UMLS	
-MONDO:0003011	mucinous tubular and spindle renal cell carcinoma	UMLS:C1513719	Mucinous Tubular and Spindle Cell Carcinoma of the Kidney	UMLS:CN203939	Mucinous tubular and spindle cell renal carcinoma	UMLS	
-MONDO:0006050	pleomorphic breast carcinoma	UMLS:C1514169	Pleomorphic Breast Carcinoma	UMLS:C2211689	Anaplastic Breast Carcinoma	UMLS	
-MONDO:0002877	cervical carcinosarcoma	UMLS:C1516420	Cervical Mixed Epithelial and Mesenchymal Neoplasm	UMLS:CN201068	Malignant Müllerian mixed tumor of the cervix uteri	UMLS	
-MONDO:0002876	cervical adenosarcoma	UMLS:C1516426	Cervical Adenosarcoma	UMLS:CN201069	Cervical adenosarcoma	UMLS	
-MONDO:0006045	ovarian clear cell adenocarcinoma	UMLS:C1518693	Ovarian Clear Cell Adenocarcinoma	UMLS:CN205034	Ovarian clear cell adenocarcinoma	UMLS	
-MONDO:0011383	autoimmune lymphoproliferative syndrome type 2A	UMLS:C1519709	Type 2 Autoimmune Lymphoproliferative Syndrome	UMLS:C1858968	AUTOIMMUNE LYMPHOPROLIFERATIVE SYNDROME, TYPE IIA	UMLS	
-MONDO:0014253	autoimmune lymphoproliferative syndrome type 3	UMLS:C1519711	Type 3 Autoimmune Lymphoproliferative Syndrome	UMLS:C3809928	AUTOIMMUNE LYMPHOPROLIFERATIVE SYNDROME, TYPE III	UMLS	
-MONDO:0019469	T-cell large granular lymphocyte leukemia	UMLS:C1522378	Large granular lymphocytic leukemia	UMLS:C1955861	T-Cell Large Granular Lymphocyte Leukemia	UMLS	
-MONDO:0000365	primary congenital glaucoma (disease)	UMLS:C1533041	Primary congenital glaucoma	UMLS:C3888011	GLAUCOMA 3, PRIMARY CONGENITAL, C	UMLS	
-MONDO:0009855	d-bifunctional protein deficiency	UMLS:C1533628	Pseudo-Zellweger syndrome	UMLS:CN203333	Pseudo-Zellweger syndrome	UMLS	
-MONDO:0016422	autoimmune polyendocrinopathy type 3	UMLS:C1535942	Autoimmune polyglandular syndrome type 3	UMLS:C3266027	Autoimmune polyendocrine syndrome type 3	UMLS	
-MONDO:0015294	nephrogenic systemic fibrosis	UMLS:C1619692	Nephrogenic fibrosing dermopathy	UMLS:C3888044	Nephrogenic systemic fibrosis	UMLS	
-MONDO:0018177	glioblastoma (disease)	UMLS:C1621958	Glioblastoma multiforme	UMLS:CN227279	Glioblastoma multiforme	UMLS	
-MONDO:0007380	lattice corneal dystrophy type I	UMLS:C1690006	Lattice corneal dystrophy Type I	UMLS:CN207224	Lattice corneal dystrophy type 1	UMLS	
-MONDO:0016505	aldosterone-producing adrenal cortex adenoma	UMLS:C1706762	Aldosterone-Producing Adrenal Cortex Adenoma	UMLS:CN226945	Pure aldosterone-secreting adrenocortical carcinoma	UMLS	
-MONDO:0005563	nut midline carcinoma	UMLS:C1707291	NUT Midline Carcinoma	UMLS:CN237663	NMC	UMLS	
-MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	UMLS:C1708045	Fetal Lung Adenocarcinoma	UMLS:CN202865	WDFA	UMLS	
-MONDO:0007888	hereditary leiomyomatosis and renal cell cancer	UMLS:C1708350	Reed syndrome	UMLS:CN239164	Multiple Cutaneous and Uterine Leiomyomas	UMLS	
-MONDO:0010771	histiocytoid cardiomyopathy	UMLS:C1708371	Oncocytic cardiomyopathy	UMLS:CN239812	Congenital cardiomyopathy	UMLS	
-MONDO:0018648	Keratocystic odontogenic tumor	UMLS:C1708604	Keratocystic Odontogenic Tumor	UMLS:CN237705	Odontogenic keratocystoma	UMLS	
-MONDO:0018509	squamous cell carcinoma of the small intestine	UMLS:C1710111	Small Intestinal Squamous Cell Carcinoma	UMLS:CN237514	Squamous cell carcinoma of the small bowel	UMLS	
-MONDO:0008047	episodic ataxia type 1	UMLS:C1719788	Episodic ataxia type 1	UMLS:CN042654	Myokymia 1 with or without hypomagnesemia	UMLS	
-MONDO:0018301	interstitial cystitis	UMLS:C1720830	Painful Bladder Syndrome	UMLS:CN204884	Interstitial cystitis/painful bladder syndrome	UMLS	
-MONDO:0008642	VACTERL/vater association	UMLS:C1735591		UMLS:CN206312	VATER association	UMLS	
-MONDO:0019018	Tako-tsubo cardiomyopathy	UMLS:C1739395	Takotsubo cardiomyopathy	UMLS:CN205479	Tako-Tsubo syndrome	UMLS	
-MONDO:0007471	Doyne honeycomb retinal dystrophy	UMLS:C1832174	DOYNE HONEYCOMB RETINAL DYSTROPHY	UMLS:C1852020	MALATTIA LEVENTINESE	UMLS	
-MONDO:0007471	Doyne honeycomb retinal dystrophy	UMLS:C1832174	DOYNE HONEYCOMB RETINAL DYSTROPHY	UMLS:CN205694	Malattia leventinese	UMLS	
-MONDO:0011091	Charcot-Marie-tooth disease type 2D	UMLS:C1832274	CMT2D	UMLS:C4274109	Autosomal dominant Charcot-Marie-Tooth disease type 2D	UMLS	
-MONDO:0011055	distal monosomy 10p	UMLS:C1832431	Telomeric deletion 10p	UMLS:C4304502	Distal monosomy 10p	UMLS	
-MONDO:0011045	MMEP syndrome	UMLS:C1832440	Microcephaly-microphthalmia-ectrodactyly of lower limbs-prognathism syndrome	UMLS:C4275099	MMEP syndrome	UMLS	
-MONDO:0011042	Martinez-Frias syndrome	UMLS:C1832443	MARTINEZ-FRIAS SYNDROME	UMLS:CN199270	Martínez-Frías syndrome	UMLS	
-MONDO:0010961	obesity due to prohormone convertase i deficiency	UMLS:C1833053	PCI deficiency	UMLS:C4302878	Obesity due to prohormone convertase I deficiency	UMLS	
-MONDO:0011430	pulverulent cataract	UMLS:C1833118	Pulverulent cataract	UMLS:C1852438	Coppock-like cataract	UMLS	
-MONDO:0011430	pulverulent cataract	UMLS:C1833118	Pulverulent cataract	UMLS:CN207240	Coppock-like cataract	UMLS	
-MONDO:0010938	T-B+ severe combined immunodeficiency due to JAK3 deficiency	UMLS:C1833275	T-B+ SCID due to JAK3 deficiency	UMLS:C4273742	Severe combined immunodeficiency T-cell negative B-cell positive due to janus kinase-3 deficiency	UMLS	
-MONDO:0010924	D-2-hydroxyglutaric aciduria	UMLS:C1833429	D-2-hydroxyglutaric aciduria	UMLS:CN233040		UMLS	
-MONDO:0010907	familial hypertryptophanemia	UMLS:C1833562		UMLS:C2931837	Familial hypertryptophanemia	UMLS	
-MONDO:0008165	southeast Asian ovalocytosis	UMLS:C1833690	Ovalocytosis, Hereditary Hemolytic	UMLS:C1862323	Southeast Asian ovalocytosis	UMLS	
-MONDO:0008138	syndromic orbital border hypoplasia	UMLS:C1833795	Urrets-Zavalia syndrome	UMLS:C4273912	Syndromic orbital border hypoplasia	UMLS	
-MONDO:0008136	isolated optic nerve hypoplasia	UMLS:C1833797	OPTIC NERVE HYPOPLASIA, BILATERAL	UMLS:C4510723	Isolated optic nerve hypoplasia	UMLS	
-MONDO:0008083	neuronal ceroid lipofuscinosis 4B	UMLS:C1834207	CLN4B disease	UMLS:C4284284	Neuronal Ceroid Lipofuscinosis Type 4B	UMLS	
-MONDO:0008049	myopathy, distal, infantile-onset	UMLS:C1834556	Myopathy, Distal, with Onset in Infancy	UMLS:C4011725	MYOPATHY, DISTAL, INFANTILE-ONSET	UMLS	
-MONDO:0016829	familial visceral myopathy	UMLS:C1835084	MEGADUODENUM AND/OR MEGACYSTIS	UMLS:CN202146	Megaduodenum and/or megacystis	UMLS	
-MONDO:0007937	renal hypomagnesemia 2	UMLS:C1835171	Renal hypomagnesemia type 2	UMLS:C4511005	Autosomal dominant primary hypomagnesemia with hypocalciuria	UMLS	
-MONDO:0007848	autosomal dominant keratitis	UMLS:C1835698	Hereditary keratitis	UMLS:C4017065	Autosomal dominant keratitis	UMLS	
-MONDO:0007848	autosomal dominant keratitis	UMLS:C1835698	Hereditary keratitis	UMLS:CN068649	Keratitis, autosomal dominant	UMLS	
-MONDO:0012570	body skin hyperlaxity due to vitamin K-dependent coagulation factor deficiency	UMLS:C1835813	Pseudoxanthoma elasticum-like syndrome	UMLS:C4049241	Pseudoxanthoma elasticum-like syndrome	UMLS	
-MONDO:0012559	primary immunodeficiency syndrome due to p14 deficiency	UMLS:C1835829	Primary immunodeficiency syndrome with short stature	UMLS:C4305256	Primary immunodeficiency syndrome due to p14 deficiency	UMLS	
-MONDO:0012557	cardiomyopathy-hypotonia-lactic acidosis syndrome	UMLS:C1835845	Cardiomyopathy-hypotonia-lactic acidosis syndrome	UMLS:C4305259	Hypertrophic cardiomyopathy with hypotonia and lactic acidosis syndrome	UMLS	
-MONDO:0012475	cone dystrophy with supernormal rod response	UMLS:C1835897	Cone dystrophy with supernormal scotopic electroretinogram	UMLS:C4304714	Cone dystrophy with supernormal rod response	UMLS	
-MONDO:0012359	combined immunodeficiency due to partial RAG1 deficiency	UMLS:C1835931	Combined immunodeficiency with expansion of gamma delta T cells	UMLS:C4510944	Combined immunodeficiency due to partial RAG1 deficiency	UMLS	
-MONDO:0012251	MEDNIK syndrome	UMLS:C1836330	Intellectual disability-enteropathy-deafness-peripheral neuropathy-ichthyosis-keratodermia syndrome	UMLS:CN229776	MEDNIK Syndrome	UMLS	
-MONDO:0012247	spinocerebellar ataxia type 27	UMLS:C1836383	SCA27	UMLS:C4304846	Spinocerebellar ataxia type 27	UMLS	
-MONDO:0012213	hereditary spastic paraplegia 26	UMLS:C1836632	GM2 synthase deficiency	UMLS:C4511959	Autosomal recessive spastic paraplegia type 26	UMLS	
-MONDO:0012204	familial pseudohyperkalemia	UMLS:C1836705	Familial pseudohyperkalemia	UMLS:C4273970	Familial pseudohyperkalemia	UMLS	
-MONDO:0012198	PCWH syndrome	UMLS:C1836727	Peripheral demyelinating neuropathy-central dysmyelinating leukodystrophy-Hirschsprung disease-Waardenburg syndrome	UMLS:CN239463		UMLS	
-MONDO:0012177	posterior column ataxia-retinitis pigmentosa syndrome	UMLS:C1836916	PCARP	UMLS:C4510304	Autosomal recessive posterior column ataxia and retinitis pigmentosa	UMLS	
-MONDO:0012156	myasthenic syndrome, congenital, 1B, fast-channel	UMLS:C1837122	Myasthenic Syndrome, Congenital, Fast-Channel	UMLS:C4225405	MYASTHENIC SYNDROME, CONGENITAL, 1B, FAST-CHANNEL	UMLS	
-MONDO:0012116	spinocerebellar ataxia type 8	UMLS:C1837454	SCA8	UMLS:C4275024	Spinocerebellar ataxia type 8	UMLS	
-MONDO:0012110	growth delay due to insulin-like growth factor type 1 deficiency	UMLS:C1837475	Growth delay-deafness- intellectual disability syndrome	UMLS:C4518327	Growth delay due to insulin-like growth factor type 1 deficiency	UMLS	
-MONDO:0012099	AICA-ribosiduria	UMLS:C1837530	ATIC deficiency	UMLS:C4510943	5-amino-4-imidazole carboxamide ribosiduria	UMLS	
-MONDO:0012096	Charcot-Marie-tooth disease axonal type 2L	UMLS:C1837552	CMT2L	UMLS:C4304673	Autosomal dominant Charcot-Marie-Tooth disease type 2L	UMLS	
-MONDO:0008869	Seckel syndrome 1	UMLS:C1837590	Seckel Syndrome 3	UMLS:CN033164	SCKL1	UMLS	
-MONDO:0012070	autosomal dominant Charcot-Marie-tooth disease type 2G	UMLS:C1837805	CMT2G	UMLS:C4304674	Autosomal dominant Charcot-Marie-Tooth disease type 2G	UMLS	
-MONDO:0009470	Baraitser-Winter syndrome 1	UMLS:C1837819	Cerebrofrontofacial Syndrome	UMLS:C1853623	Fryns-Aftimos Syndrome	UMLS	
-MONDO:0010895	ABCD syndrome	UMLS:C1838099	ABCD SYNDROME	UMLS:CN206498	ABCD syndrome	UMLS	
-MONDO:0010878	hereditary spastic paraplegia 6	UMLS:C1838192	SPG6	UMLS:C4518537	Autosomal dominant spastic paraplegia type 6	UMLS	
-MONDO:0007561	multiple epiphyseal dysplasia type 1	UMLS:C1838280	Polyepiphyseal dysplasia type 1	UMLS:C4275061	Multiple epiphyseal dysplasia type 1	UMLS	
-MONDO:0017607	caudal regression sequence	UMLS:C1838568	Sacral regression syndrome	UMLS:C1867774	SACRAL AGENESIS SYNDROME	UMLS	
-MONDO:0010801	Spondylocamptodactyly syndrome	UMLS:C1838781	Spondylocamptodactyly syndrome	UMLS:C4274762	Spondylocamptodactyly syndrome	UMLS	
-MONDO:0009640	mitochondrial complex I deficiency	UMLS:C1838979	MITOCHONDRIAL COMPLEX I DEFICIENCY	UMLS:C2936907	Isolated NADH-CoQ reductase deficiency	UMLS	
-MONDO:0013648	familial progressive hyperpigmentation	UMLS:C1840392	Familial progressive hyperpigmentation	UMLS:CN205811	Universal melanosis	UMLS	
-MONDO:0007713	clonic hemifacial spasm	UMLS:C1841639	Focal myoclonus of face	UMLS:C3536936	Clonic hemifacial spasm	UMLS	
-MONDO:0012032	Braddock syndrome	UMLS:C1842082	Vater-like syndrome with pulmonary hypertension, abnormal ears and growth deficiency	UMLS:C4303988	Braddock syndrome	UMLS	
-MONDO:0011986	tropical pancreatitis	UMLS:C1842402	Tropical calcific chronic pancreatitis	UMLS:C4510860	Tropical calcific chronic pancreatitis	UMLS	
-MONDO:0011961	hereditary sensory and autonomic neuropathy type 1B	UMLS:C1842586	Hereditary sensory and autonomic neuropathy type IB	UMLS:C4303567	Hereditary sensory and autonomic neuropathy type 1B	UMLS	
-MONDO:0011937	peeling skin syndrome 4	UMLS:C1842797	Exfoliative Ichthyosis, Autosomal Recessive, Ichthyosis Bullosa of Siemens-like	UMLS:C4225407	PEELING SKIN SYNDROME 4	UMLS	
-MONDO:0020558	autosomal dominant Charcot-Marie-tooth disease type 2K	UMLS:C1842984	Autosomal dominant Charcot-Marie-Tooth disease type 2K	UMLS:CN207468	CMT2K	UMLS	
-MONDO:0011899	Noonan syndrome-like disorder with loose anagen hair	UMLS:C1843181	Noonan syndrome-like disorder with loose anagen hair	UMLS:C3501846	Tosti syndrome	UMLS	
-MONDO:0011868	lethal congenital contracture syndrome 2	UMLS:C1843478	Multiple contracture syndrome, Israeli-Bedouin type	UMLS:C4275145	Lethal congenital contracture syndrome type 2	UMLS	
-MONDO:0011859	distal myopathy with early respiratory muscle involvement	UMLS:C1843633	Distal myopathy with early respiratory muscle involvement	UMLS:C4518808	Distal myopathy with early respiratory muscle involvement	UMLS	
-MONDO:0016809	spinocerebellar ataxia with epilepsy	UMLS:C1843852	Spinocerebellar ataxia with epilepsy	UMLS:CN202060	SCAE	UMLS	
-MONDO:0011834	spinocerebellar ataxia type 18	UMLS:C1843884	SCA18	UMLS:C4304848	Spinocerebellar ataxia type 18	UMLS	
-MONDO:0011833	spinocerebellar ataxia type 21	UMLS:C1843891	SCA21	UMLS:C4305144	Spinocerebellar ataxia type 21	UMLS	
-MONDO:0018151	coenzyme Q10 deficiency	UMLS:C1843920	Coenzyme Q10 deficiency	UMLS:CN229570	CoQ10 deficiency	UMLS	
-MONDO:0010555	X-linked chondrodysplasia punctata 1	UMLS:C1844853	Brachytelephalangic chondrodysplasia punctata	UMLS:C3669395	X-Linked Chondrodysplasia Punctata 1	UMLS	
-MONDO:0010524	X-linked sideroblastic anemia with ataxia	UMLS:C1845028	Pagon-Bird-Detter syndrome	UMLS:C4304338	X-linked sideroblastic anemia with spinocerebellar ataxia	UMLS	
-MONDO:0010378	X-linked hereditary sensory and autonomic neuropathy with deafness	UMLS:C1845095	X-linked auditory neuropathy with peripheral sensory neuropathy type 1	UMLS:C4304400	X-linked hereditary sensory and autonomic neuropathy with deafness	UMLS	
-MONDO:0010359	Dent disease type 2	UMLS:C1845167	Nephrolithiasis type 2	UMLS:C4305529	Dent disease type 2	UMLS	
-MONDO:0010355	syndromic X-linked intellectual disability Claes-Jensen type	UMLS:C1845243	Syndromic X-linked intellectual disability due to JARID1C mutation	UMLS:C4304915	Syndromic X-linked intellectual disability due to jumonji at-rich interactive domain 1c mutation	UMLS	
-MONDO:0010306	X-linked intellectual disability, Cabezas type	UMLS:C1845845	Mental Retardation, X-Linked, with Short Stature	UMLS:C1845861	Cabezas syndrome	UMLS	
-MONDO:0010277	syndromic X-linked intellectual disability Shashi type	UMLS:C1846145	Syndromic X-linked intellectual disability type 11	UMLS:C4305085	Syndromic X-linked intellectual disability type 11	UMLS	
-MONDO:0010270	syndromic X-linked intellectual disability 7	UMLS:C1846170	X-linked intellectual disability, Ahmad type	UMLS:C4304916	Syndromic X-linked intellectual disability type 7	UMLS	
-MONDO:0011803	hereditary spastic paraplegia 7	UMLS:C1846564	SPG7	UMLS:C3711370	Spastic paraplegia type 7	UMLS	
-MONDO:0019588	autosomal recessive nonsyndromic deafness	UMLS:C1846647	Deafness, autosomal recessive	UMLS:CN206424	Autosomal recessive non-syndromic neurosensory deafness type DFNB	UMLS	
-MONDO:0011773	anauxetic dysplasia	UMLS:C1846796	Spondyloepimetaphyseal dysplasia, anauxetic type	UMLS:CN029084	ANXD1	UMLS	
-MONDO:0011765	multiple epiphyseal dysplasia type 5	UMLS:C1846843	Bilateral hereditary micro-epiphyseal dysplasia	UMLS:C4275060	Multiple epiphyseal dysplasia type 5	UMLS	
-MONDO:0011752	nephronophthisis 4	UMLS:C1847013	NEPHRONOPHTHISIS 4	UMLS:C2959367	Nephronophthisis type 4	UMLS	
-MONDO:0019374	CAMOS syndrome	UMLS:C1847114	Cerebellar ataxia-intellectual disability-optic atrophy-skin abnormalities syndrome	UMLS:C4511633	CAMOS syndrome	UMLS	
-MONDO:0011724	encephalopathy due to GLUT1 deficiency	UMLS:C1847501	Glut1-DS	UMLS:CN030711	GLUT1DS1	UMLS	
-MONDO:0011694	spinocerebellar ataxia type 15/16	UMLS:C1847725	SCA15/16	UMLS:C4274322	Spinocerebellar ataxia type 15/16	UMLS	
-MONDO:0011687	Charcot-Marie-tooth disease axonal type 2F	UMLS:C1847823	CMT2F	UMLS:C4304675	Autosomal dominant Charcot-Marie-Tooth disease type 2F	UMLS	
-MONDO:0010239	lissencephaly type 1 due to doublecortin gene mutation	UMLS:C1848199	X-linked lissencephaly type 1	UMLS:C4275012	Lissencephaly type 1 due to doublecortin gene mutation	UMLS	
-MONDO:0020491	subcortical band heterotopia	UMLS:C1848201	Subcortical laminar heterotopia	UMLS:C4284594	BAND HETEROTOPIA	UMLS	
-MONDO:0010165	ulna hypoplasia-intellectual disability syndrome	UMLS:C1848650	Ulna hypoplasia-intellectual disability syndrome	UMLS:C2931370	Ulna hypoplasia with mental retardation	UMLS	
-MONDO:0010128	thyrocerebrorenal syndrome	UMLS:C1848813	Cutler-Bass-Romshe syndrome	UMLS:C4518579	Thyrocerebrorenal syndrome	UMLS	
-MONDO:0010047	hereditary spastic paraplegia 5A	UMLS:C1849115	SPG5A	UMLS:C2931357	Spastic paraplegia type 5B, recessive	UMLS	
-MONDO:0009945	pyridoxine-dependent epilepsy	UMLS:C1849508	Pyridoxine-dependent epilepsy	UMLS:CN203406		UMLS	
-MONDO:0009840	Partington-Anderson syndrome	UMLS:C1850075	PARTINGTON-ANDERSON SYNDROME	UMLS:CN202825	Partington-Anderson syndrome	UMLS	
-MONDO:0009810	autosomal recessive distal osteolysis syndrome	UMLS:C1850143	Distal osteolysis-short stature-intellectual disability syndrome	UMLS:C4275111	Autosomal recessive distal osteolysis syndrome	UMLS	
-MONDO:0009748	hereditary sensory and autonomic neuropathy with spastic paraplegia	UMLS:C1850395	HSAN with spastic paraplegia	UMLS:C4303565	Hereditary sensory and autonomic neuropathy with spastic paraplegia	UMLS	
-MONDO:0009727	atelosteogenesis type II	UMLS:C1850554	Atelosteogenesis type 2	UMLS:C1850555	DE LA CHAPELLE DYSPLASIA	UMLS	
-MONDO:0009725	nemaline myopathy 2	UMLS:C1850569	NEMALINE MYOPATHY 2	UMLS:CN187052	Nemaline myopathy 2, autosomal recessive	UMLS	
-MONDO:0009680	congenital muscular dystrophy-infantile cataract-hypogonadism syndrome	UMLS:C1850864	Bassoe syndrome	UMLS:C2931578	Bassoe syndrome	UMLS	
-MONDO:0007608	desmoid tumor	UMLS:C1851124	DESMOID DISEASE, HEREDITARY	UMLS:CN072436	Desmoid type fibromatosis	UMLS	
-MONDO:0014225	hemochromatosis type 5	UMLS:C1851316	FTH1-associated iron overload	UMLS:CN181217	HFE5	UMLS	
-MONDO:0014225	hemochromatosis type 5	UMLS:C1851316	FTH1-associated iron overload	UMLS:CN237708	Hemochromatosis type 5	UMLS	
-MONDO:0020522	Ehlers-Danlos syndrome type 7B	UMLS:C1851801	EDS VIIB	UMLS:CN706304	EDSARTH2	UMLS	
-MONDO:0007517	ectrodactyly-cleft palate syndrome	UMLS:C1851848	ECTRODACTYLY-CLEFT PALATE SYNDROME	UMLS:CN229012	Ectrodactyly-cleft palate syndrome	UMLS	
-MONDO:0007493	torsion dystonia 4	UMLS:C1851943	Hereditary whispering dysphonia	UMLS:C1860315	Hereditary whispering dysphonia	UMLS	
-MONDO:0007471	Doyne honeycomb retinal dystrophy	UMLS:C1852020	MALATTIA LEVENTINESE	UMLS:CN205694	Malattia leventinese	UMLS	
-MONDO:0015240	digitotalar dysmorphism	UMLS:C1852085	DIGITOTALAR DYSMORPHISM	UMLS:CN197602	Distal arthrogryposis type 1	UMLS	
-MONDO:0007449	dermo-odonto dysplasia	UMLS:C1852144	Dermo-odonto dysplasia	UMLS:C4303591	Dermo-odonto dysplasia	UMLS	
-MONDO:0014720	autosomal dominant optic atrophy plus syndrome	UMLS:C1852267	Optic atrophy-deafness-polyneuropathy-myopathy syndrome	UMLS:C4275164	Autosomal dominant optic atrophy plus syndrome	UMLS	
-MONDO:0021944	auditory neuropathy	UMLS:C1852271	AUDITORY NEUROPATHY	UMLS:C2732267	Auditory neuropathy spectrum disorder	UMLS	
-MONDO:0011430	pulverulent cataract	UMLS:C1852438	Coppock-like cataract	UMLS:CN207240	Coppock-like cataract	UMLS	
-MONDO:0012549	autosomal recessive ataxia, Beauce type	UMLS:C1853116	SCAR8	UMLS:C3683483	Autosomal Recessive Cerebellar Ataxia Type 1	UMLS	
-MONDO:0012465	hypercoagulability syndrome due to glycosylphosphatidylinositol deficiency	UMLS:C1853205	PIGM-CDG	UMLS:C4510605	Hypercoagulability syndrome due to glycosylphosphatidylinositol deficiency	UMLS	
-MONDO:0012450	spinocerebellar ataxia type 28	UMLS:C1853249	SCA28	UMLS:C4274988	Spinocerebellar ataxia type 28	UMLS	
-MONDO:0012449	spinocerebellar ataxia type 23	UMLS:C1853250	SCA23	UMLS:C4305146	Spinocerebellar ataxia type 23	UMLS	
-MONDO:0019207	DEND syndrome	UMLS:C1853564	Developmental delay-epilepsy-neonatal diabetes syndrome	UMLS:C4303593	K ATP Associated Developmental Delay, Epilepsy and Neonatal Diabetes	UMLS	
-MONDO:0011639	Diamond-Blackfan anemia 15 with mandibulofacial dysostosis	UMLS:C1853576	Diamond-Blackfan Anemia With Microtia And Cleft Palate	UMLS:C4225411	DIAMOND-BLACKFAN ANEMIA 15 WITH MANDIBULOFACIAL DYSOSTOSIS	UMLS	
-MONDO:0011601	neonatal intrahepatic cholestasis due to citrin deficiency	UMLS:C1853942	Neonatal intrahepatic cholestasis caused by citrin deficiency	UMLS:C4274030	Neonatal intrahepatic cholestasis due to citrin deficiency	UMLS	
-MONDO:0011576	familial hyperaldosteronism type II	UMLS:C1854107	Familial hyperaldosteronism type 2	UMLS:C3839212	Familial hyperaldosteronism type 2	UMLS	
-MONDO:0011540	spinocerebellar ataxia type 14	UMLS:C1854369	SCA14	UMLS:C4304883	Spinocerebellar ataxia type 14	UMLS	
-MONDO:0011529	spinocerebellar ataxia type 13	UMLS:C1854488	SCA13	UMLS:C4304884	Spinocerebellar ataxia type 13	UMLS	
-MONDO:0009512	lethal Larsen-like syndrome	UMLS:C1855535	Lethal Larsen-like syndrome	UMLS:C4304741	Lethal Larsen-like syndrome	UMLS	
-MONDO:0009510	Laron syndrome with immunodeficiency	UMLS:C1855548	Short stature due to STAT5b deficiency	UMLS:C4510411	Laron syndrome with immunodeficiency	UMLS	
-MONDO:0009728	nephronophthisis 1	UMLS:C1855681	Juvenile nephronophthisis	UMLS:CN205459	juvenile nephronophthisis	UMLS	
-MONDO:0009405	cervical hypertrichosis-peripheral neuropathy syndrome	UMLS:C1855902	Cervical hypertrichosis-peripheral neuropathy syndrome	UMLS:C2931676	Cervical hypertrichosis neuropathy	UMLS	
-MONDO:0009370	L-2-hydroxyglutaric aciduria	UMLS:C1855995	L-2-hydroxyglutaric aciduria	UMLS:C3888081	L-2-HYDROXYGLUTARIC ACIDEMIA	UMLS	
-MONDO:0009268	Gaucher disease-ophthalmoplegia-cardiovascular calcification syndrome	UMLS:C1856476	Gaucher-like disease	UMLS:C2931585	Gaucher-like disease	UMLS	
-MONDO:0009243	Fraser-like syndrome	UMLS:C1856708	FRASER-LIKE SYNDROME	UMLS:CN200837	Fraser-like syndrome	UMLS	
-MONDO:0009049	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:C1857451	ACTH-INDEPENDENT MACRONODULAR ADRENAL HYPERPLASIA	UMLS:C2062388	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS	
-MONDO:0009049	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:C1857451	ACTH-INDEPENDENT MACRONODULAR ADRENAL HYPERPLASIA	UMLS:CN200644	Primary bilateral macronodular adrenal hyperplasia	UMLS	
-MONDO:0012435	3-methylglutaconic aciduria type 5	UMLS:C1857776	MGA5	UMLS:C4039473	3-methylglutaconic aciduria type 5	UMLS	
-MONDO:0012342	7q11.23 microduplication syndrome	UMLS:C1857844	Trisomy 7q11.23	UMLS:C4512054	7q11.23 microduplication syndrome	UMLS	
-MONDO:0011464	spinocerebellar ataxia type 11	UMLS:C1858351	SCA11	UMLS:C4304886	Spinocerebellar ataxia type 11	UMLS	
-MONDO:0011439	spinocerebellar ataxia type 12	UMLS:C1858501	SCA12	UMLS:C4304885	Spinocerebellar ataxia type 12	UMLS	
-MONDO:0011408	hereditary spastic paraplegia 10	UMLS:C1858712	SPG10	UMLS:C4518536	Autosomal dominant spastic paraplegia type 10	UMLS	
-MONDO:0011381	dominant beta-thalassemia	UMLS:C1858990	Inclusion body beta-thalassemia	UMLS:C4274391	Dominant beta-thalassemia	UMLS	
-MONDO:0011380	leukoencephalopathy with vanishing white matter	UMLS:C1858991	Cree leukoencephalopathy	UMLS:CN199219	Myelinosis centralis diffusa	UMLS	
-MONDO:0011377	long QT syndrome 3	UMLS:C1859062	LONG QT SYNDROME 3	UMLS:C2931401	Long QT syndrome type 3	UMLS	
-MONDO:0008895	hereditary arterial and articular multiple calcification syndrome	UMLS:C1859372	Calcification of joints and arteries	UMLS:C4305347	Hereditary arterial and articular multiple calcification syndrome	UMLS	
-MONDO:0008512	syndactyly type 1	UMLS:C1861380	Syndactyly type 1	UMLS:C4275033	Syndactyly type 1	UMLS	
-MONDO:0007298	spinocerebellar ataxia type 29	UMLS:C1861732	SCA29	UMLS:C4274987	Spinocerebellar ataxia type 29	UMLS	
-MONDO:0007296	spinocerebellar ataxia type 31	UMLS:C1861736	SCA31	UMLS:C4274986	Spinocerebellar ataxia type 31	UMLS	
-MONDO:0007251	campomelic dysplasia	UMLS:C1861922	Campomelic dwarfism	UMLS:C1861923	ACAMPOMELIC CAMPOMELIC DYSPLASIA	UMLS	
-MONDO:0007245	neurofibromatosis type 6	UMLS:C1861975	NF6	UMLS:CN035858	NF6	UMLS	
-MONDO:0018607	combined hamartoma of the retina and retinal pigment epithelium	UMLS:C1862062	Combined hamartoma of the retina and retinal pigment epithelium	UMLS:CN237641	Combined hamartoma of the retina and RPE	UMLS	
-MONDO:0011936	microphthalmia with brain and digit anomalies	UMLS:C1864689	Syndromic microphthalmia type 6	UMLS:C4303070	Microphthalmia with brain and digit anomaly	UMLS	
-MONDO:0012413	syndromic microphthalmia type 5	UMLS:C1864690	Syndromic microphthalmia/anophthalmia due to OTX2 mutation	UMLS:C4305151	Syndromic microphthalmia type 5	UMLS	
-MONDO:0012411	giant axonal neuropathy 2	UMLS:C1864695	Giant Axonal Neuropathy, Autosomal Dominant	UMLS:CN226146	HMSN2 with giant axons	UMLS	
-MONDO:0012328	trichilemmal cyst	UMLS:C1864801	TRICHILEMMAL CYST 1	UMLS:C2266788	Trichilemmal cyst	UMLS	
-MONDO:0012496	Koolen de Vries syndrome	UMLS:C1864871	CHROMOSOME 17q21.31 DELETION SYNDROME	UMLS:CN776874	KdVS	UMLS	
-MONDO:0012396	exercise-induced hyperinsulinism	UMLS:C1864902	Hyperinsulinism due to monocarboxylate transporter 1 deficiency	UMLS:C1864904	Exercise-induced hyperinsulinism	UMLS	
-MONDO:0012382	hyperinsulinemic hypoglycemia, familial, 4	UMLS:C1864948	HYPERINSULINEMIC HYPOGLYCEMIA, FAMILIAL, 4	UMLS:C4303473	Hyperinsulinism due to short chain 3-hydroxyacyl-coenzyme A dehydrogenase deficiency	UMLS	
-MONDO:0008438	hereditary spastic paraplegia 4	UMLS:C1866855	SPG4	UMLS:C4510079	Autosomal dominant spastic paraplegia type 4	UMLS	
-MONDO:0008391	Robinow-Sorauf syndrome	UMLS:C1867146	ROBINOW-SORAUF SYNDROME	UMLS:CN203672	Robinow-Sorauf syndrome	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0008259	familial spontaneous pneumothorax	UMLS:C1868193	Primary spontaneous pneumothorax	UMLS:C4275252	Familial spontaneous pneumothorax	UMLS	
-MONDO:0019006	familial idiopathic steroid-resistant nephrotic syndrome	UMLS:C1868672	Familial idiopathic nephrotic syndrome	UMLS:C4273714	Familial idiopathic steroid-resistant nephrotic syndrome	UMLS	
-MONDO:0019006	familial idiopathic steroid-resistant nephrotic syndrome	UMLS:C1868672	Familial idiopathic nephrotic syndrome	UMLS:CN536255		UMLS	
-MONDO:0019957	PPoma	UMLS:C1882278	Pancreatic Polypeptide Tumor	UMLS:CN206879	Pancreatic polypeptidoma	UMLS	
-MONDO:0017050	intraocular medulloepithelioma	UMLS:C1883694	Intraocular Medulloepithelioma	UMLS:CN202409	Orbital medulloepithelioma	UMLS	
-MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C1956097	Wolf Hirschhorn syndrome	UMLS:CN207113	Pitt-Rogers-Danks syndrome	UMLS	
-MONDO:0016862	Alagille syndrome due to a JAG1 point mutation	UMLS:C1956125	ALAGILLE SYNDROME 1	UMLS:CN202206	Syndromic bile duct paucity due to a JAG1 point mutation	UMLS	
-MONDO:0018901	left ventricular noncompaction	UMLS:C1960469	Spongy myocardium	UMLS:C4021133	Left Ventricular Non-Compaction Syndrome	UMLS	
-MONDO:0011330	spinocerebellar ataxia type 10	UMLS:C1963674	SCA10	UMLS:C4275023	Spinocerebellar ataxia type 10	UMLS	
-MONDO:0009290	glycogen storage disease II	UMLS:C1968741	GLYCOGEN STORAGE DISEASE IIIc	UMLS:C3695005	GLYCOGEN STORAGE DISEASE, TYPE IIIc	UMLS	
-MONDO:0012664	spastic ataxia 3	UMLS:C1969645	SPAX3	UMLS:CN230089	Spastic Ataxia 3	UMLS	
-MONDO:0012656	lethal congenital contracture syndrome 3	UMLS:C1969655	LCCS3	UMLS:C4275144	Lethal congenital contracture syndrome type 3	UMLS	
-MONDO:0012552	multiple endocrine neoplasia type 4	UMLS:C1970712	MEN4	UMLS:C4274947	Multiple endocrine neoplasia type 4	UMLS	
-MONDO:0018957	pudendal neuralgia	UMLS:C1997249	Pudendal neuralgia	UMLS:C3178970	Pudendal Nerve Entrapment Syndrome	UMLS	
-MONDO:0018957	pudendal neuralgia	UMLS:C1997249	Pudendal neuralgia	UMLS:CN226268	Pudendalgia	UMLS	
-MONDO:0019395	Hinman syndrome	UMLS:C1997362	Non-Neurogenic Neurogenic Bladder	UMLS:CN206094	Occult neuropathic bladder	UMLS	
-MONDO:0009049	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:C2062388	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:CN200644	Primary bilateral macronodular adrenal hyperplasia	UMLS	
-MONDO:0020214	posterior corneal dystrophy	UMLS:C2063478	Posterior corneal dystrophy	UMLS:CN227822	Posterior corneal dystrophy	UMLS	
-MONDO:0018481	undifferentiated carcinoma of esophagus	UMLS:C2188058	Esophageal Undifferentiated Carcinoma	UMLS:CN237469	Undifferentiated esophageal carcinoma	UMLS	
-MONDO:0020516	thymic neuroendocrine carcinoma	UMLS:C2210965	Neuroendocrine carcinoma of thymus	UMLS:CN207412	Thymic neuroendocrine carcinoma	UMLS	
-MONDO:0019538	Gaisbock syndrome	UMLS:C2242785	Gaisbock's syndrome	UMLS:CN206365	Stress polycythemia	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C2243088	Erosive Gastritis	UMLS:C2243090	Erosive gastropathy	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C2243088	Erosive Gastritis	UMLS:C3854048	Erosive gastritis	UMLS	
-MONDO:0004966	gastritis (disease)	UMLS:C2243090	Erosive gastropathy	UMLS:C3854048	Erosive gastritis	UMLS	
-MONDO:0018615	hemicrania continua	UMLS:C2349425	Hemicrania continua	UMLS:CN237652	Hemicrania continua	UMLS	
-MONDO:0004608	oropharynx cancer	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS	
-MONDO:0002378	dermoid cyst	UMLS:C2355625	Dermoid choristoma	UMLS:C2700593	Cystic dermoid choristoma	UMLS	
-MONDO:0007295	rolandic epilepsy	UMLS:C2363129	Benign Rolandic epilepsy	UMLS:CN200685	Centrotemporal epilepsy	UMLS	
-MONDO:0019740	acquired thrombotic thrombocytopenic purpura	UMLS:C2584777	Autoimmune thrombotic thrombocytopenic purpura	UMLS:C2584778	Acquired thrombotic thrombocytopenic purpura	UMLS	
-MONDO:0012724	familial cold autoinflammatory syndrome 2	UMLS:C2673198	NAPS12	UMLS:C3897034	NALP12-Associated Hereditary Periodic Fever Syndrome	UMLS	
-MONDO:0019308	junctional epidermolysis bullosa inversa	UMLS:C2673609	JEB-I	UMLS:C2673610	JEB-I	UMLS	
-MONDO:0012719	encephalopathy due to prosaposin deficiency	UMLS:C2673635	Combined prosaposin deficiency	UMLS:C4303785	Encephalopathy due to prosaposin deficiency	UMLS	
-MONDO:0012718	hypotonia with lactic acidemia and hyperammonemia	UMLS:C2673642	Combined oxidative phosphorylation defect type 5	UMLS:C4510567	Combined oxidative phosphorylation defect type 5	UMLS	
-MONDO:0012315	distal 10q deletion syndrome	UMLS:C2674937	Telomeric deletion 10q	UMLS:C4305277	Distal monosomy 10q	UMLS	
-MONDO:0012992	pancreatic insufficiency-anemia-hyperostosis syndrome	UMLS:C2675184	Pancreatic insufficiency-anemia-hyperostosis syndrome	UMLS:C4302747	Pancreatic insufficiency, dyserythropoietic anemia, calvarial hyperostosis syndrome	UMLS	
-MONDO:0012991	Kahrizi syndrome	UMLS:C2675185	KAHRIZI SYNDROME	UMLS:CN200191	Kahrizi syndrome	UMLS	
-MONDO:0012980	endocrine-cerebro-osteodysplasia syndrome	UMLS:C2675227	ECO syndrome	UMLS:C4509819	Endocrine-cerebro-osteodysplasia syndrome	UMLS	
-MONDO:0012977	autosomal recessive nonsyndromic deafness 1B	UMLS:C2675235	DEAFNESS, AUTOSOMAL RECESSIVE 1B	UMLS:CN674504	Autosomal recessive deafness Type 1B	UMLS	
-MONDO:0012081	15q11q13 microduplication syndrome	UMLS:C2675336	Trisomy 15q11q13	UMLS:C4304726	15q11q13 microduplication syndrome	UMLS	
-MONDO:0012948	chromosome 6pter-p24 deletion syndrome	UMLS:C2675486	Monosomy 6p25	UMLS:C4305276	Distal monosomy 6p	UMLS	
-MONDO:0012927	chromosome 1q41-q42 deletion syndrome	UMLS:C2675857	Monosomy 1q41q42	UMLS:C4274528	1q41q42 microdeletion syndrome	UMLS	
-MONDO:0012916	chromosome 2p16.1-p15 deletion syndrome	UMLS:C2675875	Monosomy 2p15p16.1	UMLS:C4304538	2p15p16.1 microdeletion syndrome	UMLS	
-MONDO:0018521	squamous cell carcinoma of pancreas	UMLS:C2675993	Pancreatic squamous cell carcinoma	UMLS:CN237524	Pancreatic squamous cell carcinoma	UMLS	
-MONDO:0012864	chromosome 2q32-q33 deletion syndrome	UMLS:C2676739	Monosomy 2q32q33	UMLS:C4304531	2q32q33 microdeletion syndrome	UMLS	
-MONDO:0012830	chromosome 10q23 deletion syndrome	UMLS:C2677102	Chromosome 10q23 Deletion Syndrome	UMLS:CN202618	Monosomy 10q22.3q23.3	UMLS	
-MONDO:0012787	hereditary spastic paraplegia 39	UMLS:C2677586	Spastic paraplegia due to neuropathy target esterase mutation	UMLS:C4304963	Autosomal recessive spastic paraplegia type 39	UMLS	
-MONDO:0012784	autosomal recessive ataxia due to ubiquinone deficiency	UMLS:C2677589	SCAR9	UMLS:C4511089	Autosomal recessive ataxia due to ubiquinone deficiency	UMLS	
-MONDO:0012733	autosomal recessive bestrophinopathy	UMLS:C2678493	Bestrophinopathy	UMLS:C3888198	Autosomal recessive bestrophinopathy	UMLS	
-MONDO:0017308	Marfan syndrome type 2	UMLS:C2698016	Marfan Syndrome Type II	UMLS:C2931058	MFS2	UMLS	
-MONDO:0007686	gray platelet syndrome	UMLS:C2717750	Platelet alpha-Granule Deficiency	UMLS:CN205641	Platelet alpha-granule deficiency	UMLS	
-MONDO:0018602	necrotizing soft tissue infection	UMLS:C2732890	Necrotizing soft tissue infection	UMLS:CN237632	Necrotizing soft tissue infection	UMLS	
-MONDO:0016281	46,XX ovotesticular disorder of sex development	UMLS:C2748895		UMLS:CN776920	True hermaphroditism	UMLS	
-MONDO:0013212	Charcot-Marie-tooth disease axonal type 2N	UMLS:C2750090	CMT2N	UMLS:C4304671	Autosomal dominant Charcot-Marie-Tooth disease type 2N	UMLS	
-MONDO:0012165	BNAR syndrome	UMLS:C2750433	Bifid nose with or without anorectal and renal anomalies	UMLS:C4303547	BNAR syndrome	UMLS	
-MONDO:0013184	congenital diarrhea 5 with tufting enteropathy	UMLS:C2750737	Intestinal epithelial dysplasia	UMLS:C4275062	Intestinal epithelial dysplasia	UMLS	
-MONDO:0013182	chromosome 17p13.3 duplication syndrome	UMLS:C2750748	Trisomy 17p13.3	UMLS:C4304641	17p13.3 microduplication syndrome	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS	
-MONDO:0013090	chromosome 19q13.11 deletion syndrome	UMLS:C2751651	Monosomy 19q13.11	UMLS:C4304577	19q13.11 microdeletion syndrome	UMLS	
-MONDO:0013056	epileptic encephalopathy with global cerebral demyelination	UMLS:C2751855	Mitochondrial aspartate-glutamate carrier 1 deficiency	UMLS:C4512050	Epileptic encephalopathy with global cerebral demyelination	UMLS	
-MONDO:0013296	myeloid neoplasm associated with FGFR1 rearrangement	UMLS:C2827362	Myeloid and Lymphoid Neoplasms with FGFR1 Rearrangement	UMLS:C3150773	Stem cell leukemia/lymphoma	UMLS	
-MONDO:0013737	hereditary spastic paraplegia 46	UMLS:C2828721	SPG46	UMLS:C4510081	Autosomal recessive spastic paraplegia type 46	UMLS	
-MONDO:0019158	tropical endomyocardial fibrosis	UMLS:C2882252	Tropical endomyocardial fibrosis	UMLS:CN205710	TEMF	UMLS	
-MONDO:0009287	glycogen storage disease due to glucose-6-phosphatase deficiency type IA	UMLS:C2919796	Glycogen storage disease type Ia	UMLS:CN069618		UMLS	
-MONDO:0009287	glycogen storage disease due to glucose-6-phosphatase deficiency type IA	UMLS:C2919796	Glycogen storage disease type Ia	UMLS:CN205860	Glycogenosis due to glucose-6-phosphatase deficiency type Ia	UMLS	
-MONDO:0006687	burning mouth syndrome	UMLS:C2930806	Stomatodynia	UMLS:CN242089	Stomatopyrosis	UMLS	
-MONDO:0005116	Whipple disease	UMLS:C2930851	Intestinal lipophagic granulomatosis	UMLS:CN204440	Secondary non-tropical sprue	UMLS	
-MONDO:0018081	hemorrhagic fever-renal syndrome	UMLS:C2930957	Hantavirosis	UMLS:CN204401	Hantavirus fever	UMLS	
-MONDO:0014381	cholestasis, progressive familial intrahepatic, 4	UMLS:C2931067	CHOLESTASIS, PROGRESSIVE FAMILIAL INTRAHEPATIC, 4	UMLS:CN776838	TJP2 deficit	UMLS	
-MONDO:0009949	pyruvate carboxylase deficiency disease	UMLS:C2931141	LEIGH NECROTIZING ENCEPHALOPATHY DUE TO PYRUVATE CARBOXYLASE DEFICIENCY	UMLS:CN203409	Leigh syndrome due to pyruvate carboxylase deficiency	UMLS	
-MONDO:0019433	oligoarticular juvenile idiopathic arthritis	UMLS:C2931171	Oligoarticular JIA	UMLS:C3898105	Oligoarticular Juvenile Idiopathic Arthritis	UMLS	
-MONDO:0010043	hereditary spastic paraplegia 17	UMLS:C2931276	Silver syndrome	UMLS:CN074197	SPG17	UMLS	
-MONDO:0007078	Albright hereditary osteodystrophy	UMLS:C2931404	Albright's hereditary osteodystrophy	UMLS:C3494506	Pseudohypoparathyroidism type Ia	UMLS	
-MONDO:0023122	familial prostate cancer	UMLS:C2931456	Familial prostate cancer	UMLS:CN036094	Hereditary prostate cancer	UMLS	
-MONDO:0015995	melorheostosis with osteopoikilosis	UMLS:C2931505	Mixed sclerosing bone dystrophy	UMLS:CN200621	Mixed sclerosing bone dystrophy	UMLS	
-MONDO:0017568	Prata-Liberal-Goncalves syndrome	UMLS:C2931761	Acrodysplasia scoliosis	UMLS:CN203304	Brachydactyly-scoliosis-carpal fusion syndrome	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0018829	familial schizencephaly	UMLS:C2931870	Familial schizencephaly	UMLS:CN776926	Familial schizencephaly	UMLS	
-MONDO:0019366	free sialic acid storage disease	UMLS:C2931872	Free sialic acid storage disease	UMLS:CN206051	Free sialic acid storage disease	UMLS	
-MONDO:0018608	pure autonomic failure	UMLS:C2931939	Idiopathic orthostatic hypotension	UMLS:CN205091	Pure idiopatic dysautonomia	UMLS	
-MONDO:0008749	pseudohypoparathyroidism type 2	UMLS:C2932717	Pseudohypoparathyroidism Type 2	UMLS:CN206737	Pseudohypoparathyroidism type 2	UMLS	
-MONDO:0017576	46,XX disorder of sex development	UMLS:C2936403		UMLS:CN776919	Female pseudohermaphroditism	UMLS	
-MONDO:0010766	46,XX testicular disorder of sex development	UMLS:C2936419		UMLS:CN205000	XX, male syndrome	UMLS	
-MONDO:0013241	spinocerebellar ataxia type 30	UMLS:C2936793	SCA30	UMLS:C4304845	Spinocerebellar ataxia type 30	UMLS	
-MONDO:0011992	hereditary spastic paraplegia 25	UMLS:C2936860	Autosomal recessive spastic paraplegia-disc herniation syndrome	UMLS:C4518003	Autosomal recessive spastic paraplegia type 25	UMLS	
-MONDO:0009025	apparent mineralocorticoid excess	UMLS:C2936861	CORTISOL 11-BETA-KETOREDUCTASE DEFICIENCY	UMLS:C3887949	Apparent mineralocorticoid excess	UMLS	
-MONDO:0009025	apparent mineralocorticoid excess	UMLS:C2936861	CORTISOL 11-BETA-KETOREDUCTASE DEFICIENCY	UMLS:CN203981	Ulick syndrome	UMLS	
-MONDO:0013132	hereditary spastic paraplegia 36	UMLS:C2936879	SPG36	UMLS:C4510078	Autosomal dominant spastic paraplegia type 36	UMLS	
-MONDO:0001175	immature cataract	UMLS:C2939157	Incipient senile cataract	UMLS:C2960113	Immature cataract	UMLS	
-MONDO:0015924	pulmonary arterial hypertension	UMLS:C2973725	Pulmonary arterial hypertension	UMLS:CN200519	PAH	UMLS	
-MONDO:0016727	extraventricular neurocytoma	UMLS:C2985175	Extraventricular neurocytoma	UMLS:CN201975	EVN	UMLS	
-MONDO:0000408	fetal alcohol spectrum disorder	UMLS:C2985290	Fetal Alcohol Spectrum Disorder	UMLS:CN200663	Fetal alcohol spectrum disorders	UMLS	
-MONDO:0016473	familial rhabdoid tumor	UMLS:C2985524	Rhabdoid Tumor Predisposition Syndrome	UMLS:CN201468	Rhabdoid tumor predisposition syndrome	UMLS	
-MONDO:0019716	overgrowth syndrome	UMLS:C2986703	Overgrowth Syndrome	UMLS:CN206621	Overgrowth syndrome	UMLS	
-MONDO:0013025	chromosome 6q24-q25 deletion syndrome	UMLS:C3150215	Monosomy 6q25	UMLS:C4304527	6q25 microdeletion syndrome	UMLS	
-MONDO:0013238	chromosome 17q23.1-q23.2 deletion syndrome	UMLS:C3150607	Monosomy 17q23.1q23.2	UMLS:C4304591	17q23.1q23.2 microdeletion syndrome	UMLS	
-MONDO:0013256	chromosome 15q24 deletion syndrome	UMLS:C3150674	CHROMOSOME 15q24 DELETION SYNDROME	UMLS:CN237818	Chromosome 15q24 deletion syndrome	UMLS	
-MONDO:0013267	distal 16p11.2 microdeletion syndrome	UMLS:C3150701	Distal monosomy 16p11.2	UMLS:C4518824	Distal 16p11.2 microdeletion syndrome	UMLS	
-MONDO:0013272	chromosome 14q11-q22 deletion syndrome	UMLS:C3150707	Monosomy 14q11.2	UMLS:C4304999	14q11.2 microdeletion syndrome	UMLS	
-MONDO:0013275	hemolytic anemia due to glucophosphate isomerase deficiency	UMLS:C3150730	Hemolytic anemia due to glucophosphate isomerase deficiency	UMLS:CN072763	Glucosephosphate isomerase deficiency	UMLS	
-MONDO:0013292	chromosome 4q21 deletion syndrome	UMLS:C3150756	Monosomy 4q21	UMLS:C4304530	4q21 microdeletion syndrome	UMLS	
-MONDO:0013298	chromosome 17q21.31 duplication syndrome	UMLS:C3150787	Trisomy 17q21.31	UMLS:C4274345	17q21.31 microduplication syndrome	UMLS	
-MONDO:0013308	Noonan syndrome-like disorder with juvenile myelomonocytic leukemia	UMLS:C3150803	NOONAN SYNDROME-LIKE DISORDER WITH OR WITHOUT JUVENILE MYELOMONOCYTIC LEUKEMIA	UMLS:C4016301	NOONAN SYNDROME-LIKE DISORDER WITH JUVENILE MYELOMONOCYTIC LEUKEMIA	UMLS	
-MONDO:0013320	chromosome 16p12.2-p11.2 deletion syndrome	UMLS:C3150858	Monosomy 16p11.2p12.2	UMLS:C4304597	16p11.2p12.2 microdeletion syndrome	UMLS	
-MONDO:0013336	chromosome 19p13.13 deletion syndrome	UMLS:C3150894	CHROMOSOME 19p13.13 DELETION SYNDROME	UMLS:CN204595	Monosomy 19p13.13	UMLS	
-MONDO:0013352	intellectual disability-severe speech delay-mild dysmorphism syndrome	UMLS:C3150923	MENTAL RETARDATION WITH LANGUAGE IMPAIRMENT AND AUTISTIC FEATURES	UMLS:CN204965	Intellectual disability-severe speech delay-mild dysmorphism syndrome	UMLS	
-MONDO:0013354	spastic ataxia 4	UMLS:C3150925	SPAX4	UMLS:CN230090	Spastic Ataxia 4	UMLS	
-MONDO:0013359	familial hyperaldosteronism type III	UMLS:C3150933	Familial hyperaldosteronism type 3	UMLS:C3838758	Familial hyperaldosteronism type 3	UMLS	
-MONDO:0013396	chromosome 1p32-p31 deletion syndrome	UMLS:C3151036	CHROMOSOME 1p32-p31 DELETION SYNDROME	UMLS:CN226149	Monosomy 1p31p32	UMLS	
-MONDO:0013404	hypermethioninemia with deficiency of S-adenosylhomocysteine hydrolase	UMLS:C3151058	Hypermethioninemia due to S-adenosylhomocysteine hydrolase deficiency	UMLS:C4510276	Psychomotor retardation due to S-adenosylhomocysteine hydrolase deficiency	UMLS	
-MONDO:0013408	FADD-related immunodeficiency	UMLS:C3151062	FADD-related immunodeficiency	UMLS:C4509831	FADD-related immunodeficiency	UMLS	
-MONDO:0013439	congenital bile acid synthesis defect 3	UMLS:C3151147	BASD3	UMLS:C4304715	Congenital bile acid synthesis defect type 3	UMLS	
-MONDO:0013486	spinocerebellar ataxia type 32	UMLS:C3151343	SCA32	UMLS:C4304844	Spinocerebellar ataxia type 32	UMLS	
-MONDO:0013500	immunodeficiency 51	UMLS:C3151402	CANDIDIASIS, FAMILIAL, 5	UMLS:C4310803	IMMUNODEFICIENCY 51	UMLS	
-MONDO:0009636	mitochondrial DNA depletion syndrome 3	UMLS:C3151513	Mitochondrial DNA depletion syndrome, hepatocerebral form due to DGUOK deficiency	UMLS:C4310935	MITOCHONDRIAL DNA DEPLETION SYNDROME 3	UMLS	
-MONDO:0010437	severe X-linked mitochondrial encephalomyopathy	UMLS:C3151753	Mitochondrial encephalomyopathy due to combined oxidative phosphorylation defect 6	UMLS:C4302745	Severe X-linked mitochondrial encephalomyopathy	UMLS	
-MONDO:0018957	pudendal neuralgia	UMLS:C3178970	Pudendal Nerve Entrapment Syndrome	UMLS:CN226268	Pudendalgia	UMLS	
-MONDO:0017147	idiopathic pulmonary arterial hypertension	UMLS:C3203102	Idiopathic pulmonary arterial hypertension	UMLS:CN202574	Primary pulmonary arterial hypertension	UMLS	
-MONDO:0016423	autoimmune polyendocrinopathy type 4	UMLS:C3266026	Autoimmune polyendocrine syndrome type 4	UMLS:CN201378	Autoimmune polyglandular syndrome type 4	UMLS	
-MONDO:0019146	mendelian susceptibility to mycobacterial diseases	UMLS:C3266863	Mendelian susceptibility to mycobacterial infections	UMLS:CN181681	MSMD	UMLS	
-MONDO:0019751	autoinflammatory syndrome	UMLS:C3267073	Autoinflammatory syndrome	UMLS:C3890737	Autoinflammatory Syndrome	UMLS	
-MONDO:0015062	gastric neuroendocrine tumor, well differentiated, low or intermediate grade	UMLS:C3272399	Gastric Neuroendocrine Tumor	UMLS:CN197355	GNET	UMLS	
-MONDO:0015072	liver neuroendocrine carcinoma	UMLS:C3273031	Liver Neuroendocrine Carcinoma	UMLS:CN197365	Primary hepatic neuroendocrine carcinoma	UMLS	
-MONDO:0015073	gallbladder neuroendocrine tumor, grade 1/2	UMLS:C3273116	Gallbladder Neuroendocrine Tumor	UMLS:CN197366	Gallbladder neuroendocrine tumor	UMLS	
-MONDO:0011582	multiple mitochondrial dysfunctions syndrome 1	UMLS:C3276432	MULTIPLE MITOCHONDRIAL DYSFUNCTIONS SYNDROME 1	UMLS:CN226135	NFU1 deficiency	UMLS	
-MONDO:0013550	distal myopathy with posterior leg and anterior hand involvement	UMLS:C3279722	Distal ABD-filaminopathy	UMLS:C4518807	Distal myopathy with posterior leg and anterior hand involvement	UMLS	
-MONDO:0013570	combined oxidative phosphorylation defect type 8	UMLS:C3279793	COXPD8	UMLS:C4518839	Combined oxidative phosphorylation defect type 8	UMLS	
-MONDO:0013609	Meckel syndrome, type 10	UMLS:C3280036	MECKEL SYNDROME, TYPE 10	UMLS:CN620433	JBTS34	UMLS	
-MONDO:0013646	chromosome 8q21.11 deletion syndrome	UMLS:C3280231	Monosomy 8q21.11	UMLS:C4305343	8q21.11 microdeletion syndrome	UMLS	
-MONDO:0013673	Wolfram-like syndrome	UMLS:C3280358	Wolfram-like syndrome	UMLS:C4518338	Wolfram-like syndrome	UMLS	
-MONDO:0013758	Charcot-Marie-tooth disease dominant intermediate E	UMLS:C3280845	Charcot-Marie-Tooth disease-nephropathy syndrome	UMLS:C4302667	Autosomal dominant intermediate Charcot-Marie-Tooth disease type E	UMLS	
-MONDO:0013797	chromosome 17q12 deletion syndrome	UMLS:C3281138	Monosomy 17q12	UMLS:C4518822	17q12 microdeletion syndrome	UMLS	
-MONDO:0017593	juvenile amyotrophic lateral sclerosis	UMLS:C3468114	Juvenile amyotrophic lateral sclerosis	UMLS:CN239582	Juvenile Lou Gehrig disease	UMLS	
-MONDO:0007891	familial generalized lentiginosis	UMLS:C3492944	LENTIGINOSIS PROFUSA	UMLS:CN201466	Familial multiple lentigines syndrome without systemic involvement	UMLS	
-MONDO:0010142	hypothyroidism due to TSH receptor mutations	UMLS:C3493776	HYPOTHYROIDISM, CONGENITAL, NONGOITROUS, 1	UMLS:CN206435	Hypothyroidism due to TSH receptor mutations	UMLS	
-MONDO:0019187	Axenfeld-Rieger syndrome	UMLS:C3495488	Axenfeld-Rieger syndrome	UMLS:CN776842	Rieger syndrome	UMLS	
-MONDO:0007059	acrorenal syndrome	UMLS:C3495490	Acrorenal syndrome	UMLS:CN206860	Acrorenal syndrome	UMLS	
-MONDO:0008709	acrocephalopolydactyly	UMLS:C3495588	Acrocephalopolydactylous dysplasia	UMLS:CN201238	Elejalde syndrome	UMLS	
-MONDO:0009007	Jalili syndrome	UMLS:C3495589	Jalili syndrome	UMLS:CN200616	Cone rod dystrophy-amelogenesis imperfecta syndrome	UMLS	
-MONDO:0012105	granulomatosis with polyangiitis	UMLS:C3495801	Granulomatosis with polyangiitis	UMLS:C4050407	Pauci-Immune Glomerulonephritis associated with Granulomatosis with Polyangiitis	UMLS	
-MONDO:0015446	atypical coarctation of aorta	UMLS:C3496579	Middle aortic syndrome	UMLS:C3805239	Middle aortic syndrome	UMLS	
-MONDO:0002350	familial nephrotic syndrome	UMLS:C3501848	Nephrosis, congenital	UMLS:CN043611		UMLS	
-MONDO:0017338	fatal multiple mitochondrial dysfunctions syndrome	UMLS:C3502075	Multiple mitochondrial dysfunctions syndrome	UMLS:CN202994	Fatal multiple mitochondrial dysfunctions syndrome	UMLS	
-MONDO:0017338	fatal multiple mitochondrial dysfunctions syndrome	UMLS:C3502075	Multiple mitochondrial dysfunctions syndrome	UMLS:CN234684		UMLS	
-MONDO:0013962	hereditary spastic paraplegia 53	UMLS:C3539494	SPG53	UMLS:C4510082	Autosomal recessive spastic paraplegia type 53	UMLS	
-MONDO:0014018	hereditary spastic paraplegia 54	UMLS:C3539495	SPG54	UMLS:C4510083	Autosomal recessive spastic paraplegia type 54	UMLS	
-MONDO:0014020	hereditary spastic paraplegia 55	UMLS:C3539506	SPG55	UMLS:C4510214	Autosomal recessive spastic paraplegia type 55	UMLS	
-MONDO:0010476	neurodegeneration with brain iron accumulation 5	UMLS:C3550973	Neurodegeneration with brain iron accumulation type 5	UMLS:CN168656	BPAN	UMLS	
-MONDO:0013918	distal tetrasomy 15q	UMLS:C3553858	TETRASOMY 15q26	UMLS:CN203770	Tetrasomy 15q26	UMLS	
-MONDO:0014043	microcephalic primordial dwarfism due to ZNF335 deficiency	UMLS:C3554499	Microcephalic primordial dwarfism, Walsh type	UMLS:C4510378	Microcephalic primordial dwarfism due to ZNF335 deficiency	UMLS	
-MONDO:0016096	malignant non-dysgerminomatous germ cell tumor of ovary	UMLS:C3640983	Ovarian Non-Dysgerminomatous Germ Cell Tumor	UMLS:CN200863	Non-dysgerminomatous germ cell cancer of ovary	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0018737	catastrophic antiphospholipid syndrome	UMLS:C3662487	Catastrophic antiphospholipid syndrome	UMLS:CN242096	Catastrophic APS	UMLS	
-MONDO:0018023	hemoglobin M disease	UMLS:C3665425	Hemoglobin M disease	UMLS:CN204238	M hemoglobinopathy	UMLS	
-MONDO:0015459	nasopharyngeal carcinoma	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS	
-MONDO:0017152	pulmonary arterial hypertension associated with congenital heart disease	UMLS:C3697119	Pulmonary arterial hypertension associated with congenital heart disease	UMLS:CN243982		UMLS	
-MONDO:0017151	pulmonary arterial hypertension associated with connective tissue disease	UMLS:C3697982	Pulmonary arterial hypertension associated with connective tissue disease	UMLS:CN202578	PAH associated with connective tissue disease	UMLS	
-MONDO:0017157	pulmonary hypertension owing to lung disease and/or hypoxia	UMLS:C3698136	Pulmonary hypertension due to lung disease and/or hypoxia	UMLS:CN202580	Pulmonary hypertension due to lung disease and/or hypoxia	UMLS	
-MONDO:0016808	mitochondrial DNA depletion syndrome, hepatocerebral form	UMLS:C3711385	Deoxyguanosine Kinase Deficiency	UMLS:CN069134	Deoxyguanosine kinase deficiency	UMLS	
-MONDO:0012173	long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:C3711645	Long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:CN074230	LCHAD deficiency	UMLS	
-MONDO:0012173	long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:C3711645	Long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:CN239369	LCHAD Deficiency	UMLS	
-MONDO:0016525	familial hyperaldosteronism	UMLS:C3713420	Familial hyperaldosteronism	UMLS:CN229602	FH	UMLS	
-MONDO:0014295	hereditary spastic paraplegia 57	UMLS:C3714897	Spastic paraplegia due to partial TFG deficiency	UMLS:C4510084	Autosomal recessive spastic paraplegia type 57	UMLS	
-MONDO:0024532	otofaciocervical syndrome 1	UMLS:C3714941	OTOFACIOCERVICAL SYNDROME 1	UMLS:CN034490		UMLS	
-MONDO:0019123	continuous spikes and waves during sleep	UMLS:C3806403	Continuous spike and waves during slow sleep	UMLS:CN181337	CSWS	UMLS	
-MONDO:0019123	continuous spikes and waves during sleep	UMLS:C3806403	Continuous spike and waves during slow sleep	UMLS:CN205644	Epileptic encephalopathy with continuous spike-and-wave during slow sleep	UMLS	
-MONDO:0013851	autosomal dominant aplasia and myelodysplasia	UMLS:C3808553	BONE MARROW FAILURE SYNDROME 1	UMLS:CN203751	Autosomal dominant aplastic anemia and myelodysplasia	UMLS	
-MONDO:0014021	familial episodic pain syndrome with predominantly upper body involvement	UMLS:C3808667	EPISODIC PAIN SYNDROME, FAMILIAL, 1	UMLS:CN204968	Familial episodic pain syndrome with predominantly upper body involvement	UMLS	
-MONDO:0014070	oculocutaneous albinism type 7	UMLS:C3808786	ALBINISM, OCULOCUTANEOUS, TYPE VII	UMLS:CN204524	OCA7	UMLS	
-MONDO:0014094	severe congenital hypochromic anemia with ringed sideroblasts	UMLS:C3808920	Severe congenital hypochromic sideroblastic anemia	UMLS:C4511137	Severe congenital hypochromic anemia with ringed sideroblasts	UMLS	
-MONDO:0014185	chromosome 3q13.31 deletion syndrome	UMLS:C3809490	CHROMOSOME 3q13.31 DELETION SYNDROME	UMLS:CN036884	Monosomy 3q13	UMLS	
-MONDO:0014276	combined immunodeficiency due to CD3gamma deficiency	UMLS:C3810107	Combined immunodeficiency due to CD3gamma deficiency	UMLS:C4510864	Combined immunodeficiency due to CD3gamma deficiency	UMLS	
-MONDO:0014303	hereditary spastic paraplegia 64	UMLS:C3810289	SPG64	UMLS:C4511960	Autosomal recessive spastic paraplegia type 64	UMLS	
-MONDO:0014304	hereditary spastic paraplegia 61	UMLS:C3810294	SPG61	UMLS:C4511962	Autosomal recessive spastic paraplegia type 61	UMLS	
-MONDO:0015407	cerebrofacial arteriovenous metameric syndrome type 3	UMLS:C3838691	Cerebrofacial arteriovenous metameric syndrome type 3	UMLS:CN199502	CAMS3	UMLS	
-MONDO:0019524	infantile Bartter syndrome with sensorineural deafness	UMLS:C3838860	Bartter syndrome type 4	UMLS:CN206343	Bartter syndrome type IV	UMLS	
-MONDO:0015405	cerebrofacial arteriovenous metameric syndrome	UMLS:C3839265	Cerebrofacial arteriovenous metameric syndrome	UMLS:CN199500	CAMS	UMLS	
-MONDO:0016223	infantile hemangioma of rare localization	UMLS:C3839613	Infantile hemangioma of rare localization	UMLS:CN226884	Infantile hemangioma of rare localization	UMLS	
-MONDO:0017288	DICER1 syndrome	UMLS:C3839822	DICER1 syndrome	UMLS:CN202862	Pleuro-pulmonary blastoma familial tumor susceptibility syndrome	UMLS	
-MONDO:0017288	DICER1 syndrome	UMLS:C3839822	DICER1 syndrome	UMLS:CN240512		UMLS	
-MONDO:0019396	collagen type III glomerulopathy	UMLS:C3872695	Collagenofibrotic glomerulopathy	UMLS:CN206095	Collagenofibrotic glomerulopathy	UMLS	
-MONDO:0019621	chronic pneumonitis of infancy	UMLS:C3872848	Chronic pneumonitis of infancy	UMLS:CN206472	CPI	UMLS	
-MONDO:0019370	vulvovaginal gingival syndrome	UMLS:C3873472	Vulvovaginal gingival syndrome	UMLS:CN206058	Vulvovaginal gingival syndrome	UMLS	
-MONDO:0007744	cholesterol-ester transfer protein deficiency	UMLS:C3875011	Familial hyperalphalipoproteinemia	UMLS:CN205999	Familial hyperalphalipoproteinemia	UMLS	
-MONDO:0009025	apparent mineralocorticoid excess	UMLS:C3887949	Apparent mineralocorticoid excess	UMLS:CN203981	Ulick syndrome	UMLS	
-MONDO:0013560	Hermansky-Pudlak syndrome 8	UMLS:C3888026	HERMANSKY-PUDLAK SYNDROME 8	UMLS:CN201510	HPS8	UMLS	
-MONDO:0017161	frontotemporal dementia with motor neuron disease	UMLS:C3888102	Frontotemporal Dementia With Motor Neuron Disease	UMLS:CN239493	Frontotemporal dementia with amyotrophic lateral sclerosis	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS	
-MONDO:0009738	sialidosis type 2	UMLS:C3888317	Sialidosis, type 2	UMLS:CN206285	Infantile dysmorphic sialidosis	UMLS	
-MONDO:0017694	glycogen storage disease due to acid maltase deficiency, infantile onset	UMLS:C3888924	Glycogen storage disease due to acid maltase deficiency, infantile onset	UMLS:CN203590	Glycogenosis type II, infantile onset	UMLS	
-MONDO:0014410	spinocerebellar ataxia type 37	UMLS:C3889636	Spinocerebellar ataxia with altered vertical eye movements	UMLS:C4304821	Spinocerebellar ataxia type 37	UMLS	
-MONDO:0020349	acute motor axonal neuropathy	UMLS:C3890941	Acute motor axonal neuropathy	UMLS:CN207196	Acute pure motor Guillain-Barré syndrome	UMLS	
-MONDO:0010491	X-linked acrogigantism due to Xq26 microduplication	UMLS:C3891556	CHROMOSOME Xq26.3 DUPLICATION SYNDROME	UMLS:CN237731	X-LAG (X-linked acrogigantism) due to dup(X)q(26)	UMLS	
-MONDO:0017807	growing teratoma syndrome	UMLS:C3891714	Growing Teratoma Syndrome	UMLS:CN203773	Growing teratoma syndrome	UMLS	
-MONDO:0018604	familial colorectal cancer type X	UMLS:C3896578	Familial Colorectal Cancer Type X	UMLS:CN237636	FCCTX	UMLS	
-MONDO:0017895	familial papillary or follicular thyroid carcinoma	UMLS:C3896673	Familial Nonmedullary Thyroid Gland Carcinoma	UMLS:CN227215	Familial pure nonmedullary thyroid carcinoma	UMLS	
-MONDO:0019753	localized Castleman disease	UMLS:C3898582	Localized Angiofollicular Lymphoid Hyperplasia	UMLS:CN206685	Localized Castleman disease	UMLS	
-MONDO:0014405	STING-associated vasculopathy with onset in infancy	UMLS:C4014722	SAVI	UMLS:C4040879	STING-associated vasculopathy with onset in infancy	UMLS	
-MONDO:0014417	spinocerebellar ataxia type 38	UMLS:C4014812	SCA38	UMLS:C4518337	Spinocerebellar ataxia type 38	UMLS	
-MONDO:0014512	PURA-related severe neonatal hypotonia-seizures-encephalopathy syndrome due to a point mutation	UMLS:C4015357	MENTAL RETARDATION, AUTOSOMAL DOMINANT 31	UMLS:CN237609	PURA-related severe neonatal hypotonia-seizures-encephalopathy syndrome due to a point mutation	UMLS	
-MONDO:0014529	cerebellar-facial-dental syndrome	UMLS:C4015495	Cerebellofaciodental syndrome	UMLS:CN221667	cerebellar-facial-dental syndrome	UMLS	
-MONDO:0014546	myopathy due to calsequestrin and SERCA1 protein overload	UMLS:C4015624	Myopathy due to calsequestrin and SERCA1 protein overload	UMLS:C4510368	Myopathy due to calsequestrin and SERCA1 protein overload	UMLS	
-MONDO:0007848	autosomal dominant keratitis	UMLS:C4017065	Autosomal dominant keratitis	UMLS:CN068649	Keratitis, autosomal dominant	UMLS	
-MONDO:0019079	proximal spinal muscular atrophy	UMLS:C4024957	Proximal spinal muscular atrophy	UMLS:CN205570	SMA	UMLS	
-MONDO:0020467	mosaic monosomy X	UMLS:C4040907	Mosaic Turner syndrome	UMLS:CN776903	Mosaic monosomy X	UMLS	
-MONDO:0019003	multiple endocrine neoplasia type 2	UMLS:C4048306	Multiple Endocrine Neoplasia Type 2	UMLS:CN073359	MEN2	UMLS	
-MONDO:0014669	cone-rod dystrophy 21	UMLS:C4049066	CONE-ROD DYSTROPHY 21	UMLS:CN231743	CORD21	UMLS	
-MONDO:0017408	rapid-onset childhood obesity-hypothalamic dysfunction-hypoventilation-autonomic dysregulation syndrome	UMLS:C4053506	Rapid-Onset Obesity with Hypothalamic Dysfunction, Hypoventilation, and Autonomic Dysregulation	UMLS:CN203158	Rapid-onset childhood obesity-hypothalamic dysfunction-hypoventilation-autonomic dysregulation-neural tumors syndrome	UMLS	
-MONDO:0019828	pituitary stalk interruption syndrome	UMLS:C4053775	Pituitary stalk interruption syndrome	UMLS:CN206776	PSIS	UMLS	
-MONDO:0015542	secondary hemophagocytic lymphohistiocytosis	UMLS:C4054044	Secondary Hemophagocytic Lymphohistiocytosis	UMLS:CN199700	Reactive hemophagocytic syndrome	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0013892	C3 glomerulonephritis	UMLS:C4055342	C3 Glomerulonephritis	UMLS:CN187045		UMLS	
-MONDO:0018540	PFAPA syndrome	UMLS:C4082167	Periodic Fever, Aphthous Stomatitis, Pharyngitis, Adenitis Syndrome	UMLS:CN205072	Marshall syndrome with periodic fever	UMLS	
-MONDO:0014741	facial dysmorphism-developmental delay-behavioral abnormalities syndrome due to WAC point mutation	UMLS:C4225239	DESANTO-SHINAWI SYNDROME	UMLS:CN242167	Facial dysmorphism-developmental delay-behavioral abnormalities syndrome due to WAC point mutation	UMLS	
-MONDO:0014717	early-onset Lafora body disease	UMLS:C4225258	Early-onset Lafora body disease	UMLS:C4518574	Early-onset Lafora body disease	UMLS	
-MONDO:0014700	neurodevelopmental disorder-craniofacial dysmorphism-cardiac defect-hip dysplasia syndrome due to a point mutation	UMLS:C4225274	AU-KLINE SYNDROME	UMLS:CN237748	Au-Kline syndrome	UMLS	
-MONDO:0014822	15q14 microdeletion syndrome	UMLS:C4225666	Monosomy 15q14	UMLS:C4305230	15q14 microdeletion syndrome	UMLS	
-MONDO:0019995	peripheral resistance to thyroid hormones	UMLS:C4273673	Peripheral resistance to thyroid hormone	UMLS:CN206931	Peripheral resistance to thyroid hormones	UMLS	
-MONDO:0019006	familial idiopathic steroid-resistant nephrotic syndrome	UMLS:C4273714	Familial idiopathic steroid-resistant nephrotic syndrome	UMLS:CN536255		UMLS	
-MONDO:0019643	transient pseudohypoaldosteronism	UMLS:C4273962	Transient pseudohypoaldosteronism	UMLS:CN776908	TPHA	UMLS	
-MONDO:0019448	benign adult familial myoclonic epilepsy	UMLS:C4273988	Benign adult familial myoclonic epilepsy	UMLS:CN206220	Benign adult familial myoclonus epilepsy	UMLS	
-MONDO:0016577	biliary atresia with splenic malformation syndrome	UMLS:C4274029	Biliary atresia with splenic malformation syndrome	UMLS:CN201730	BASM syndrome	UMLS	
-MONDO:0017184	autosomal dominant hyperinsulinism due to SUR1 deficiency	UMLS:C4274080	Autosomal dominant hyperinsulinism due to SUR1 deficiency	UMLS:CN202625	Autosomal dominant hyperinsulinemic hypoglycemia due to SUR1 deficiency	UMLS	
-MONDO:0017264	syndromic recessive X-linked ichthyosis	UMLS:C4274085	Syndromic recessive X-linked ichthyosis	UMLS:CN202782	Syndromic recessive X-linked ichthyosis	UMLS	
-MONDO:0016364	Joubert syndrome with ocular defect	UMLS:C4274118	Joubert syndrome with ocular defect	UMLS:CN201217	Joubert syndrome with retinopathy	UMLS	
-MONDO:0015084	FRAXF syndrome	UMLS:C4274329	FRAXF syndrome	UMLS:CN197382	FRAXF syndrome	UMLS	
-MONDO:0016208	solitary rectal ulcer syndrome	UMLS:C4274343	Solitary rectal ulcer syndrome	UMLS:CN200964	Solitary rectal ulcer syndrome	UMLS	
-MONDO:0016317	limbic encephalitis with NMDA receptor antibodies	UMLS:C4274344	Limbic encephalitis with N-methyl-D-aspartate receptor antibodies	UMLS:CN201135	Limbic encephalitis with N-methyl-D-aspartate receptor antibodies	UMLS	
-MONDO:0017418	chronic intestinal failure	UMLS:C4274352	Chronic intestinal failure	UMLS:CN203168	CIF	UMLS	
-MONDO:0017327	primary non-gestational choriocarcinoma of ovary	UMLS:C4274424	Primary non-gestational choriocarcinoma of ovary	UMLS:CN202967	Primary non-gestational ovarian choriocarcinoma	UMLS	
-MONDO:0017872	Lujo hemorrhagic fever	UMLS:C4274433	Lujo hemorrhagic fever	UMLS:CN203921	Zambian hemorrhagic fever	UMLS	
-MONDO:0017878	Chapare hemorrhagic fever	UMLS:C4274434	Chapare hemorrhagic fever	UMLS:CN203927	Chapare hemorrhagic fever	UMLS	
-MONDO:0016652	2q31.1 microdeletion syndrome	UMLS:C4274647	2q31.1 microdeletion syndrome	UMLS:CN201880	Monosomy 2q31.1	UMLS	
-MONDO:0015346	Jeavons syndrome	UMLS:C4274731	Jeavons syndrome	UMLS:CN199399	Eyelid myoclonia with and without absences	UMLS	
-MONDO:0019413	ischio-vertebral syndrome	UMLS:C4274732	Ischio-vertebral syndrome	UMLS:CN206143	Ischio-vertebral dysplasia	UMLS	
-MONDO:0017199	osteoporosis-macrocephaly-blindness-joint hyperlaxity syndrome	UMLS:C4274786	Heide syndrome	UMLS:CN202651	Heide syndrome	UMLS	
-MONDO:0016528	limb body wall complex	UMLS:C4274839	Limb body wall complex	UMLS:CN201594	LBWC syndrome	UMLS	
-MONDO:0016342	familial isolated arrhythmogenic right ventricular dysplasia	UMLS:C4274968	Familial isolated arrhythmogenic right ventricular dysplasia	UMLS:CN226907	Familial isolated arrhythmogenic ventricular dysplasia	UMLS	
-MONDO:0015039	lissencephaly with cerebellar hypoplasia type F	UMLS:C4274989	Lissencephaly with cerebellar hypoplasia type F	UMLS:CN228905	Lissencephaly with cerebellar hypoplasia type F	UMLS	
-MONDO:0015037	lissencephaly with cerebellar hypoplasia type D	UMLS:C4274991	Lissencephaly with cerebellar hypoplasia type D	UMLS:CN228903	Lissencephaly with cerebellar hypoplasia type D	UMLS	
-MONDO:0015036	lissencephaly with cerebellar hypoplasia type C	UMLS:C4274992	Lissencephaly with cerebellar hypoplasia type C	UMLS:CN228902	Lissencephaly with cerebellar hypoplasia type C	UMLS	
-MONDO:0015035	lissencephaly with cerebellar hypoplasia type B	UMLS:C4274993	Lissencephaly with cerebellar hypoplasia type B	UMLS:CN228901	Lissencephaly with cerebellar hypoplasia type B	UMLS	
-MONDO:0020505	ravine syndrome	UMLS:C4275006	RAVINE syndrome	UMLS:CN207401	Reunion island-anorexia-vomiting which is irrepressible-neurological signs syndrome	UMLS	
-MONDO:0019617	pituitary deficiency due to empty sella turcica syndrome	UMLS:C4275064	Pituitary deficiency due to empty sella turcica syndrome	UMLS:CN206468	Hypopituitarism due to empty sella turcica syndrome	UMLS	
-MONDO:0019321	atypical Werner syndrome	UMLS:C4275075	Atypical Werner syndrome	UMLS:CN205977	Atypical progeroid syndrome	UMLS	
-MONDO:0019160	primary progressive freezing gait	UMLS:C4275078	Primary progressive freezing gait	UMLS:CN205712	PPFG	UMLS	
-MONDO:0016005	indomethacin embryofetopathy	UMLS:C4275138	Indomethacin embryofetopathy	UMLS:CN200656	Fetal indomethacin syndrome	UMLS	
-MONDO:0015205	isolated lissencephaly type 1 without known genetic defects	UMLS:C4275151	Isolated lissencephaly type 1 without known genetic defect	UMLS:CN226623	Isolated lissencephaly type 1 without known genetic defects	UMLS	
-MONDO:0019493	primary adult heart tumor	UMLS:C4275152	Adult heart tumor	UMLS:CN206280	Adult heart tumor	UMLS	
-MONDO:0007031	familial abdominal aortic aneurysm	UMLS:C4275172	Familial abdominal aortic aneurysm	UMLS:CN206207	Familial abdominal aortic aneurysm	UMLS	
-MONDO:0018541	familial hypoaldosteronism	UMLS:C4275180	Familial hypoaldosteronism	UMLS:CN205074	Familial hypoaldosteronism	UMLS	
-MONDO:0009364	muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type A1	UMLS:C4284790	Muscular Dystrophy-Dystroglycanopathy (Congenital with Brain and Eye Anomalies) Type A, 1	UMLS:CN033898	POMT1-Related Muscle Diseases	UMLS	
-MONDO:0016282	rhabdomyosarcoma of the cervix uteri	UMLS:C4289809	Cervical Rhabdomyosarcoma	UMLS:CN201072	Cervical rhabdomyosarcoma	UMLS	
-MONDO:0016283	leiomyosarcoma of the cervix uteri	UMLS:C4289817	Cervical Leiomyosarcoma	UMLS:CN201073	Cervical leiomyosarcoma	UMLS	
-MONDO:0017323	hypocalcemic rickets	UMLS:C4302195	Hypocalcemic rickets	UMLS:C4329608	Calcium Deficiency Rickets	UMLS	
-MONDO:0017227	autoimmune pancreatitis type 1	UMLS:C4302243	Autoimmune pancreatitis type 1	UMLS:CN202712	IgG4-related pancreatitis	UMLS	
-MONDO:0017810	variant ABeta2M amyloidosis	UMLS:C4302669	Autosomal dominant beta2-microglobulinic amyloidosis	UMLS:CN203779	Autosomal dominant beta2-microglobulinic amyloidosis	UMLS	
-MONDO:0019151	oligocone trichromacy	UMLS:C4302876	Oligocone trichromacy	UMLS:CN205696	Oligocone syndrome	UMLS	
-MONDO:0017770	Robinow-like syndrome	UMLS:C4302956	Robinow-like syndrome	UMLS:CN203671	Saal-Greenstein syndrome	UMLS	
-MONDO:0017233	familial Alzheimer-like prion disease	UMLS:C4303482	Familial Alzheimer-like prion disease	UMLS:CN202723	Familial Alzheimer-like prion disease	UMLS	
-MONDO:0018130	brain dopamine-serotonin vesicular transport disease	UMLS:C4303546	Brain dopamine-serotonin vesicular transport disease	UMLS:CN204508	Brain dopamine-serotonin vesicular transport disease	UMLS	
-MONDO:0015354	hereditary sensory and autonomic neuropathy with deafness and global delay	UMLS:C4303566	Hereditary sensory and autonomic neuropathy with deafness and global delay	UMLS:CN226662	HSAN with deafness and global delay	UMLS	
-MONDO:0015399	glossopalatine ankylosis	UMLS:C4303569	Glossopalatine ankylosis	UMLS:CN199497	Cosack syndrome	UMLS	
-MONDO:0015372	autosomal dominant macrothrombocytopenia	UMLS:C4304021	Autosomal dominant macrothrombocytopenia	UMLS:CN199474	Autosomal dominant macrothrombocytopenia	UMLS	
-MONDO:0018133	attenuated Chédiak-Higashi syndrome	UMLS:C4304022	Attenuated Chédiak-Higashi syndrome	UMLS:CN204519	Atypical Chédiak-Higashi syndrome	UMLS	
-MONDO:0017905	X-linked mendelian susceptibility to mycobacterial diseases	UMLS:C4304413	X-linked mendelian susceptibility to mycobacterial disease	UMLS:CN203967	X-linked MSMD	UMLS	
-MONDO:0016458	8q12 microduplication syndrome	UMLS:C4304504	8q12 microduplication syndrome	UMLS:CN201422	Trisomy 8q12	UMLS	
-MONDO:0016657	8p11.2 deletion syndrome	UMLS:C4304505	8p11.2 deletion syndrome	UMLS:CN201887	Monosomy 8p11.2	UMLS	
-MONDO:0019164	6q terminal deletion syndrome	UMLS:C4304514	6q terminal deletion syndrome	UMLS:CN205719	6q terminal deletion syndrome	UMLS	
-MONDO:0016461	5q35 microduplication syndrome	UMLS:C4304526	5q35 microduplication syndrome	UMLS:CN201426	Trisomy 5q35	UMLS	
-MONDO:0016655	6p22 microdeletion syndrome	UMLS:C4304528	6p22 microdeletion syndrome	UMLS:CN201884	Monosomy 6p22	UMLS	
-MONDO:0015583	2p21 microdeletion syndrome	UMLS:C4304537	2p21 microdeletion syndrome	UMLS:CN199952	2p21 deletion syndrome	UMLS	
-MONDO:0016841	20p12.3 microdeletion syndrome	UMLS:C4304539	20p12.3 microdeletion syndrome	UMLS:CN202180	Monosomy 20p12.3	UMLS	
-MONDO:0016561	1q44 microdeletion syndrome	UMLS:C4304540	1q44 microdeletion syndrome	UMLS:CN201644	Monosomy 1q44	UMLS	
-MONDO:0017405	1p21.3 microdeletion syndrome	UMLS:C4304578	1p21.3 microdeletion syndrome	UMLS:CN203152	Monosomy 1p21.3	UMLS	
-MONDO:0016765	19p13.12 microdeletion syndrome	UMLS:C4304579	19p13.12 microdeletion syndrome	UMLS:CN202023	Monosomy 19p13.12	UMLS	
-MONDO:0016838	16q24.3 microdeletion syndrome	UMLS:C4304594	16q24.3 microdeletion syndrome	UMLS:CN202174	Monosomy 16q24.3	UMLS	
-MONDO:0016837	16p13.11 microduplication syndrome	UMLS:C4304595	16p13.11 microduplication syndrome	UMLS:CN202173	Trisomy 16p13.11	UMLS	
-MONDO:0016836	16p13.11 microdeletion syndrome	UMLS:C4304596	16p13.11 microdeletion syndrome	UMLS:CN202172	Monosomy 16p13.11	UMLS	
-MONDO:0015350	17q11.2 microduplication syndrome	UMLS:C4304642	17q11.2 microduplication syndrome	UMLS:CN199408	Trisomy 17q11.2	UMLS	
-MONDO:0016431	autosomal dominant Charcot-Marie-tooth disease type 2M	UMLS:C4304672	Autosomal dominant Charcot-Marie-Tooth disease type 2M	UMLS:CN201389	CMT2M	UMLS	
-MONDO:0019309	late-onset junctional epidermolysis bullosa	UMLS:C4304724	Late-onset junctional epidermolysis bullosa	UMLS:CN205949	JEB-lo	UMLS	
-MONDO:0020478	Leber plus disease	UMLS:C4304725	Leber plus disease	UMLS:CN207347	LHON plus disease	UMLS	
-MONDO:0015425	lethal recessive chondrodysplasia	UMLS:C4304745	Lethal recessive chondrodysplasia	UMLS:CN199522	Maroteaux-Stanescu-Cousin syndrome	UMLS	
-MONDO:0013485	spinocerebellar ataxia type 35	UMLS:C4304822	Spinocerebellar ataxia type 35	UMLS:CN202597	SCA35	UMLS	
-MONDO:0015999	primary pigmented nodular adrenocortical disease	UMLS:C4304832	Primary pigmented nodular adrenocortical disease	UMLS:CN200645	PPNAD	UMLS	
-MONDO:0016087	progressive non-infectious anterior vertebral fusion	UMLS:C4304839	Progressive non-infectious anterior vertebral fusion	UMLS:CN200850	Copenhagen syndrome	UMLS	
-MONDO:0018885	orbital leiomyoma	UMLS:C4305000	Orbital leiomyoma	UMLS:CN205236	Orbital leiomyoma	UMLS	
-MONDO:0018861	Zellweger-like syndrome without peroxisomal anomalies	UMLS:C4305104	Zellweger-like syndrome without peroxisomal anomaly	UMLS:CN205183	Ahn-Lerman-Sagie syndrome	UMLS	
-MONDO:0019428	fried syndrome	UMLS:C4305134	Fried syndrome	UMLS:CN206186	Fried syndrome	UMLS	
-MONDO:0019784	12q14 microdeletion syndrome	UMLS:C4305140	12q14 microdeletion syndrome	UMLS:CN206727	Osteopoikilosis-short stature-intellectual disability syndrome	UMLS	
-MONDO:0010033	generalized peeling skin syndrome	UMLS:C4305156	Generalized peeling skin syndrome	UMLS:CN202304	Generalized deciduous skin	UMLS	
-MONDO:0016833	14q12 microdeletion syndrome	UMLS:C4305240	14q12 microdeletion syndrome	UMLS:CN202163	Monosomy 14q12	UMLS	
-MONDO:0018268	Medich giant platelet syndrome	UMLS:C4305375	Medich giant platelet syndrome	UMLS:CN204847	Medich macrothrombocytopenia	UMLS	
-MONDO:0015071	middle ear neuroendocrine tumor	UMLS:C4305468	Neuroendocrine tumor of middle ear	UMLS:CN197364	Middle ear neuroendocrine tumor	UMLS	
-MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:C4310473	HYPERCALCEMIA, INFANTILE, 2	UMLS:CN262351		UMLS	
-MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:C4310473	HYPERCALCEMIA, INFANTILE, 2	UMLS:CN774236		UMLS	
-MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:C4310473	HYPERCALCEMIA, INFANTILE, 2	UMLS:CN847585		UMLS	
-MONDO:0015011	optic atrophy 11; OPA11	UMLS:C4310628	OPTIC ATROPHY 11	UMLS:CN230145	Optic Atrophy Type 11	UMLS	
-MONDO:0014977	autosomal recessive limb-girdle muscular dystrophy type 2Z	UMLS:C4310660	MUSCULAR DYSTROPHY, LIMB-GIRDLE, TYPE 2Z	UMLS:CN776834	LGMD2Z	UMLS	
-MONDO:0014884	cholestasis, progressive familial intrahepatic, 5; PFIC5	UMLS:C4310747	CHOLESTASIS, PROGRESSIVE FAMILIAL INTRAHEPATIC, 5	UMLS:CN776839	PFIC5	UMLS	
-MONDO:0007204	Cole-Carpenter syndrome 1	UMLS:C4317154	COLE-CARPENTER SYNDROME 1	UMLS:CN029402		UMLS	
-MONDO:0015892	growth hormone insensitivity syndrome	UMLS:C4318479	Growth Hormone Insensitivity Syndromes	UMLS:CN200504	Short stature due to a defect in growth hormone receptor or post-receptor pathway	UMLS	
-MONDO:0007749	autosomal recessive infantile hypercalcemia	UMLS:C4329374	Autosomal Recessive Infantile Hypercalcemia	UMLS:CN203398	Familial infantile hypercalcemia with suppressed intact parathyroid hormone	UMLS	
-MONDO:0019194	localized lipodystrophy	UMLS:C4329999	Focal Lipodystrophy	UMLS:CN227583	Localized lipodystrophy	UMLS	
-MONDO:0016736	rosette-forming glioneuronal tumor of fourth ventricule	UMLS:C4331262	Rosette-forming glioneuronal tumor	UMLS:CN201984	Dysembryoplastic neuroepithelial tumor of cerebellum	UMLS	
-MONDO:0010517	ciliary dyskinesia, primary, 36, X-linked; CILD36	UMLS:C4478372	CILIARY DYSKINESIA, PRIMARY, 36, X-LINKED	UMLS:CN240511		UMLS	
-MONDO:0015023	nemaline myopathy 11	UMLS:C4479186	NEMALINE MYOPATHY 11, AUTOSOMAL RECESSIVE	UMLS:C4479695	NEMALINE MYOPATHY 11	UMLS	
-MONDO:0015023	nemaline myopathy 11	UMLS:C4479186	NEMALINE MYOPATHY 11, AUTOSOMAL RECESSIVE	UMLS:CN240509		UMLS	
-MONDO:0015025	epileptic encephalopathy, early infantile, 51; EIEE51	UMLS:C4479208	EPILEPTIC ENCEPHALOPATHY, EARLY INFANTILE, 51	UMLS:CN240510		UMLS	
-MONDO:0024570	hyperparathyroidism 4	UMLS:C4479229	HYPERPARATHYROIDISM 4	UMLS:CN240514		UMLS	
-MONDO:0015023	nemaline myopathy 11	UMLS:C4479695	NEMALINE MYOPATHY 11	UMLS:CN240509		UMLS	
-MONDO:0018070	familial multiple fibrofolliculoma	UMLS:C4509837	Familial multiple fibrofolliculoma	UMLS:CN204388	Familial multiple fibrofolliculoma	UMLS	
-MONDO:0016460	Polyvalvular heart disease syndrome	UMLS:C4509918	Polyvalvular heart disease syndrome	UMLS:CN201425	PHD syndrome	UMLS	
-MONDO:0019606	simple cryoglobulinemia	UMLS:C4510006	Simple cryoglobulinemia	UMLS:CN206459	Cryoglobulinemia type 1	UMLS	
-MONDO:0016842	paternal 20q13.2q13.3 microdeletion syndrome	UMLS:C4510306	Paternal 20q13.2q13.3 microdeletion syndrome	UMLS:CN202182	Paternal monosomy 20q13.2q13.3	UMLS	
-MONDO:0019604	acquired monoclonal Ig light chain-associated Fanconi syndrome	UMLS:C4510369	Acquired monoclonal immunoglobulin light chain-associated Fanconi syndrome	UMLS:CN206457	Acquired monoclonal immunoglobulin light chain-associated Fanconi syndrome	UMLS	
-MONDO:0018101	familial primary hypomagnesemia with normocalciuria and normocalcemia	UMLS:C4510731	Familial primary hypomagnesemia with normocalciuria and normocalcemia	UMLS:CN204443	Familial primary hypomagnesemia with normocalciuria and normocalcemia	UMLS	
-MONDO:0019388	pelvis syndrome	UMLS:C4510867	PELVIS syndrome	UMLS:CN206083	Perineal hemangioma-external genitalia malformations-lipomyelomeningocele-vesicorenal abnormalities-imperforate anus syndrome	UMLS	
-MONDO:0018321	atypical juvenile parkinsonism	UMLS:C4510873	Atypical juvenile parkinsonism	UMLS:CN204972	Atypical juvenile parkinsonism	UMLS	
-MONDO:0018854	acquired purpura fulminans	UMLS:C4510896	Acquired purpura fulminans	UMLS:CN205163	Acquired purpura fulminans	UMLS	
-MONDO:0018256	acute myeloid leukemia with t(8;16)(p11;p13) translocation	UMLS:C4511003	Acute myeloid leukemia with t(8;16)(p11;p13) translocation	UMLS:CN204831	AML with t(8;16)(p11;p13) translocation	UMLS	
-MONDO:0020381	patterned macular dystrophy	UMLS:C4511237	Butterfly-shaped pigmentary macular dystrophy	UMLS:CN207254	Butterfly-shaped pigmentary macular dystrophy	UMLS	
-MONDO:0019680	genochondromatosis type 2	UMLS:C4511481	Genochondromatosis type 2	UMLS:CN206604	Genochondromatosis type 2	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0017394	ketamine-induced biliary dilatation	UMLS:C4512018	Ketamine-induced biliary dilatation	UMLS:CN227122	Ketamine-induced biliary dilatation	UMLS	
-MONDO:0019873	4p16.3 microduplication syndrome	UMLS:C4512053	4p16.3 microduplication syndrome	UMLS:CN206808	Trisomy 4pter	UMLS	
-MONDO:0020469	48,XYYY syndrome	UMLS:C4518082	48,XYYY syndrome	UMLS:CN207331	48,XYYY syndrome	UMLS	
-MONDO:0016850	atypical Norrie disease due to monosomy Xp11.3	UMLS:C4518083	Atypical Norrie disease due to monosomy Xp11.3	UMLS:CN202196	Atypical Norrie disease due to del(X)(p11.3)	UMLS	
-MONDO:0015552	acral dystrophic epidermolysis bullosa	UMLS:C4518087	Acral dystrophic epidermolysis bullosa	UMLS:CN199731	DEB-ac	UMLS	
-MONDO:0014475	spinocerebellar ataxia type 40	UMLS:C4518336	Spinocerebellar ataxia type 40	UMLS:CN237494	SCA40	UMLS	
-MONDO:0014475	spinocerebellar ataxia type 40	UMLS:C4518336	Spinocerebellar ataxia type 40	UMLS:CN219009		UMLS	
-MONDO:0020470	49,XYYYY syndrome	UMLS:C4518342	49,XYYYY syndrome	UMLS:CN207332	49,XYYYY syndrome	UMLS	
-MONDO:0017334	12q15q21.1 microdeletion syndrome	UMLS:C4518344	12q15q21.1 microdeletion syndrome	UMLS:CN202984	Monosomy 12q15q21.1	UMLS	
-MONDO:0019122	idiopathic acute eosinophilic pneumonia	UMLS:C4518469	Idiopathic acute eosinophilic pneumonia	UMLS:CN227574	Loffler syndrome	UMLS	
-MONDO:0015367	Charlie M syndrome	UMLS:C4518555	Charlie M syndrome	UMLS:CN199458	Charlie M syndrome	UMLS	
-MONDO:0018342	Joubert syndrome with Jeune asphyxiating thoracic dystrophy	UMLS:C4518774	Joubert syndrome with Jeune asphyxiating thoracic dystrophy	UMLS:CN225944	Joubert syndrome with JATD	UMLS	
-MONDO:0016445	familial anetoderma	UMLS:C4518793	Hereditary anetoderma	UMLS:CN226934	Hereditary macular atrophy	UMLS	
-MONDO:0016834	16p11.2p12.2 microduplication syndrome	UMLS:C4518821	16p11.2p12.2 microduplication syndrome	UMLS:CN202168	Trisomy 16p11.2p12.2	UMLS	
-MONDO:0016843	20q13.33 microdeletion syndrome	UMLS:C4518823	20q13.33 microdeletion syndrome	UMLS:CN202183	Monosomy 20q13.33	UMLS	
-MONDO:0009032	cranioectodermal dysplasia	UMLS:CN016627	Sensenbrenner syndrome	UMLS:CN119432	Sensenbrenner syndrome	UMLS	
-MONDO:0009974	familial hemophagocytic lymphohistiocytosis type 1	UMLS:CN034020	FHL1	UMLS:CN205265	Familial HLH	UMLS	
-MONDO:0010247	X-linked cerebral adrenoleukodystrophy	UMLS:CN036464	Childhood cerebral ALD	UMLS:CN199389	X-linked cerebral adrenoleukodystrophy	UMLS	
-MONDO:0019220	inborn disorder of cobalamin metabolism and transport	UMLS:CN043592	Disorders of Intracellular Cobalamin Metabolism	UMLS:CN227587	Disorder of cobalamin metabolism and transport	UMLS	
-MONDO:0015151	autosomal dominant limb-girdle muscular dystrophy	UMLS:CN043626	Limb-Girdle Muscular Dystrophy, Autosomal Dominant	UMLS:CN228919	Autosomal dominant limb-girdle muscular dystrophy	UMLS	
-MONDO:0009287	glycogen storage disease due to glucose-6-phosphatase deficiency type IA	UMLS:CN069618		UMLS:CN205860	Glycogenosis due to glucose-6-phosphatase deficiency type Ia	UMLS	
-MONDO:0012017	Parkes Weber syndrome	UMLS:CN074207	RASA1-Related Disorders	UMLS:CN206396	Parkes Weber syndrome	UMLS	
-MONDO:0012173	long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:CN074230	LCHAD deficiency	UMLS:CN239369	LCHAD Deficiency	UMLS	
-MONDO:0014225	hemochromatosis type 5	UMLS:CN181217	HFE5	UMLS:CN237708	Hemochromatosis type 5	UMLS	
-MONDO:0019123	continuous spikes and waves during sleep	UMLS:CN181337	CSWS	UMLS:CN205644	Epileptic encephalopathy with continuous spike-and-wave during slow sleep	UMLS	
-MONDO:0015356	hereditary neoplastic syndrome	UMLS:CN199448	Inherited cancer-predisposing syndrome	UMLS:CN882908	Hereditary Cancer Syndrome	UMLS	
-MONDO:0008146	osteogenesis imperfecta type 1	UMLS:CN201103	Van der Hoeve syndrome	UMLS:CN536249	Osteogenesis imperfecta type 1	UMLS	
-MONDO:0016796	mitochondrial DNA depletion syndrome, encephalomyopathic form	UMLS:CN202052	mtDNA depletion syndrome, encephalomyopathic form	UMLS:CN230130	Mitochondrial DNA Depletion Syndrome, Encephalomyopathic Form	UMLS	
-MONDO:0017219	microform holoprosencephaly	UMLS:CN202701	Holoprosencéphalie, minor form	UMLS:CN236719	microform holoprosencephaly	UMLS	
-MONDO:0017288	DICER1 syndrome	UMLS:CN202862	Pleuro-pulmonary blastoma familial tumor susceptibility syndrome	UMLS:CN240512		UMLS	
-MONDO:0017309	neonatal Marfan syndrome	UMLS:CN202885	Neonatal MFS	UMLS:CN536247	Neonatal Marfan syndrome	UMLS	
-MONDO:0017338	fatal multiple mitochondrial dysfunctions syndrome	UMLS:CN202994	Fatal multiple mitochondrial dysfunctions syndrome	UMLS:CN234684		UMLS	
-MONDO:0017385	malignant migrating partial seizures of infancy	UMLS:CN203114	Migrating partial seizures of infancy	UMLS:CN240507	Malignant migrating partial seizures of infancy	UMLS	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS	
-MONDO:0018319	familial episodic pain syndrome	UMLS:CN204967	FEPS	UMLS:CN228162	Familial episodic pain syndrome	UMLS	
-MONDO:0019192	AKT2-related familial partial lipodystrophy	UMLS:CN205772	AKT2-related FPLD	UMLS:CN536246	AKT2-related familial partial lipodystrophy	UMLS	
-MONDO:0009557	mandibuloacral dysplasia with type A lipodystrophy	UMLS:CN206381	Mandibuloacral dysplasia with type A lipodystrophy	UMLS:CN236772	Mandibuloacral dysplasia with type A lipodystrophy	UMLS	
-MONDO:0016587	arrhythmogenic right ventricular cardiomyopathy	UMLS:CN221565	Arrhythmogenic right ventricular dysplasia/cardiomyopathy	UMLS:CN239850		UMLS	
-MONDO:0017290	familial intrahepatic cholestasis	UMLS:CN227107	Familial intrahepatic cholestasis	UMLS:CN239338	Familial Intrahepatic Cholestasis	UMLS	
-MONDO:0014645	BENTA disease	UMLS:CN231446	BENTA	UMLS:CN242071	B-cell expansion with NF-kB and T-cell anergy disease	UMLS	
-MONDO:0019218	inborn disorder of bile acid synthesis	UMLS:CN231736	Disorder of bile acid synthesis	UMLS:CN544763	Inborn Errors of Bile Acid Synthesis	UMLS	
-MONDO:0018065	isolated trigonocephaly	UMLS:CN236409	Trigonocephaly, nonsyndromic	UMLS:CN239481	Nonsyndromic Trigonocephaly	UMLS	
-MONDO:0005267	heart disease	UMLS:CN236661	Heart Diseases	UMLS:CN239852	Cardiac disease	UMLS	
-MONDO:0018698	hereditary neuroendocrine tumor of small intestine	UMLS:CN237770	Hereditary neuroendocrine tumor of small bowel	UMLS:CN847586	Hereditary neuroendocrine tumor of small intestine	UMLS	
-MONDO:0017824	familial isolated pituitary adenoma	UMLS:CN239192	Familial Isolated Pituitary Adenomas	UMLS:CN244420	FIPA	UMLS	
-MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:CN262351		UMLS:CN774236		UMLS	
-MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:CN262351		UMLS:CN847585		UMLS	
-MONDO:0044777	premature ovarian failure 14	UMLS:CN753759	GDF9 related ovarian dysfunction	UMLS:CN757793	GDF9-related primary ovarian insufficiency	UMLS	
-MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:CN774236		UMLS:CN847585		UMLS	
-MONDO:0019118	inherited retinal dystrophy	COHD:377270		COHD:380395		COHD	
-MONDO:0000774	autoimmune neuropathy	DOID:0040087	autoimmune peripheral neuropathy	DOID:0060499		DOID	
-MONDO:0006558	pemphigoid gestationis	DOID:0040098	pemphigus gestationis	DOID:14482	herpes gestationis	DOID	
-MONDO:0016575	primary ciliary dyskinesia	DOID:0050144	Kartagener syndrome	DOID:9562	primary ciliary dyskinesia	DOID	
-MONDO:0010524	X-linked sideroblastic anemia with ataxia	DOID:0050554	X-linked sideroblastic anemia with ataxia	DOID:0060064	sideroblastic anemia with spinocerebellar ataxia	DOID	
-MONDO:0010060	infantile onset spinocerebellar ataxia	DOID:0050556	infantile onset spinocerebellar ataxia	DOID:0080126		DOID	
-MONDO:0007100	familial amyloid neuropathy	DOID:0050638	transthyretin amyloidosis	DOID:0050761	paramyloidosis	DOID	
-MONDO:0016011	fetal alcohol syndrome	DOID:0050665	fetal alcohol syndrome	DOID:0050667	alcohol-related neurodevelopmental disorder	DOID	
-MONDO:0004379	female breast carcinoma	DOID:0050671	female breast cancer	DOID:7843	female breast carcinoma	DOID	
-MONDO:0004992	cancer	DOID:0050686	organ system cancer	DOID:0050687	cell type cancer	DOID	
-MONDO:0004992	cancer	DOID:0050686	organ system cancer	DOID:162	cancer	DOID	
-MONDO:0004992	cancer	DOID:0050687	cell type cancer	DOID:162	cancer	DOID	
-MONDO:0016021	early infantile epileptic encephalopathy	DOID:0050709	early infantile epileptic encephalopathy	DOID:2481	infantile epileptic encephalopathy	DOID	
-MONDO:0002412	glycogen storage disease	DOID:0050728	glycogen metabolism disorder	DOID:2747	glycogen storage disease	DOID	
-MONDO:0000430	mature T-cell and NK-cell non-Hodgkin lymphoma	DOID:0050743	mature T-cell and NK-cell lymphoma	DOID:0050749	peripheral T-cell lymphoma	DOID	
-MONDO:0005484	colorectal adenoma	DOID:0050860	colorectal adenoma	DOID:0050914	large intestine adenoma	DOID	
-MONDO:0005008	colorectal adenocarcinoma	DOID:0050861	colorectal adenocarcinoma	DOID:0050913	large intestine adenocarcinoma	DOID	
-MONDO:0012496	Koolen de Vries syndrome	DOID:0050880	Koolen de Vries syndrome	DOID:0070076	Koolen-De Vries syndrome	DOID	
-MONDO:0003924	adrenal cortex adenoma	DOID:0050891	adrenal cortical adenoma	DOID:656	adrenal adenoma	DOID	
-MONDO:0007959	medulloblastoma	DOID:0050902	medulloblastoma	DOID:0060104	cerebellar medulloblastoma	DOID	
-MONDO:0005211	ovarian serous adenocarcinoma	DOID:0050933	ovarian serous carcinoma	DOID:5744	ovary serous adenocarcinoma	DOID	
-MONDO:0008458	spinocerebellar ataxia type 2	DOID:0050955	spinocerebellar ataxia type 2	DOID:0060204	amyotrophic lateral sclerosis type 13	DOID	
-MONDO:0019046	leukodystrophy	DOID:0050987	hypomyelinating leukoencephalopathy	DOID:0060786	hypomyelinating leukodystrophy	DOID	
-MONDO:0019046	leukodystrophy	DOID:0050987	hypomyelinating leukoencephalopathy	DOID:10579	leukodystrophy	DOID	
-MONDO:0011225	severe combined immunodeficiency due to DCLRE1C deficiency	DOID:0060006	artemis deficiency	DOID:0090012	severe combined immunodeficiency with sensitivity to ionizing radiation	DOID	
-MONDO:0010626	X-linked hyper-IgM syndrome	DOID:0060022	CD40 ligand deficiency	DOID:6620	X-linked hyper IgM syndrome	DOID	
-MONDO:0001341	selective IgA deficiency disease	DOID:0060025	immunoglobulin alpha deficiency	DOID:11701	selective IgA deficiency disease	DOID	
-MONDO:0001300	autonomic neuropathy	DOID:0060054	autonomic peripheral neuropathy	DOID:11504	autonomic neuropathy	DOID	
-MONDO:0005165	benign neoplasm	DOID:0060072	benign neoplasm	DOID:0060084	cell type benign neoplasm	DOID	
-MONDO:0005165	benign neoplasm	DOID:0060072	benign neoplasm	DOID:0060085	organ system benign neoplasm	DOID	
-MONDO:0005165	benign neoplasm	DOID:0060084	cell type benign neoplasm	DOID:0060085	organ system benign neoplasm	DOID	
-MONDO:0009669	Werdnig-Hoffmann disease	DOID:0060160	survival motor neuron spinal muscular atrophy	DOID:13137	Werdnig-Hoffmann disease	DOID	
-MONDO:0009833	Shwachman-Diamond syndrome	DOID:0060479		DOID:0080023	Shwachman-Diamond type metaphyseal dysplasia	DOID	
-MONDO:0010542	dilated cardiomyopathy 3B	DOID:0060561	DMD-related dilated cardiomyopathy	DOID:0110461	X-linked dilated cardiomyopathy	DOID	
-MONDO:0000902	agenesis of the corpus callosum with peripheral neuropathy	DOID:0060600	hereditary motor and sensory neuropathy with agenesis of the corpus callosum	DOID:0090003	agenesis of the corpus callosum with peripheral neuropathy	DOID	
-MONDO:0019046	leukodystrophy	DOID:0060786	hypomyelinating leukodystrophy	DOID:10579	leukodystrophy	DOID	
-MONDO:0014076	dyskeratosis congenita, autosomal recessive 5	DOID:0070020	autosomal dominant dyskeratosis congenita 4	DOID:0070022	autosomal recessive dyskeratosis congenita 5	DOID	
-MONDO:0009054	autosomal recessive cutis laxa type 2, classic type	DOID:0070136	autosomal dominant cutis laxa 2	DOID:0070141	autosomal recessive cutis laxa type II classic type	DOID	
-MONDO:0007920	Meige disease	DOID:0070213	hereditary lymphedema II	DOID:3982	Meige syndrome	DOID	
-MONDO:0019072	intrahepatic cholestasis	DOID:0070227	intrahepatic cholestasis of pregnancy	DOID:1852	intrahepatic cholestasis	DOID	
-MONDO:0009856	Peters plus syndrome	DOID:0070312	Peters-Plus Syndrome	DOID:0080201		DOID	
-MONDO:0005380	osteonecrosis	DOID:0080008	ischemic bone disease	DOID:10159	osteonecrosis	DOID	
-MONDO:0008758	mitochondrial DNA depletion syndrome 4a	DOID:0080122	mitochondrial DNA depletion syndrome 4a	DOID:1442	Alpers syndrome	DOID	
-MONDO:0033044	Meckel syndrome 13	DOID:0080253		DOID:0080276		DOID	
-MONDO:0027772	lung colloid adenocarcinoma	DOID:0080303		DOID:0080304		DOID	
-MONDO:0018555	hypogonadotropic hypogonadism	DOID:0090070	hypogonadotropic hypogonadism	DOID:7455	hypogonadotropism	DOID	
-MONDO:0000960	diabetic peripheral angiopathy	DOID:10182	diabetic peripheral angiopathy	DOID:11713	diabetic angiopathy	DOID	
-MONDO:0008346	pulmonary hemosiderosis	DOID:10328	siderosis	DOID:12118	pulmonary hemosiderosis	DOID	
-MONDO:0001561	pyloric stenosis (disease)	DOID:12639	pyloric stenosis	DOID:3122	gastric outlet obstruction	DOID	
-MONDO:0003730	aleukemic leukemia	DOID:12965	subleukemic leukemia	DOID:6004	aleukemic leukemia	DOID	
-MONDO:0018301	interstitial cystitis	DOID:13949	interstitial cystitis	DOID:1678	chronic interstitial cystitis	DOID	
-MONDO:0002008	labyrinthitis	DOID:1468	labyrinthitis	DOID:3930	otitis interna	DOID	
-MONDO:0005689	cannabis dependence	DOID:1849	cannabis dependence	DOID:9505	cannabis abuse	DOID	
-MONDO:0019004	kidney Wilms tumor	DOID:2154	nephroblastoma	DOID:5176	renal Wilms' tumor	DOID	
-MONDO:0002277	arteriosclerosis disorder	DOID:2348	arteriosclerotic cardiovascular disease	DOID:2349	arteriosclerosis	DOID	
-MONDO:0003061	benign muscle neoplasm	DOID:2691	myoma	DOID:461	muscle benign neoplasm	DOID	
-MONDO:0006906	pigmented villonodular synovitis	DOID:2702	pigmented villonodular synovitis	DOID:9898	villonodular synovitis	DOID	
-MONDO:0002422	adamantinoma	DOID:2775	long bone adamantinoma	DOID:2776	adamantinoma	DOID	
-MONDO:0006451	thymic carcinoma	DOID:3284	thymic carcinoma	DOID:4554	type C thymoma	DOID	
-MONDO:0005184	pancreatic ductal adenocarcinoma	DOID:3498	pancreatic ductal adenocarcinoma	DOID:3587	pancreatic ductal carcinoma	DOID	
-MONDO:0002722	olfactory nerve neoplasm	DOID:366	olfactory nerve neoplasm	DOID:8256	olfactory neural tumor	DOID	
-MONDO:0016706	chordoid glioma of the third ventricle	DOID:3773	third ventricle chordoid glioma	DOID:3774	chordoid glioma	DOID	
-MONDO:0006639	adrenal cortex carcinoma	DOID:3948	adrenocortical carcinoma	DOID:3959	adrenal cortical adenocarcinoma	DOID	
-MONDO:0006639	adrenal cortex carcinoma	DOID:3948	adrenocortical carcinoma	DOID:660	adrenal cortex cancer	DOID	
-MONDO:0006639	adrenal cortex carcinoma	DOID:3959	adrenal cortical adenocarcinoma	DOID:660	adrenal cortex cancer	DOID	
-MONDO:0006962	sebaceous adenocarcinoma	DOID:4839	sebaceous adenocarcinoma	DOID:4840	sebaceous carcinoma	DOID	
-MONDO:0003345	hilar cholangiocarcinoma	DOID:4927	Klatskin's tumor	DOID:5246	hilar cholangiocellular carcinoma	DOID	
-MONDO:0006280	lung sclerosing hemangioma	DOID:495	sclerosing hemangioma	DOID:5766	pulmonary sclerosing hemangioma	DOID	
-MONDO:0013280	myxoid liposarcoma	DOID:5363	myxoid liposarcoma	DOID:5709	mixed-type liposarcoma	DOID	
-MONDO:0005575	colorectal cancer	DOID:5672	large intestine cancer	DOID:9256	colorectal cancer	DOID	
-MONDO:0020513	spermatocytic seminoma	DOID:5834	spermatocytoma	DOID:7891	testicular spermatocytic seminoma	DOID	
-MONDO:0003680	periosteal chondrosarcoma	DOID:5859	periosteal chondrosarcoma	DOID:5866	juxtacortical chondrosarcoma	DOID	
-MONDO:0004398	mediastinal schwannoma	DOID:6175	mediastinal neurilemmoma	DOID:7922	benign mediastinal neurilemmoma	DOID	
-MONDO:0007256	hepatocellular carcinoma	DOID:684	hepatocellular carcinoma	DOID:686	liver carcinoma	DOID	
-MONDO:0018523	pancreatic mucinous cystadenoma	DOID:7235	pancreatic mucinous cystadenoma	DOID:7735	pancreatic colloid cystadenoma	DOID	
-MONDO:0005076	periodontitis	DOID:824	periodontitis	DOID:9893	periodontosis	DOID	
-MONDO:0019118	inherited retinal dystrophy	DOID:8500	hereditary retinal dystrophy	DOID:8501	fundus dystrophy	DOID	
-MONDO:0013424	3p- syndrome	GARD:0000037	Chromosome 3p deletion	GARD:0003750	Chromosome 3p- syndrome	GARD	
-MONDO:0018940	congenital myasthenic syndrome	GARD:0000098	Myasthenia gravis congenital	GARD:0011902	Congenital myasthenic syndrome	GARD	
-MONDO:0019122	idiopathic acute eosinophilic pneumonia	GARD:0000107	Pneumonia, eosinophilic	GARD:0000519	Idiopathic acute eosinophilic pneumonia	GARD	
-MONDO:0012221	alpha-N-acetylgalactosaminidase deficiency type 1	GARD:0000116	Schindler disease type 1	GARD:0003903	N-acetyl-alpha-D-galactosaminidase deficiency type III	GARD	
-MONDO:0007047	punctate palmoplantar keratoderma type III	GARD:0000125	Acrokeratoelastoidosis of Costa	GARD:0000133	Aganglionosis, total intestinal	GARD	
-MONDO:0009476	atresia of small intestine	GARD:0000140	Atresia of small intestine	GARD:0006799	Jejunal atresia	GARD	
-MONDO:0010831	familial caudal dysgenesis	GARD:0000215	Familial caudal dysgenesis	GARD:0004751	Sacral defect with anterior meningocele	GARD	
-MONDO:0018960	congenital primary megaureter	GARD:0000219	Congenital giant megaureter	GARD:0001492	Congenital megalo-ureter	GARD	
-MONDO:0016333	familial dilated cardiomyopathy	GARD:0000221	Dilated cardiomyopathy	GARD:0002905	Familial dilated cardiomyopathy	GARD	
-MONDO:0009634	microtia with meatal atresia and conductive deafness	GARD:0000357	Gupta Patton syndrome	GARD:0003657	Microtia, meatal atresia and conductive deafness	GARD	
-MONDO:0009151	Zlotogora-Ogur syndrome	GARD:0000375	Zlotogora syndrome	GARD:0001045	Bustos Simosa Pinto Cisternas syndrome	GARD	
-MONDO:0011052	amelia cleft lip palate hydrocephalus iris coloboma	GARD:0000388	Brachial amelia, forebrain defects and facial clefts	GARD:0000641	Amelia cleft lip palate hydrocephalus iris coloboma	GARD	
-MONDO:0008704	short-limb skeletal dysplasia with severe combined immunodeficiency	GARD:0000463	Achondroplasia and Swiss type agammaglobulinemia	GARD:0002988	Achondroplasia and severe combined immunodeficiency	GARD	
-MONDO:0018874	acute myeloid leukemia	GARD:0000537	Acute non lymphoblastic leukemia	GARD:0012757	Acute myeloid leukemia	GARD	
-MONDO:0011142	Ehlers-Danlos syndrome, musculocontractural type	GARD:0000545	Adducted thumbs Dundar type	GARD:0008486	Musculocontractural Ehlers-Danlos syndrome	GARD	
-MONDO:0013869	adenine phosphoribosyltransferase deficiency	GARD:0000546	Adenine phosphoribosyltransferase deficiency	GARD:0010666	Dihydroxyadeninuria	GARD	
-MONDO:0008771	amelogenesis imperfecta type 1G	GARD:0000646	Amelogenesis imperfecta nephrocalcinosis	GARD:0009860	Amelogenesis imperfecta hypoplastic type, IG	GARD	
-MONDO:0015564	Castleman disease	GARD:0000673	Angiofollicular lymph hyperplasia	GARD:0012656	Castleman disease	GARD	
-MONDO:0015241	arthrogryposis-like syndrome	GARD:0000783	Arthrogryposis like disorder	GARD:0003150	Kuskokwim disease	GARD	
-MONDO:0009626	pseudo-TORCH syndrome	GARD:0000815	Baraitser Brett Piesowicz syndrome	GARD:0012426	Congenital intrauterine infection-like syndrome	GARD	
-MONDO:0009680	congenital muscular dystrophy-infantile cataract-hypogonadism syndrome	GARD:0000835	Bassoe syndrome	GARD:0003842	Muscular dystrophy, congenital, infantile with cataract and hypogonadism	GARD	
-MONDO:0015457	corpus callosum agenesis-double urinary collecting system syndrome	GARD:0000852	Ben Ari Shuper Mimouni syndrome	GARD:0001536	Corpus callosum agenesis double urinary collecting	GARD	
-MONDO:0007226	brachydactyly-nystagmus-cerebellar ataxia syndrome	GARD:0000881	Biemond syndrome type 1	GARD:0000971	Biemond syndrome	GARD	
-MONDO:0019341	tuberous sclerosis complex	GARD:0000946	Bourneville syndrome	GARD:0007830	Tuberous sclerosis	GARD	
-MONDO:0007216	brachydactyly type A2	GARD:0000979	Brachydactyly type A2	GARD:0000989	Brachymesophalangy type 2	GARD	
-MONDO:0007401	craniosynostosis-Dandy-Walker malformation-hydrocephalus syndrome	GARD:0000998	Braddock Jones Superneau syndrome	GARD:0001592	Dandy-Walker malformation with sagittal craniosynostosis and hydrocephalus	GARD	
-MONDO:0007245	neurofibromatosis type 6	GARD:0001050	Cafe au lait spots, multiple	GARD:0003967	Autosomal dominant café au lait spots	GARD	
-MONDO:0009675	autosomal recessive limb-girdle muscular dystrophy type 2A	GARD:0001057	Limb-girdle muscular dystrophy type 2A	GARD:0003845	Muscular dystrophy limb girdle type 2A, Erb type	GARD	
-MONDO:0008926	COFS syndrome	GARD:0001060	Cataract-microcephaly-failure to thrive-kyphoscoliosis	GARD:0006027	Cerebro-oculo-facio-skeletal syndrome	GARD	
-MONDO:0013325	COG5-CDG	GARD:0001173	CDG syndrome type 3	GARD:0012348	COG5-CDG (CDG-IIi)	GARD	
-MONDO:0017409	fetal cytomegalovirus syndrome	GARD:0001409	CMV antenatal infection	GARD:0001480	Congenital cytomegalovirus	GARD	
-MONDO:0008272	polysyndactyly	GARD:0001616	Crossed polydactyly type 1	GARD:0009903	Preaxial polydactyly type 4	GARD	
-MONDO:0010576	X-linked mixed deafness with perilymphatic gusher	GARD:0001694	Deafness mixed with perilymphatic Gusher, X-linked	GARD:0004504	Deafness, X-linked 2	GARD	
-MONDO:0008681	WAGR syndrome	GARD:0001732	Chromosome 11p deletion	GARD:0005528	WAGR syndrome	GARD	
-MONDO:0009109	lysinuric protein intolerance	GARD:0001853	Dibasic aminoaciduria 2	GARD:0003335	Lysinuric protein intolerance	GARD	
-MONDO:0020491	subcortical band heterotopia	GARD:0001904	Subcortical band heterotopia	GARD:0002250	Familial band heterotopia	GARD	
-MONDO:0016145	qualitative or quantitative defects of dysferlin	GARD:0002003	Dysferlinopathy	GARD:0002031	Dystrophinopathy	GARD	
-MONDO:0007510	Clouston syndrome	GARD:0002056	Clouston syndrome	GARD:0004253	Patel Bixler syndrome	GARD	
-MONDO:0012391	neuronal ceroid lipofuscinosis 8 northern epilepsy variant	GARD:0002163	Epilepsy mental deterioration Finnish type	GARD:0004010	Northern epilepsy	GARD	
-MONDO:0013099	combined pituitary hormone deficiencies, genetic form	GARD:0002252	Familial hypopituitarism	GARD:0010602	Combined pituitary hormone deficiencies, genetic forms	GARD	
-MONDO:0008650	posterior fusion of lumbosacral vertebrae-blepharoptosis syndrome	GARD:0002276	Faulk Epstein Jones syndrome	GARD:0005487	Vertebral fusion posterior lumbosacral blepharoptosis	GARD	
-MONDO:0015193	hydrops fetalis (disease)	GARD:0002301	Fetal edema	GARD:0002783	Hydrops fetalis	GARD	
-MONDO:0017453	fetal parvovirus syndrome	GARD:0002310	Fetal parvovirus syndrome	GARD:0004236	Parvovirus antenatal infection	GARD	
-MONDO:0011359	acromelic frontonasal dysostosis	GARD:0002393	Frontonasal dysplasia acromelic	GARD:0005539	Acromelic frontonasal dysostosis	GARD	
-MONDO:0023204	Fukuda Miyanomae Nakata syndrome	GARD:0002411	Fukuda Miyanomae Nakata syndrome	GARD:0006475	Fukuyama type muscular dystrophy	GARD	
-MONDO:0009268	Gaucher disease-ophthalmoplegia-cardiovascular calcification syndrome	GARD:0002445	Gaucher-like disease	GARD:0012504	Gaucher disease - ophthalmoplegia - cardiovascular calcification	GARD	
-MONDO:0017048	pseudomyxoma peritonei	GARD:0002448	Gelatinous ascites	GARD:0007488	Pseudomyxoma peritonei	GARD	
-MONDO:0019499	Turner syndrome	GARD:0002458	Genital dwarfism	GARD:0002459	Genital dwarfism, Turner type	GARD	
-MONDO:0019499	Turner syndrome	GARD:0002458	Genital dwarfism	GARD:0002540	Gonadal dysgenesis Turner type	GARD	
-MONDO:0019499	Turner syndrome	GARD:0002458	Genital dwarfism	GARD:0007831	Turner syndrome	GARD	
-MONDO:0019499	Turner syndrome	GARD:0002459	Genital dwarfism, Turner type	GARD:0002540	Gonadal dysgenesis Turner type	GARD	
-MONDO:0019499	Turner syndrome	GARD:0002459	Genital dwarfism, Turner type	GARD:0007831	Turner syndrome	GARD	
-MONDO:0024456	anterior segment dysgenesis 3	GARD:0002482	Glaucoma iridogoniodysgenesia	GARD:0002978	Iridogoniodysgenesis type 1	GARD	
-MONDO:0009290	glycogen storage disease II	GARD:0002503	Glucosidase acid-1,4-alpha deficiency	GARD:0005714	Glycogen storage disease type 2	GARD	
-MONDO:0009414	glycogen storage disease due to hepatic glycogen synthase deficiency	GARD:0002513	Glycogen storage disease type 0, liver	GARD:0002889	Hypoglycemia with deficiency of glycogen synthetase in the liver	GARD	
-MONDO:0019499	Turner syndrome	GARD:0002540	Gonadal dysgenesis Turner type	GARD:0007831	Turner syndrome	GARD	
-MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	GARD:0002558	Grand Kaine Fulling syndrome	GARD:0010535	Hereditary vascular retinopathy	GARD	
-MONDO:0009008	heart defect-tongue hamartoma-polysyndactyly syndrome	GARD:0002612	Heart defect, tongue hamartoma and polysyndactyly	GARD:0004166	Orstavik Lindemann Solberg syndrome	GARD	
-MONDO:0009655	Sanfilippo syndrome type A	GARD:0002649	Heparane sulfamidase deficiency	GARD:0007071	Mucopolysaccharidosis type IIIA	GARD	
-MONDO:0042971	congenital herpes virus infection	GARD:0002669	Herpes virus antenatal infection	GARD:0002670	Herpetic embryopathy	GARD	
-MONDO:0009609	methylcobalamin deficiency type cblG	GARD:0002733	Homocystinuria due to defect in methylation cbl g	GARD:0003577	Methylcobalamin deficiency cbl G type	GARD	
-MONDO:0010237	X-linked intellectual disability-plagiocephaly syndrome	GARD:0002765	Hyde Forster Mccarthy Berry syndrome	GARD:0004377	Plagiocephaly and X-linked mental retardation	GARD	
-MONDO:0009383	transient familial neonatal hyperbilirubinemia	GARD:0002791	Hyperbilirubinemia transient familial neonatal	GARD:0003304	Lucey-Driscoll syndrome	GARD	
-MONDO:0009380	Dubin-Johnson syndrome	GARD:0002793	Hyperbilirubinemia type 2	GARD:0006289	Dubin-Johnson syndrome	GARD	
-MONDO:0011236	hyperinsulinism due to glucokinase deficiency	GARD:0002818	Hyperinsulinism due to glucokinase deficiency	GARD:0009930	Hyperinsulinemic hypoglycemia familial 3	GARD	
-MONDO:0008045	spinal muscular atrophy-progressive myoclonic epilepsy syndrome	GARD:0003044	Jankovic Rivera syndrome	GARD:0003875	Myoclonus hereditary progressive distal muscular atrophy	GARD	
-MONDO:0007879	larynx atresia	GARD:0003192	Larynx, congenital partial atresia of	GARD:0003194	Larynx atresia	GARD	
-MONDO:0009591	metachromatic leukodystrophy, juvenile form	GARD:0003230	Metachromatic leukodystrophy	GARD:0004545	Pseudoarylsulfatase A deficiency	GARD	
-MONDO:0010109	tetraamelia with ectodermal dysplasia and lacrimal duct abnormalities	GARD:0003348	Madokoro Ohdo Sonoda syndrome	GARD:0005146	Tetraamelia with ectodermal dysplasia and lacrimal duct abnormalities	GARD	
-MONDO:0015995	melorheostosis with osteopoikilosis	GARD:0003690	Melorheostosis with osteopoikilosis	GARD:0003800	MSBD syndrome	GARD	
-MONDO:0019960	VIPoma	GARD:0003787	WDHA syndrome	GARD:0005493	VIPoma	GARD	
-MONDO:0010148	Mounier-Kuhn syndrome	GARD:0003793	Mounier-Kuhn syndrome	GARD:0005234	Tracheobronchomegaly	GARD	
-MONDO:0008152	multicentric carpo-tarsal osteolysis with or without nephropathy	GARD:0003818	Multicentric osteolysis nephropathy	GARD:0013042	Multicentric carpotarsal osteolysis syndrome	GARD	
-MONDO:0008747	oculocutaneous albinism type 3	GARD:0004039	Oculocutaneous albinism type 3	GARD:0009641	Rufous oculocutaneous albinism	GARD	
-MONDO:0009810	autosomal recessive distal osteolysis syndrome	GARD:0004144	Osteolysis syndrome recessive	GARD:0004299	Petit-Fryns syndrome	GARD	
-MONDO:0011150	acroosteolysis-keloid-like lesions-premature aging syndrome	GARD:0004276	Penttinen-Aula syndrome	GARD:0004498	Progeroid syndrome, Penttinen type	GARD	
-MONDO:0009312	lipodystrophy due to peptidic growth factors deficiency	GARD:0004280	Peptidic growth factors deficiency	GARD:0012604	Lipodystrophy due to peptidic growth factors deficiency	GARD	
-MONDO:0009869	isolated Pierre-Robin syndrome	GARD:0004347	Pierre Robin sequence	GARD:0004354	Pierre Robin syndrome skeletal dysplasia polydactyly	GARD	
-MONDO:0010713	properdin deficiency	GARD:0004513	Properdin deficiency	GARD:0009913	Properdin deficiency, X-linked	GARD	
-MONDO:0017571	Proteus-like syndrome	GARD:0004525	Proteus like syndrome mental retardation eye defect	GARD:0012801	Proteus-like syndrome	GARD	
-MONDO:0017985	congenital radioulnar synostosis	GARD:0004630	Radio-ulnar synostosis type 1	GARD:0010876	Congenital radioulnar synostosis	GARD	
-MONDO:0007124	ankyloblepharon-ectodermal defects-cleft lip/palate syndrome	GARD:0004805	Seres-Santamaria Arimany Muniz syndrome	GARD:0006571	Hay-Wells syndrome	GARD	
-MONDO:0010104	non-eruption of teeth-maxillary hypoplasia-genu valgum syndrome	GARD:0005027	Stoelinga de Koomen Davis syndrome	GARD:0005127	Teeth noneruption of with maxillary hypoplasia and genu valgum	GARD	
-MONDO:0010164	phocomelia, Schinzel type	GARD:0005124	Teebi Naguib Al Awadi syndrome	GARD:0009212	Al-Awadi-Raas-Rothschild syndrome	GARD	
-MONDO:0008592	tricho-dento-osseous syndrome	GARD:0005252	Tricho-dento-osseous syndrome 1	GARD:0007799	Tricho-dento-osseous syndrome	GARD	
-MONDO:0010168	Usher syndrome type 1	GARD:0005435	Usher syndrome, type 1	GARD:0005436	Usher syndrome, type 1B	GARD	
-MONDO:0009411	autoimmune polyendocrine syndrome type 1	GARD:0005558	Whitaker syndrome	GARD:0008466	Autoimmune polyglandular syndrome type 1	GARD	
-MONDO:0008728	classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	GARD:0005757	21-hydroxylase deficiency	GARD:0012665	Classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	GARD	
-MONDO:0015943	eosinophilic granulomatosis with polyangiitis	GARD:0005776	Allergic angiitis	GARD:0006111	Eosinophilic granulomatosis with polyangiitis	GARD	
-MONDO:0010561	Coffin-Lowry syndrome	GARD:0006123	Coffin-Lowry syndrome	GARD:0008589	Coffin syndrome 1	GARD	
-MONDO:0011527	Charcot-Marie-tooth disease type 4E	GARD:0006170	Congenital hypomyelination neuropathy	GARD:0009203	Charcot-Marie-Tooth disease type 4E	GARD	
-MONDO:0009114	congenital sucrase-isomaltase deficiency	GARD:0006183	Congenital sucrose isomaltose malabsorption	GARD:0007710	Congenital sucrase-isomaltase deficiency	GARD	
-MONDO:0016244	atypical hemolytic-uremic syndrome	GARD:0006240	D-minus hemolytic uremic syndrome (D-HUS)	GARD:0008702	Atypical hemolytic uremic syndrome	GARD	
-MONDO:0023073	eosinophilic cryptitis	GARD:0006346	Eosinophilic cryptitis	GARD:0006347	Eosinophilic cystitis	GARD	
-MONDO:0009796	gyrate atrophy	GARD:0006556	Gyrate atrophy of choroid and retina	GARD:0007272	Ornithinemia	GARD	
-MONDO:0008346	pulmonary hemosiderosis	GARD:0006763	Idiopathic pulmonary hemosiderosis	GARD:0007645	Siderosis	GARD	
-MONDO:0000359	spondylocostal dysostosis	GARD:0006798	Spondylothoracic dysostosis	GARD:0010726	Spondylocostal dysostosis 1	GARD	
-MONDO:0000359	spondylocostal dysostosis	GARD:0006798	Spondylothoracic dysostosis	GARD:0012174	Spondylocostal dysostosis	GARD	
-MONDO:0018838	lissencephaly (disease)	GARD:0007300	Pachygyria	GARD:0012291	Lissencephaly	GARD	
-MONDO:0020485	King-Denborough syndrome	GARD:0008433	King Denborough syndrome	GARD:0008561	Kousseff Nichols syndrome	GARD	
-MONDO:0019234	peroxisome biogenesis disorder	GARD:0009473	Peroxisomal biogenesis disorders	GARD:0011890	Peroxisome biogenesis disorder-Zellweger syndrome spectrum	GARD	
-MONDO:0017884	papillary renal cell carcinoma	GARD:0009572	Papillary renal cell carcinoma	GARD:0009575	Chromophil renal cell carcinoma	GARD	
-MONDO:0017858	acute erythroid leukemia	GARD:0009620	Acute erythroid leukemia	GARD:0009750	Di Guglielmo's syndrome	GARD	
-MONDO:0010337	X-linked intellectual disability-cerebellar hypoplasia syndrome	GARD:0009947	Mental retardation x-linked with cerebellar hypoplasia and distinctive facial appearance	GARD:0013093	OPHN1 syndrome	GARD	
-MONDO:0007648	hereditary diffuse gastric adenocarcinoma	GARD:0010334	Diffuse gastric cancer	GARD:0010900	Hereditary diffuse gastric cancer	GARD	
-MONDO:0012435	3-methylglutaconic aciduria type 5	GARD:0010344	3 methylglutaconic aciduria type V	GARD:0012964	DCMA syndrome	GARD	
-MONDO:0000359	spondylocostal dysostosis	GARD:0010726	Spondylocostal dysostosis 1	GARD:0012174	Spondylocostal dysostosis	GARD	
-MONDO:0003582	hereditary breast ovarian cancer syndrome	GARD:0012351	BRCA1 hereditary breast and ovarian cancer syndrome	GARD:0012352	BRCA2 hereditary breast and ovarian cancer syndrome	GARD	
-MONDO:0007390	coumarin resistance	GARD:0012639	Warfarin sensitivity	GARD:0012721	Warfarin resistance	GARD	
-MONDO:0000129	glutaric aciduria (disease)	HP:0003150	Glutaric aciduria	HP:0003530	Glutaric acidemia	HP	
-MONDO:0021645	esophageal varices with bleeding	ICD10:I85.0		ICD10:I85.01		ICD10	
-MONDO:0021644	esophageal varices without bleeding	ICD10:I85.00		ICD10:I85.9		ICD10	
-MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	MEDGEN:358137		MEDGEN:881357		MEDGEN	
-MONDO:0007113	Angelman syndrome	MESH:C531619	Happy puppet syndrome (formerly)	MESH:D017204	Angelman Syndrome	MESH	
-MONDO:0011865	COL4A1-related familial vascular leukoencephalopathy	MESH:C531642	Familial vascular leukoencephalopathy	MESH:C564372	Brain Small Vessel Disease with Hemorrhage	MESH	
-MONDO:0007436	dentin dysplasia type I	MESH:C531665	Opalescent dentin	MESH:C538215	Dentin dysplasia, type 1	MESH	
-MONDO:0016242	hemoglobin c disease	MESH:C531699	Hb C disease	MESH:D006445	Hemoglobin C Disease	MESH	
-MONDO:0016035	Nelson syndrome	MESH:C531754	Ridges-off-the-end syndrome	MESH:D009347	Nelson Syndrome	MESH	
-MONDO:0019234	peroxisome biogenesis disorder	MESH:C531857	Zellweger leukodystrophy	MESH:C536664	Peroxisome biogenesis disorders	MESH	
-MONDO:0019145	hereditary thrombophilia due to congenital protein C deficiency	MESH:C535424	Congenital thrombotic disease, due to Protein C deficiency	MESH:D020151	Protein C Deficiency	MESH	
-MONDO:0011166	lymphedema-atrial septal defects-facial changes syndrome	MESH:C535539	Irons Bhan syndrome	MESH:C567398	Lymphedema, Cardiac Septal Defects, And Characteristic Facies	MESH	
-MONDO:0006235	granular cell tumor	MESH:C535558	Abrikosov's tumor	MESH:D016586	Granular Cell Tumor	MESH	
-MONDO:0009146	ectodermal dysplasia-sensorineural deafness syndrome	MESH:C535757	Congenital ectodermal dysplasia with hearing loss	MESH:C565606	Ectodermal Dysplasia and Neurosensory Deafness	MESH	
-MONDO:0017851	erythrokeratodermia variabilis	MESH:C536154	Keratoderma palmoplantaris transgrediens	MESH:D056266	Erythrokeratodermia Variabilis	MESH	
-MONDO:0009934	congenital alveolar capillary dysplasia	MESH:C536590	Alveolar capillary dysplasia	MESH:D010547	Persistent Fetal Circulation Syndrome	MESH	
-MONDO:0007671	fibronectin glomerulopathy	MESH:C536826	Glomerulopathy with fibronectin deposits	MESH:C562900	Glomerulopathy with Giant Fibrillar Deposits	MESH	
-MONDO:0007250	camptodactyly of fingers	MESH:C536852	Familial streblodactyly	MESH:C567780	Camptodactyly 1	MESH	
-MONDO:0020485	King-Denborough syndrome	MESH:C536883	King Denborough syndrome	MESH:C537504	Kousseff Nichols syndrome	MESH	
-MONDO:0011819	spinocerebellar ataxia type 19/22	MESH:C537198	Spinocerebellar ataxia 19	MESH:C542540	Spinocerebellar ataxia 22	MESH	
-MONDO:0007880	congenital laryngeal web	MESH:C537676	Gay Feinmesser Cohen syndrome	MESH:C563636	Laryngeal Web, Familial	MESH	
-MONDO:0011606	baby rattle pelvis dysplasia	MESH:C537794	Baby rattle pelvic dysplasia	MESH:C565282	Baby Rattle Pelvis Dysplasia	MESH	
-MONDO:0009916	46,XY disorder of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency	MESH:C537805	17-Hydroxysteroid Dehydrogenase Deficiency	MESH:C564868	Polycystic Ovarian Disease due to 17-Ketosteroid Reductase Deficiency	MESH	
-MONDO:0009796	gyrate atrophy	MESH:C538071	Fuchs atrophia gyrata chorioideae et retinae	MESH:D015799	Gyrate Atrophy	MESH	
-MONDO:0009343	Hirschsprung disease with ulnar polydactyly, polysyndactyly of big toes, and ventricular septal defect	MESH:C538120	Hirschsprung disease polydactyly heart disease	MESH:C565517	Hirschsprung Disease with Ulnar Polydactyly, Polysyndactyly of Big Toes, and Ventricular Septal Defect	MESH	
-MONDO:0009504	mitochondrial DNA depletion syndrome 9	MESH:C538134	Lactic acidosis congenital infantile	MESH:C566885	Lactic Acidosis, Fatal Infantile	MESH	
-MONDO:0009952	radioulnar synostosis-developmental delay-hypotonia syndrome	MESH:C538217	Der Kaloustian Mcintosh Silver syndrome	MESH:C564856	Radioulnar Synostosis, Unilateral, with Developmental Retardation and Hypotonia	MESH	
-MONDO:0008772	amelogenesis imperfecta type 2A1	MESH:C538242	Amelogenesis imperfecta pigmented hypomaturation type	MESH:C567146	Amelogenesis Imperfecta, Hypomaturation Type, Iia1	MESH	
-MONDO:0007920	Meige disease	MESH:C562467	Lymphedema, Hereditary, II	MESH:D008538	Meige Syndrome	MESH	
-MONDO:0002422	adamantinoma	MESH:C562741	Adamantinoma Of Long Bones	MESH:D050398	Adamantinoma	MESH	
-MONDO:0016575	primary ciliary dyskinesia	MESH:D002925	Ciliary Motility Disorders	MESH:D007619	Kartagener Syndrome	MESH	
-MONDO:0004849	pulmonary emphysema	MESH:D004646	Emphysema	MESH:D011656	Pulmonary Emphysema	MESH	
-MONDO:0019136	Zygomycosis	MESH:D009091	Mucormycosis	MESH:D020096	Zygomycosis	MESH	
-MONDO:0000989	mumps infectious disease	MESH:D009107	Mumps	MESH:D019351	Rubulavirus Infections	MESH	
-MONDO:0021545	myomatous neoplasm	MESH:D009379	Neoplasms, Muscle Tissue	MESH:D019042	Muscle Neoplasms	MESH	
-MONDO:0001561	pyloric stenosis (disease)	MESH:D011707	Pyloric Stenosis	MESH:D017219	Gastric Outlet Obstruction	MESH	
-MONDO:0008501	Sturge-Weber syndrome	UMLS:C0038505		UMLS:CN204001	Sturge-Weber-Krabbe syndrome	UMLS	
-MONDO:0010684	X-linked myopathy with excessive autophagy	UMLS:C1839615	X-linked myopathy with excessive autophagy	UMLS:C2931230	Vacuolar myopathy	UMLS	
-MONDO:0006271	low grade central osteosarcoma	UMLS:C1266163	Intraosseous well differentiated osteosarcoma	UMLS:C3814534	Low grade central osteosarcoma	UMLS	
-MONDO:0012643	hereditary spastic paraplegia 32	UMLS:C1970009	SPG32	UMLS:C4511958	Autosomal recessive spastic paraplegia type 32	UMLS	
-MONDO:0001444	Chagas disease	UMLS:C0153125	Chagas' disease with other organ involvement	UMLS:C0348781	Chagas' disease with digestive system involvement	UMLS	
-MONDO:0001444	Chagas disease	UMLS:C0153125	Chagas' disease with other organ involvement	UMLS:C0348782	Chagas' disease with nervous system involvement	UMLS	
-MONDO:0008557	Paris-Trousseau thrombocytopenia	UMLS:C1861178	THROMBOCYTOPENIA, PARIS-TROUSSEAU TYPE	UMLS:C1956093	Paris-Trousseau Thrombocytopenia	UMLS	
-MONDO:0002056	breast fibroadenoma	UMLS:C0206650	Fibroadenoma	UMLS:C0346158	Juvenile fibroadenoma	UMLS	
-MONDO:0008798	nonsyndromic congenital nail disorder 4	DOID:0050643	anonychia congenita	DOID:0080082	nonsyndromic congenital nail disorder 4	DOID	
-MONDO:0013892	C3 glomerulonephritis	UMLS:C3553720	C3 glomerulonephritis	UMLS:C4055342	C3 Glomerulonephritis	UMLS	
-MONDO:0013892	C3 glomerulonephritis	UMLS:C3553720	C3 glomerulonephritis	UMLS:CN187045		UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS	
-MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS	
-MONDO:0005402	lymphoid leukemia (disease)	UMLS:C0023448	Lymphoid leukemia	UMLS:C0152271	Subacute lymphoid leukemia	UMLS	
-MONDO:0010006	Sandhoff disease	GARD:0002521	GM2 gangliosidosis, 0 variant	GARD:0007604	Sandhoff disease	GARD	
-MONDO:0019005	nephronophthisis (disease)	UMLS:C0687120	Nephronophthisis	UMLS:C2939174	Medullary cystic disease	UMLS	
-MONDO:0015564	Castleman disease	UMLS:C2931179	Angiofollicular ganglionic hyperplasia	UMLS:CN199886	Angiofollicular lymph hyperplasia	UMLS	
-MONDO:0013273	chromosome 16p13.3 duplication syndrome	UMLS:C3150708	Trisomy 16pter	UMLS:C4518796	16p13.3 microduplication syndrome	UMLS	
-MONDO:0010561	Coffin-Lowry syndrome	MESH:C536435	Coffin syndrome 1	MESH:D038921	Coffin-Lowry Syndrome	MESH	
-MONDO:0002578	botryoid rhabdomyosarcoma	UMLS:C1306573	Botryoid-Type Embryonal Rhabdomyosarcoma	UMLS:C1306574	Botryoid rhabdomyosarcoma	UMLS	
-MONDO:0014746	SLC39A8-CDG	UMLS:C4225234	CDG2N	UMLS:CN234734	SLC39A8 deficiency	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS	
-MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS	
-MONDO:0017185	autosomal dominant hyperinsulinism due to Kir6.2 deficiency	UMLS:C4274081	Autosomal dominant hyperinsulinism due to Kir6.2 deficiency	UMLS:CN202626	Dominant KATP hyperinsulinism due to Kir6.2 deficiency	UMLS	
-MONDO:0008171	nephrolithiasis	UMLS:C0156257	Calculus of kidney and ureter	UMLS:C0392525	Nephrolithiasis	UMLS	
-MONDO:0008171	nephrolithiasis	UMLS:C0156257	Calculus of kidney and ureter	UMLS:C1833683	Nephrolithiasis, calcium oxalate	UMLS	
-MONDO:0018263	fetal carbamazepine syndrome	UMLS:C0432370	Fetal carbamazepine syndrome	UMLS:CN204839	Fetal carbamazepine syndrome	UMLS	
-MONDO:0001926	ureteral disease	UMLS:C0041954	Ureteral Diseases	UMLS:C0403608	Disorder of ureter	UMLS	
-MONDO:0008974	Greenberg dysplasia	UMLS:C2931048	HEM dysplasia	UMLS:CN199524	HEM dysplasia	UMLS	
-MONDO:0015564	Castleman disease	UMLS:C0017531	Angiolymphoid hyperplasia	UMLS:CN199886	Angiofollicular lymph hyperplasia	UMLS	
-MONDO:0015564	Castleman disease	UMLS:C0017531	Angiolymphoid hyperplasia	UMLS:C2931179	Angiofollicular ganglionic hyperplasia	UMLS	
-MONDO:0018988	iridocorneal endothelial syndrome	UMLS:C1096100		UMLS:CN205427	ICE syndrome	UMLS	
-MONDO:0014475	spinocerebellar ataxia type 40	UMLS:CN219009		UMLS:CN237494	SCA40	UMLS	
-MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	GARD:0001217	Retinal vasculopathy with cerebral leukodystrophy	GARD:0002558	Grand Kaine Fulling syndrome	GARD	
-MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	GARD:0001217	Retinal vasculopathy with cerebral leukodystrophy	GARD:0010535	Hereditary vascular retinopathy	GARD	
-MONDO:0010225	Dent disease type 1	UMLS:C4305530	Dent disease type 1	UMLS:CN206679	Nephrolithiasis type 1	UMLS	
-MONDO:0000107	auriculocondylar syndrome	UMLS:C1865295	Auriculo-condylar syndrome	UMLS:CN160484	Question mark ear syndrome	UMLS	
-MONDO:0007078	Albright hereditary osteodystrophy	GARD:0005770	Albright's hereditary osteodystrophy	GARD:0007486	Pseudohypoparathyroidism type 1A	GARD	
-MONDO:0004114	urinary bladder small cell neuroendocrine carcinoma	UMLS:C1332564	Small cell neuroendocrine carcinoma of bladder	UMLS:CN202866	Small cell carcinoma of the urinary bladder	UMLS	
-MONDO:0017762	disorder of copper metabolism	UMLS:C0012714	Disorder of copper metabolism	UMLS:CN043585	Copper Transport Disorders	UMLS	
-MONDO:0012885	SRD5A3-CDG	UMLS:C3150191	CDG syndrome type Iq	UMLS:C4317224	Congenital disorder of glycosylation type 1q	UMLS	
-MONDO:0012740	chromosome 22q11.2 deletion syndrome, distal	UMLS:C2678480	Distal monosomy 22q11.2	UMLS:C4518343	Distal 22q11.2 microdeletion syndrome	UMLS	
-MONDO:0008219	pemphigus vulgaris	GARD:0004270	Familial pemphigus vulgaris	GARD:0007355	Pemphigus vulgaris	GARD	
-MONDO:0015826	autosomal dominant spondylocostal dysostosis	UMLS:C4274761	Autosomal dominant spondylocostal dysostosis	UMLS:CN200437	Autosomal dominant spondylocostal dysplasia	UMLS	
-MONDO:0015406	cerebrofacial arteriovenous metameric syndrome type 1	UMLS:C3840102	Cerebrofacial arteriovenous metameric syndrome type 1	UMLS:CN199501	CAMS1	UMLS	
 
+MONDO:0000107	auriculocondylar syndrome	UMLS:C1865295	Auriculo-condylar syndrome	UMLS:CN160484	Question mark ear syndrome	UMLS		live		live	
+MONDO:0000129	glutaric aciduria (disease)	HP:0003150	Glutaric aciduria	HP:0003530	Glutaric acidemia	HP		live		live	
+MONDO:0000166	encephalopathy, acute, infection-induced	OMIMPS:601551		OMIMPS:610551	Encephalopathy, acute, infection-induced	OMIMPS		not_present		live	
+MONDO:0000181	microcephaly and chorioretinopathy	OMIMPS:251270	Microcephaly and chorioretinopathy	OMIMPS:251279		OMIMPS		live		not_present	
+MONDO:0000261	adenoiditis	UMLS:C0001427	Adenoiditis	UMLS:C0396023	Chronic adenoiditis	UMLS		live		live	
+MONDO:0000265	aspiration pneumonia (disease)	UMLS:C0032290	Aspiration pneumonia	UMLS:C0085740	Mendelson Syndrome	UMLS		live		live	
+MONDO:0000276	Powassan encephalitis	UMLS:C0032858	Powassan encephalitis	UMLS:C1563215	Powassan encephalitis virus infection	UMLS		live		live	
+MONDO:0000290	primary amebic meningoencephalitis	UMLS:C0300934	Primary Amebic Meningoencephalitis	UMLS:C4303098	Naegleria fowleri infection	UMLS		live		live	
+MONDO:0000294	mesocestoidiasis	UMLS:C0277108	Infection by Mesocestoides	UMLS:C0277110	Infection by Mesocestoides lineatus	UMLS		live		live	
+MONDO:0000297	baylisascariasis	UMLS:C0162626	Infections, Ascaridida	UMLS:C0277150	Infection by Baylisascaris	UMLS		live		live	
+MONDO:0000304	penicilliosis	SCTID:372936000	infection caused by penicillium marneffei (disorder)	SCTID:713315007	disseminated infection caused by penicillium marneffei (disorder)	SCTID		live		live	
+MONDO:0000337	exanthema subitum	UMLS:C0015231	Exanthema subitum	UMLS:C0595993	Roseola Infantum	UMLS		live		live	
+MONDO:0000359	spondylocostal dysostosis	GARD:0006798	Spondylothoracic dysostosis	GARD:0010726	Spondylocostal dysostosis 1	GARD		live		live	
+MONDO:0000359	spondylocostal dysostosis	GARD:0006798	Spondylothoracic dysostosis	GARD:0012174	Spondylocostal dysostosis	GARD		live		live	
+MONDO:0000359	spondylocostal dysostosis	GARD:0010726	Spondylocostal dysostosis 1	GARD:0012174	Spondylocostal dysostosis	GARD		live		live	
+MONDO:0000365	primary congenital glaucoma (disease)	UMLS:C1533041	Primary congenital glaucoma	UMLS:C3888011	GLAUCOMA 3, PRIMARY CONGENITAL, C	UMLS		live		live	
+MONDO:0000408	fetal alcohol spectrum disorder	UMLS:C2985290	Fetal Alcohol Spectrum Disorder	UMLS:CN200663	Fetal alcohol spectrum disorders	UMLS		live		live	
+MONDO:0000425	X-linked disease	UMLS:C1138434	X-Linked Genetic Diseases	UMLS:C2828000	X-Linked Inherited Disorder	UMLS		live		live	
+MONDO:0000430	mature T-cell and NK-cell non-Hodgkin lymphoma	DOID:0050743	mature T-cell and NK-cell lymphoma	DOID:0050749	peripheral T-cell lymphoma	DOID		live		live	
+MONDO:0000467	second-degree atrioventricular block	UMLS:C0264906	Second degree atrioventricular block	UMLS:C1621824	Incomplete atrioventricular block	UMLS		live		live	
+MONDO:0000471	tricuspid valve disease	UMLS:C0264776	Rheumatic disease of tricuspid valve	UMLS:C0264882	Tricuspid valve disorder	UMLS		live		live	
+MONDO:0000497	pyometritis	UMLS:C0034215	Pyometra	UMLS:C0686163	Pyometritis	UMLS		live		live	
+MONDO:0000503	lung adenocarcinoma in situ	NCIT:C136486	Lung Adenocarcinoma In Situ	NCIT:C8748	Stage 0 Adenosquamous Lung Carcinoma AJCC v6 and v7	NCIT		live		live	
+MONDO:0000554	endocervical adenocarcinoma	UMLS:C1263762	Endocervical adenocarcinoma	UMLS:C4289591	Endocervical Adenocarcinoma, Usual Type	UMLS		live		live	
+MONDO:0000651	thoracic disease	SCTID:118946009	disorder of thorax (disorder)	SCTID:609622007	disorder of thoracic segment of trunk (disorder)	SCTID		live		live	
+MONDO:0000651	thoracic disease	UMLS:C0039978	Thoracic Disease	UMLS:C3661979	Disorder of thoracic segment of trunk	UMLS		live		live	
+MONDO:0000728	ptosis (disease)	UMLS:C0005745	Blepharoptosis	UMLS:C0033377	Ptosis	UMLS		live		live	
+MONDO:0000736	dyschromatosis universalis hereditaria	UMLS:C1306229	Dyschromatosis universalis	UMLS:C2930995	Dyschromatosis universalis hereditaria	UMLS		live		live	
+MONDO:0000741	angular cheilitis	UMLS:C0221237	Angular cheilitis	UMLS:C0221264	Cheilosis	UMLS		live		live	
+MONDO:0000745	cardiac arrest	UMLS:C0018790	Cardiac arrest	UMLS:C0444720	Circulatory arrest	UMLS		live		live	
+MONDO:0000751	cervical polyp (disease)	UMLS:C0007855	Cervical polyp	UMLS:C0347493	Adenomatous polyp of cervix	UMLS		live		live	
+MONDO:0000774	autoimmune neuropathy	DOID:0040087	autoimmune peripheral neuropathy	DOID:0060499	autoimmune neuropathy	DOID		live		live	
+MONDO:0000902	agenesis of the corpus callosum with peripheral neuropathy	DOID:0060600	hereditary motor and sensory neuropathy with agenesis of the corpus callosum	DOID:0090003	agenesis of the corpus callosum with peripheral neuropathy	DOID		deprecated		live	
+MONDO:0000916	intestinal infectious disease	UMLS:C0152516	Bacterial enteritis	UMLS:C0178238	Intestinal infectious disease	UMLS		live		live	
+MONDO:0000948	xerophthalmia	UMLS:C0043349	Xerophthalmia	UMLS:C3665609	Conjunctival xerosis	UMLS		live		live	
+MONDO:0000960	diabetic peripheral angiopathy	DOID:10182	diabetic peripheral angiopathy	DOID:11713	diabetic angiopathy	DOID		live		live	
+MONDO:0000960	diabetic peripheral angiopathy	UMLS:C0011871	Diabetic peripheral angiopathy	UMLS:C0011875	Diabetic Angiopathy	UMLS		live		live	
+MONDO:0000989	mumps infectious disease	MESH:D009107	Mumps	MESH:D019351	Rubulavirus Infections	MESH		live		live	
+MONDO:0001039	tonsillitis	UMLS:C0040425	Tonsillitis	UMLS:C0149517	Chronic tonsillitis	UMLS		live		live	
+MONDO:0001040	nasopharyngitis	UMLS:C0027441	Nasopharyngitis	UMLS:C0155826	Chronic nasopharyngitis	UMLS		live		live	
+MONDO:0001066	late yaws	UMLS:C0276007	Gummatous frambeside	UMLS:C1517744	Late Yaws	UMLS		live		live	
+MONDO:0001085	interstitial nephritis	UMLS:C0027707	IN - Interstitial nephritis	UMLS:C0041349	Tubulointerstitial nephritis	UMLS		live		live	
+MONDO:0001106	kidney failure	UMLS:C0035078	Kidney Failure	UMLS:C1565489	Renal insufficiency	UMLS		live		live	
+MONDO:0001114	bacterial myocarditis	UMLS:C0155690	Septic myocarditis	UMLS:C1384588	Bacterial myocarditis	UMLS		live		live	
+MONDO:0001147	meningocele (disease)	NCIT:C101209	Spinal Meningocele	NCIT:C105595	Meningocele	NCIT		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156042	Acute gastrojejunal ulcer with hemorrhage	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156044	Acute gastrojejunal ulcer with hemorrhage AND obstruction	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156045	Acute gastrojejunal ulcer with perforation	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156047	Acute gastrojejunal ulcer with perforation AND obstruction	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS		live		live	
+MONDO:0001155	gastrojejunal ulcer	UMLS:C0156048	Acute gastrojejunal ulcer with hemorrhage AND perforation	UMLS:C0156050	Acute gastrojejunal ulcer with hemorrhage, with perforation AND with obstruction	UMLS		live		live	
+MONDO:0001175	immature cataract	UMLS:C0271163	Incipient cataract	UMLS:C2939157	Incipient senile cataract	UMLS		live		live	
+MONDO:0001175	immature cataract	UMLS:C0271163	Incipient cataract	UMLS:C2960113	Immature cataract	UMLS		live		live	
+MONDO:0001175	immature cataract	UMLS:C2939157	Incipient senile cataract	UMLS:C2960113	Immature cataract	UMLS		live		live	
+MONDO:0001243	disseminated intravascular coagulation	UMLS:C0012739	Disseminated intravascular coagulation	UMLS:C4321305	Consumptive Coagulopathy	UMLS		live		live	
+MONDO:0001244	vitamin K deficiency hemorrhagic disease	UMLS:C0042880	Vitamin K deficiency	UMLS:C0272348	Vitamin K deficiency coagulation disorder	UMLS		live		live	
+MONDO:0001246	typhus	UMLS:C0041471	Typhus	UMLS:C0041472	Endemic Flea-Borne Typhus	UMLS		live		live	
+MONDO:0001260	cercarial dermatitis	UMLS:C0546996	Cutaneous schistosomiasis	UMLS:C4282208	Cercarial Dermatitis	UMLS		live		live	
+MONDO:0001268	gingival recession	UMLS:C0017572	Gingival recession	UMLS:C0266916	Localized gingival recession	UMLS		live		live	
+MONDO:0001280	choroiditis	UMLS:C0008526	Choroiditis	UMLS:C0042167	Posterior uveitis	UMLS		live		live	
+MONDO:0001292	autonomic nervous system disease	SCTID:128123007	disorder of peripheral autonomic nervous system (disorder)	SCTID:15241006	disorder of autonomic nervous system (disorder)	SCTID		live		live	
+MONDO:0001300	autonomic neuropathy	DOID:0060054	autonomic peripheral neuropathy	DOID:11504	autonomic neuropathy	DOID		live		live	
+MONDO:0001318	functional gastric disease	SCTID:150541000119104	functional disorder of gastrointestinal tract (disorder)	SCTID:386211005	disorder of function of stomach (disorder)	SCTID		live		live	
+MONDO:0001333	Patau syndrome	UMLS:C0152095	Patau syndrome	UMLS:CN204386	Patau syndrome	UMLS		live		live	
+MONDO:0001341	selective IgA deficiency disease	DOID:0060025	immunoglobulin alpha deficiency	DOID:11701	selective IgA deficiency disease	DOID		live		live	
+MONDO:0001341	selective IgA deficiency disease	UMLS:C0162538	IgA deficiency	UMLS:C4049006	Selective immunoglobulin A deficiency	UMLS		live		live	
+MONDO:0001409	esophagitis (disease)	UMLS:C0014868	Esophagitis	UMLS:C0149882	Acute esophagitis	UMLS		live		live	
+MONDO:0001410	postmenopausal atrophic vaginitis	UMLS:C0156409	Postmenopausal atrophic vaginitis	UMLS:C0221392	Atrophic vaginitis	UMLS		live		live	
+MONDO:0001444	Chagas disease	UMLS:C0041234	Chagas' disease	UMLS:C0153125	Chagas' disease with other organ involvement	UMLS		live		live	
+MONDO:0001444	Chagas disease	UMLS:C0041234	Chagas' disease	UMLS:C0348781	Chagas' disease with digestive system involvement	UMLS		live		live	
+MONDO:0001444	Chagas disease	UMLS:C0041234	Chagas' disease	UMLS:C0348782	Chagas' disease with nervous system involvement	UMLS		live		live	
+MONDO:0001444	Chagas disease	UMLS:C0153125	Chagas' disease with other organ involvement	UMLS:C0348781	Chagas' disease with digestive system involvement	UMLS		live		live	
+MONDO:0001444	Chagas disease	UMLS:C0153125	Chagas' disease with other organ involvement	UMLS:C0348782	Chagas' disease with nervous system involvement	UMLS		live		live	
+MONDO:0001444	Chagas disease	UMLS:C0348781	Chagas' disease with digestive system involvement	UMLS:C0348782	Chagas' disease with nervous system involvement	UMLS		live		live	
+MONDO:0001452	pseudoretinitis pigmentosa	UMLS:C0154858	Secondary pigmentary retinal degeneration	UMLS:C2053820	Pseudoretinitis pigmentosa	UMLS		live		live	
+MONDO:0001461	tinea corporis	UMLS:C0040252	Tinea corporis	UMLS:C0546826	Dermatophytosis of the body	UMLS		live		live	
+MONDO:0001495	hematocele of tunica vaginalis testis	UMLS:C0018931	Hematocele of tunica vaginalis testis	UMLS:C1456400	Hematocele	UMLS		live		live	
+MONDO:0001557	olecranon bursitis	UMLS:C0263962	Olecranon bursitis	UMLS:C3887895	Bursitis of elbow	UMLS		live		live	
+MONDO:0001561	pyloric stenosis (disease)	DOID:12639	pyloric stenosis	DOID:3122	gastric outlet obstruction	DOID		live		live	
+MONDO:0001561	pyloric stenosis (disease)	MESH:D011707	Pyloric Stenosis	MESH:D017219	Gastric Outlet Obstruction	MESH		live		live	
+MONDO:0001600	mucocele of salivary gland	UMLS:C0026686	Mucocele of salivary gland	UMLS:C2242813	Ranula	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157691	Cellulitis and abscess of finger	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157696	Cellulitis and abscess of face	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0040261	Onychomycosis	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157691	Cellulitis and abscess of finger	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157696	Cellulitis and abscess of face	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157690	Cellulitis and abscess of finger and toe	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C0157696	Cellulitis and abscess of face	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157691	Cellulitis and abscess of finger	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157696	Cellulitis and abscess of face	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157696	Cellulitis and abscess of face	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157696	Cellulitis and abscess of face	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157698	Cellulitis and abscess of trunk	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS		live		live	
+MONDO:0001628	tinea unguium	UMLS:C0157701	Cellulitis and abscess of buttock	UMLS:C4082762	Onychomycosis due to dermatophyte	UMLS		live		live	
+MONDO:0001703	color vision disorder	UMLS:C0009398	Color vision defects	UMLS:C0242225	Color blindness	UMLS		live		live	
+MONDO:0001703	color vision disorder	UMLS:C0009398	Color vision defects	UMLS:CN207064	Color-vision disease	UMLS		live		live	
+MONDO:0001703	color vision disorder	UMLS:C0242225	Color blindness	UMLS:CN207064	Color-vision disease	UMLS		live		live	
+MONDO:0001713	inherited aplastic anemia	UMLS:C0702159	Constitutional aplastic anemia	UMLS:C0949116	Congenital hypoplastic anemia	UMLS		live		live	
+MONDO:0001720	gonococcal synovitis	UMLS:C0275662	Gonococcal synovitis	UMLS:C0343714	Gonococcal synovitis or tenosynovitis	UMLS		live		live	
+MONDO:0001748	maxillary sinus carcinoma	NCIT:C3540	Malignant Maxillary Sinus Neoplasm	NCIT:C9332	Maxillary Sinus Carcinoma	NCIT		live		live	
+MONDO:0001754	eclampsia	UMLS:C0013537	Eclampsia	UMLS:C0156678	Eclampsia in puerperium	UMLS		live		live	
+MONDO:0001834	visual pathway disease	SCTID:54767005	disorder of visual pathways (disorder)	SCTID:95776004	disorder of optic tract (disorder)	SCTID		live		live	
+MONDO:0001874	toxic labyrinthitis	SCTID:3344003	toxic labyrinthitis (disorder)	SCTID:9062008	ototoxicity (disorder)	SCTID		live		live	
+MONDO:0001881	toxic shock syndrome	UMLS:C0600327	Toxic shock syndrome	UMLS:CN204669	Bacterial TSS	UMLS		live		live	
+MONDO:0001921	chronic atticoantral disease	UMLS:C0155441	Chronic suppurative otitis media - atticoantral	UMLS:C0565831	Chronic atticoantral disease	UMLS		live		live	
+MONDO:0001926	ureteral disease	UMLS:C0041954	Ureteral Diseases	UMLS:C0403608	Disorder of ureter	UMLS		live		live	
+MONDO:0001984	candidal paronychia	UMLS:C0006842	Candidiasis of skin and nails	UMLS:C1282977	Candidal paronychia	UMLS		live		live	
+MONDO:0002008	labyrinthitis	DOID:1468	labyrinthitis	DOID:3930	otitis interna	DOID		live		live	
+MONDO:0002012	methylmalonic acidemia	UMLS:C0268583	Methylmalonic acidemia	UMLS:C1855119	Methylmalonic aciduria	UMLS		live		live	
+MONDO:0002038	head and neck carcinoma	UMLS:C1334927	Carcinoma of the Neck	UMLS:C3887461	Carcinoma of the Head and Neck	UMLS		live		live	
+MONDO:0002049	thrombocytopenia	UMLS:C0040034	Thrombocytopenia	UMLS:CN130080	Thrombocytopenia	UMLS		live		live	
+MONDO:0002052	lymphadenitis (disease)	UMLS:C0024205	Lymphadenitis	UMLS:C0154304	Chronic lymphadenitis	UMLS		live		live	
+MONDO:0002052	lymphadenitis (disease)	UMLS:C0024205	Lymphadenitis	UMLS:C0157705	Acute lymphadenitis	UMLS		live		live	
+MONDO:0002052	lymphadenitis (disease)	UMLS:C0154304	Chronic lymphadenitis	UMLS:C0157705	Acute lymphadenitis	UMLS		live		live	
+MONDO:0002056	breast fibroadenoma	UMLS:C0178421	Fibroadenoma of breast	UMLS:C0206650	Fibroadenoma	UMLS		live		live	
+MONDO:0002056	breast fibroadenoma	UMLS:C0178421	Fibroadenoma of breast	UMLS:C0346158	Juvenile fibroadenoma	UMLS		live		live	
+MONDO:0002056	breast fibroadenoma	UMLS:C0206650	Fibroadenoma	UMLS:C0346158	Juvenile fibroadenoma	UMLS		live		live	
+MONDO:0002073	malignant pineal area germ cell neoplasm	UMLS:C0349621	Pineal germ cell tumor	UMLS:C1334612	Malignant Pineal Region Germ Cell Tumor	UMLS		live		live	
+MONDO:0002100	cardiovascular cancer	UMLS:C0497243	Cardiovascular Neoplasm	UMLS:C3898472	Malignant Cardiovascular Neoplasm	UMLS		live		live	
+MONDO:0002142	undifferentiated pleomorphic sarcoma	NCIT:C114541	Adult Undifferentiated Pleomorphic Sarcoma	NCIT:C4247	Undifferentiated Pleomorphic Sarcoma	NCIT		live		live	
+MONDO:0002158	fallopian tube cancer	UMLS:C0153579	Neoplasm, Fallopian Tube, Malignant	UMLS:CN200469	Tubal cancer	UMLS		live		live	
+MONDO:0002181	exostosis	SCTID:235231000119100	osteophyte of bone (disorder)	SCTID:416189003	exostosis (disorder)	SCTID		live		live	
+MONDO:0002181	exostosis	UMLS:C1442903	Exostosis	UMLS:C1956089	Osteophyte	UMLS		live		live	
+MONDO:0002204	transient arthritis	UMLS:C0152083	Transient arthropathy	UMLS:C3887596	Transient arthritis	UMLS		live		live	
+MONDO:0002277	arteriosclerosis disorder	DOID:2348	arteriosclerotic cardiovascular disease	DOID:2349	arteriosclerosis	DOID		live		live	
+MONDO:0002277	arteriosclerosis disorder	NCIT:C34398	Arteriosclerosis	NCIT:C34403	Arteriosclerotic Cardiovascular Disease	NCIT		live		live	
+MONDO:0002277	arteriosclerosis disorder	UMLS:C0003850	Arteriosclerosis	UMLS:C3665365	Arteriosclerotic Cardiovascular Disease	UMLS		live		live	
+MONDO:0002286	renal artery disease	UMLS:C0268790	Renal vascular disorder	UMLS:C3640053	Renal Artery Disease	UMLS		live		live	
+MONDO:0002334	hematopoietic and lymphoid system neoplasm	UMLS:C0376544	Hematopoietic neoplasm	UMLS:C0376545	Hematologic neoplasm	UMLS		live		live	
+MONDO:0002334	hematopoietic and lymphoid system neoplasm	UMLS:C0376544	Hematopoietic neoplasm	UMLS:C1512393	Hematopoietic and Lymphoid System Neoplasm	UMLS		live		live	
+MONDO:0002334	hematopoietic and lymphoid system neoplasm	UMLS:C0376545	Hematologic neoplasm	UMLS:C1512393	Hematopoietic and Lymphoid System Neoplasm	UMLS		live		live	
+MONDO:0002350	familial nephrotic syndrome	UMLS:C3501848	Nephrosis, congenital	UMLS:CN043611		UMLS		live		not_present	
+MONDO:0002378	dermoid cyst	UMLS:C0011649	Dermoid cyst	UMLS:C2355625	Dermoid choristoma	UMLS		live		live	
+MONDO:0002378	dermoid cyst	UMLS:C0011649	Dermoid cyst	UMLS:C2700593	Cystic dermoid choristoma	UMLS		live		live	
+MONDO:0002378	dermoid cyst	UMLS:C2355625	Dermoid choristoma	UMLS:C2700593	Cystic dermoid choristoma	UMLS		live		live	
+MONDO:0002380	myoepithelial tumor	UMLS:C0027070	Myoepithelioma	UMLS:C1947949	Benign myoepithelioma	UMLS		live		live	
+MONDO:0002412	glycogen storage disease	DOID:0050728	glycogen metabolism disorder	DOID:2747	glycogen storage disease	DOID		live		live	
+MONDO:0002422	adamantinoma	DOID:2775	long bone adamantinoma	DOID:2776	adamantinoma	DOID		live		live	
+MONDO:0002422	adamantinoma	MESH:C562741	Adamantinoma Of Long Bones	MESH:D050398	Adamantinoma	MESH		live		live	
+MONDO:0002422	adamantinoma	UMLS:C0334556	Adamantinoma of long bone	UMLS:C1367554	Adamantinoma of long bones	UMLS		live		live	
+MONDO:0002512	papillary adenocarcinoma	UMLS:C0001420	Papillary adenocarcinoma	UMLS:C1321863	Infiltrating papillary adenocarcinoma	UMLS		live		live	
+MONDO:0002519	anus disease	UMLS:C0003462	Diseases, Anus	UMLS:C0016167	Anal fissure	UMLS		live		live	
+MONDO:0002519	anus disease	UMLS:C0003462	Diseases, Anus	UMLS:C1301262	Disorder of anal region	UMLS		live		live	
+MONDO:0002519	anus disease	UMLS:C0016167	Anal fissure	UMLS:C1301262	Disorder of anal region	UMLS		live		live	
+MONDO:0002520	acute hepatic porphyria	UMLS:C0162533	Hepatic porphyria	UMLS:CN552491	Acute Porphyria	UMLS		live		live	
+MONDO:0002546	schwannoma	UMLS:C0027809	Neurilemoma	UMLS:CN202001	Peripheral fibroblastoma	UMLS		live		live	
+MONDO:0002561	lysosomal storage disease	UMLS:C0085078	Lysosomal Storage Disease	UMLS:CN205533	Lysosomal disease	UMLS		live		live	
+MONDO:0002578	botryoid rhabdomyosarcoma	UMLS:C1306573	Botryoid-Type Embryonal Rhabdomyosarcoma	UMLS:C1306574	Botryoid rhabdomyosarcoma	UMLS		live		live	
+MONDO:0002691	liver cancer	UMLS:C0024620	Primary malignant neoplasm of liver	UMLS:C0345904	Malignant neoplasm of liver	UMLS		live		live	
+MONDO:0002691	liver cancer	UMLS:C0024620	Primary malignant neoplasm of liver	UMLS:C0854795	Resectable Malignant Neoplasm of Liver	UMLS		live		live	
+MONDO:0002691	liver cancer	UMLS:C0345904	Malignant neoplasm of liver	UMLS:C0854795	Resectable Malignant Neoplasm of Liver	UMLS		live		live	
+MONDO:0002722	olfactory nerve neoplasm	DOID:366	olfactory nerve neoplasm	DOID:8256	olfactory neural tumor	DOID		live		live	
+MONDO:0002738	acute transudative otitis media	UMLS:C0271432	Acute transudative otitis media	UMLS:C2939185	Acute otitis media with effusion	UMLS		live		live	
+MONDO:0002794	adult medulloblastoma	UMLS:C0278876	Adult Medulloblastoma	UMLS:C1332188	Adult Brain Medulloblastoma	UMLS		live		live	
+MONDO:0002863	rhabdomyosarcoma with mixed embryonal and alveolar features	UMLS:C0334481	Mixed type rhabdomyosarcoma	UMLS:C1709053	Rhabdomyosarcoma with Mixed Embryonal and Alveolar Features	UMLS		live		live	
+MONDO:0002876	cervical adenosarcoma	UMLS:C1516426	Cervical Adenosarcoma	UMLS:CN201069	Cervical adenosarcoma	UMLS		live		live	
+MONDO:0002877	cervical carcinosarcoma	UMLS:C1332917	Cervical Carcinosarcoma	UMLS:C1516420	Cervical Mixed Epithelial and Mesenchymal Neoplasm	UMLS		live		live	
+MONDO:0002877	cervical carcinosarcoma	UMLS:C1332917	Cervical Carcinosarcoma	UMLS:CN201068	Malignant Müllerian mixed tumor of the cervix uteri	UMLS		live		live	
+MONDO:0002877	cervical carcinosarcoma	UMLS:C1516420	Cervical Mixed Epithelial and Mesenchymal Neoplasm	UMLS:CN201068	Malignant Müllerian mixed tumor of the cervix uteri	UMLS		live		live	
+MONDO:0002885	erythrasma	UMLS:C0014752	Erythrasma	UMLS:C2364003	Infection due to Corynebacterium minutissimum	UMLS		live		live	
+MONDO:0002896	primary syphilis	UMLS:C0153139	Early symptomatic syphilis	UMLS:C2931317	Primary syphilis	UMLS		live		live	
+MONDO:0002897	secondary syphilis	UMLS:C0149985	Secondary syphilis	UMLS:C0343676	Secondary syphilis of viscera or bone	UMLS		live		live	
+MONDO:0002917	disease of pilosebaceous unit	UMLS:C0018500	Hair Disease	UMLS:C0554472	Hair and hair follicle diseases	UMLS		live		live	
+MONDO:0002928	carcinosarcoma	UMLS:C0007140	Carcinosarcoma	UMLS:C0206627	Mullerian mixed tumor	UMLS		live		live	
+MONDO:0002928	carcinosarcoma	UMLS:C0007140	Carcinosarcoma	UMLS:C1334603	Malignant Mixed Mesodermal (Mullerian) Tumor	UMLS		live		live	
+MONDO:0002928	carcinosarcoma	UMLS:C0206627	Mullerian mixed tumor	UMLS:C1334603	Malignant Mixed Mesodermal (Mullerian) Tumor	UMLS		live		live	
+MONDO:0002967	dermatophytosis of scalp or beard	UMLS:C0011640	Dermatophytosis of scalp or beard	UMLS:C1274426	Tinea capitis due to Trichophyton rubrum	UMLS		live		live	
+MONDO:0002977	autoimmune disease of the nervous system	UMLS:C0751871	Autoimmune Nervous System Diseases	UMLS:C0751872	Immune Disorders, Nervous System	UMLS		live		live	
+MONDO:0003011	mucinous tubular and spindle renal cell carcinoma	UMLS:C1513719	Mucinous Tubular and Spindle Cell Carcinoma of the Kidney	UMLS:CN203939	Mucinous tubular and spindle cell renal carcinoma	UMLS		live		live	
+MONDO:0003050	lung large cell carcinoma	EFO:0003050	large cell lung carcinoma	EFO:1000016	anaplastic lung carcinoma	EFO		live		live	
+MONDO:0003061	benign muscle neoplasm	DOID:2691	myoma	DOID:461	muscle benign neoplasm	DOID		live		live	
+MONDO:0003112	malignant gastric germ cell tumor	UMLS:C1333769	Gastric Germ Cell Tumor	UMLS:C1334584	Malignant Gastric Germ Cell Tumor	UMLS		live		live	
+MONDO:0003143	angiokeratoma	UMLS:C0002985	Angiokeratoma	UMLS:C0346075	Angiokeratoma of skin	UMLS		live		live	
+MONDO:0003214	apocrine adenocarcinoma	UMLS:C0334346	Apocrine adenocarcinoma	UMLS:C1706827	Apocrine Carcinoma	UMLS		live		live	
+MONDO:0003219	gastroesophageal junction adenocarcinoma	ONCOTREE:EGC	esophagogastric adenocarcinoma	ONCOTREE:GEJ	adenocarcinoma of the gastroesophageal junction	ONCOTREE		live		live	
+MONDO:0003266	ependymal tumor	UMLS:C1333407	Ependymal Tumor	UMLS:CN203416	Ependymal tumor	UMLS		live		live	
+MONDO:0003345	hilar cholangiocarcinoma	DOID:4927	Klatskin's tumor	DOID:5246	hilar cholangiocellular carcinoma	DOID		live		deprecated	
+MONDO:0003472	lice infestation	UMLS:C0030756	Louse infestation	UMLS:C0153317	Pediculosis and phthirus infections	UMLS		live		live	
+MONDO:0003472	lice infestation	UMLS:C0030756	Louse infestation	UMLS:C0277351	Mixed pediculosis	UMLS		live		live	
+MONDO:0003472	lice infestation	UMLS:C0153317	Pediculosis and phthirus infections	UMLS:C0277351	Mixed pediculosis	UMLS		live		live	
+MONDO:0003487	pseudoglandular squamous cell carcinoma	UMLS:C0334250	Adenoid squamous cell carcinoma	UMLS:C0334393	Adenocarcinoma with squamous metaplasia	UMLS		live		live	
+MONDO:0003532	breast papillary carcinoma	UMLS:C1336027	Solid Papillary Carcinoma of the Breast	UMLS:C3812899	Papillary carcinoma of the breast	UMLS		live		live	
+MONDO:0003582	hereditary breast ovarian cancer syndrome	GARD:0012351	BRCA1 hereditary breast and ovarian cancer syndrome	GARD:0012352	BRCA2 hereditary breast and ovarian cancer syndrome	GARD		live		live	
+MONDO:0003604	functioning pituitary gland neoplasm	UMLS:C0851693	Functioning Pituitary Gland Neoplasm	UMLS:C3163678	Functioning pituitary neoplasm	UMLS		live		live	
+MONDO:0003608	optic atrophy	UMLS:C0029124	Optic atrophy	UMLS:C1744705	Atrophy of optic disc	UMLS		live		live	
+MONDO:0003649	esophageal neuroendocrine tumor	UMLS:C1333462	Esophageal Neuroendocrine Neoplasm	UMLS:C2987260	Esophageal Neuroendocrine Tumor	UMLS		live		live	
+MONDO:0003652	acute urate nephropathy	UMLS:C0341712	Acute urate nephropathy	UMLS:C0403719	Uric acid urolithiasis	UMLS		live		live	
+MONDO:0003661	breast lymphoma	UMLS:C0349669	Malignant lymphoma of breast	UMLS:C1704251	Breast Lymphoma	UMLS		live		live	
+MONDO:0003680	periosteal chondrosarcoma	DOID:5859	periosteal chondrosarcoma	DOID:5866	juxtacortical chondrosarcoma	DOID		live		live	
+MONDO:0003701	thyroid gland diffuse sclerosing papillary carcinoma	UMLS:C0334330	Nonencapsulated sclerosing carcinoma	UMLS:C1321862	Nonencapsulated sclerosing tumor	UMLS		live		live	
+MONDO:0003730	aleukemic leukemia	DOID:12965	subleukemic leukemia	DOID:6004	aleukemic leukemia	DOID		live		live	
+MONDO:0003741	juvenile type testicular granulosa cell tumor	UMLS:C0334403	Juvenile granulosa cell tumor	UMLS:C1515285	Juvenile Type Testicular Granulosa Cell Tumor	UMLS		live		live	
+MONDO:0003749	esophageal disease	SCTID:30811009	ulcer of esophagus (disorder)	SCTID:37657006	disorder of esophagus (disorder)	SCTID		live		live	
+MONDO:0003767	mitral valve disease	UMLS:C0026265	Mitral valve disease	UMLS:C2939153	Chronic rheumatic mitral valve	UMLS		live		live	
+MONDO:0003805	malignant pericardial mesothelioma	UMLS:C0346110	Malignant mesothelioma of pericardium	UMLS:C1335381	Pericardial Mesothelioma	UMLS		live		live	
+MONDO:0003857	adult intracranial malignant hemangiopericytoma	UMLS:C1334558	Adult Intracranial Solitary Fibrous Tumor/Hemangiopericytoma, Grade 3	UMLS:C4331858	Central Nervous System Solitary Fibrous Tumor/Hemangiopericytoma, Grade 3	UMLS		live		live	
+MONDO:0003924	adrenal cortex adenoma	DOID:0050891	adrenal cortical adenoma	DOID:656	adrenal adenoma	DOID		live		live	
+MONDO:0003945	bone epithelioid hemangioma	UMLS:C1332575	Bone Epithelioid Hemangioma	UMLS:C1332578	Bone Hemangioma	UMLS		live		live	
+MONDO:0004083	Borst-Jadassohn intraepidermal carcinoma	UMLS:C0334260	Bowen's disease, clonal	UMLS:C2937231	Intraepidermal epithelioma of Jadassohn	UMLS		live		live	
+MONDO:0004114	urinary bladder small cell neuroendocrine carcinoma	UMLS:C1332564	Small cell neuroendocrine carcinoma of bladder	UMLS:CN202866	Small cell carcinoma of the urinary bladder	UMLS		live		live	
+MONDO:0004135	subacute lymphocytic thyroiditis	UMLS:C0271814	Silent thyroiditis	UMLS:C1306804	Subacute lymphocytic thyroiditis	UMLS		live		live	
+MONDO:0004150	breast giant fibroadenoma	UMLS:C0334500	Giant fibroadenoma	UMLS:C0346157	Giant fibroadenoma of breast	UMLS		live		live	
+MONDO:0004225	monoclonal gammopathy of uncertain significance	SCTID:277577000	monoclonal gammopathy of uncertain significance (disorder)	SCTID:58648008	benign monoclonal gammopathy (disorder)	SCTID		live		live	
+MONDO:0004241	Osgood-Schlatter disease	SCTID:430506003	osteochondritis of tibial tubercle (disorder)	SCTID:72047008	juvenile osteochondrosis of tibial tubercle (disorder)	SCTID		live		live	
+MONDO:0004260	peptic ulcer perforation	UMLS:C0030925	Peptic ulcer with perforation	UMLS:C0267291	Acute peptic ulcer with perforation	UMLS		live		live	
+MONDO:0004264	acute gonococcal endometritis	UMLS:C0153196	Acute gonococcal endometritis	UMLS:C0341829	Gonococcal endometritis	UMLS		live		live	
+MONDO:0004276	ceruminoma	UMLS:C0334352	Ceruminous adenoma	UMLS:C1333488	Ceruminous Adenoma of the External Auditory Canal	UMLS		live		live	
+MONDO:0004278	infiltrating bladder urothelial carcinoma sarcomatoid variant	UMLS:C1512743	Infiltrating Bladder Urothelial Carcinoma Sarcomatoid Variant	UMLS:C1512744	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant with Heterologous Elements	UMLS		live		live	
+MONDO:0004278	infiltrating bladder urothelial carcinoma sarcomatoid variant	UMLS:C1512743	Infiltrating Bladder Urothelial Carcinoma Sarcomatoid Variant	UMLS:C1512745	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant without Heterologous Elements	UMLS		live		live	
+MONDO:0004278	infiltrating bladder urothelial carcinoma sarcomatoid variant	UMLS:C1512744	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant with Heterologous Elements	UMLS:C1512745	Infiltrating Bladder Urothelial Carcinoma, Sarcomatoid Variant without Heterologous Elements	UMLS		live		live	
+MONDO:0004332	lung hilum cancer	UMLS:C0346601	Primary malignant neoplasm of hilus of lung	UMLS:C2607931	Malignant Neoplasm of the Lung Hilum	UMLS		live		live	
+MONDO:0004379	female breast carcinoma	DOID:0050671	female breast cancer	DOID:7843	female breast carcinoma	DOID		live		live	
+MONDO:0004379	female breast carcinoma	SCTID:372064008	malignant neoplasm of female breast (disorder)	SCTID:447782002	malignant epithelial neoplasm of female breast (disorder)	SCTID		live		live	
+MONDO:0004387	luteoma of pregnancy	UMLS:C0024167	Luteoma	UMLS:C1517842	Leuteoma of Pregnancy	UMLS		live		live	
+MONDO:0004398	mediastinal schwannoma	DOID:6175	mediastinal neurilemmoma	DOID:7922	benign mediastinal neurilemmoma	DOID		live		live	
+MONDO:0004473	epiglottis cancer	NCIT:C35697	Epiglottic Carcinoma	NCIT:C4836	Malignant Epiglottis Neoplasm	NCIT		live		live	
+MONDO:0004526	mixed endometrial stromal and smooth muscle tumor	UMLS:C1513364	Mixed Endometrial Stromal and Smooth Muscle Neoplasm	UMLS:C1519865	Uterine Corpus Soft Tissue Neoplasm	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153382	Malignant Neoplasm of the Oropharynx	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153389	Malignant neoplasm of lateral wall of oropharynx	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C0153390	Malignant neoplasm of posterior wall of oropharynx	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS		live		live	
+MONDO:0004608	oropharynx cancer	UMLS:C2349952	Oropharyngeal Carcinoma	UMLS:C3165521	Primary malignant neoplasm of lateral wall of oropharynx	UMLS		live		live	
+MONDO:0004636	lip carcinoma in situ	UMLS:C0347082	Stage 0 Lip Carcinoma	UMLS:C4316815	Carcinoma in situ of lip	UMLS		live		live	
+MONDO:0004668	fascioliasis	UMLS:C0015652	Fascioliasis	UMLS:C1331532	Fasciola hepatica infection	UMLS		live		live	
+MONDO:0004707	anal canal carcinoma in situ	UMLS:C0154064	Carcinoma in situ of anus	UMLS:C2242854	Carcinoma in situ of anal canal	UMLS		live		live	
+MONDO:0004709	occipital lobe neoplasm	UMLS:C0153638	Malignant neoplasm of occipital lobe	UMLS:C1263889	Neoplasm of Occipital Lobe	UMLS		live		live	
+MONDO:0004769	orbital plasma cell granuloma	SCTID:72789009	inflammatory pseudotumor of orbit proper (disorder)	SCTID:80698001	orbital myositis (disorder)	SCTID		live		live	
+MONDO:0004790	fatty liver disease	SCTID:197321007	steatosis of liver (disorder)	SCTID:371330000		SCTID		live		not_present	
+MONDO:0004817	non-secretory plasma cell myeloma	UMLS:C0456845	Non-secretory myeloma	UMLS:C3898125	Non-Secretory Plasma Cell Myeloma	UMLS		live		live	
+MONDO:0004842	stomatitis	UMLS:C0038362	Stomatitis	UMLS:C1568868	Oral Mucositis	UMLS		live		live	
+MONDO:0004849	pulmonary emphysema	MESH:D004646	Emphysema	MESH:D011656	Pulmonary Emphysema	MESH		live		live	
+MONDO:0004948	B-cell chronic lymphocytic leukemia	UMLS:C0023434	Chronic lymphocytic leukemia	UMLS:C0855095	Small lymphocytic lymphoma	UMLS		live		live	
+MONDO:0004957	mucinous adenocarcinoma	EFO:0000197	mucinous carcinoma	EFO:1000387	mucinuos carcinoma	EFO		live		live	
+MONDO:0004957	mucinous adenocarcinoma	UMLS:C0007130	Mucinous adenocarcinoma	UMLS:C0334368	Mucin-producing adenocarcinoma	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C0267112	Acute gastric mucosal erosion	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C2243088	Erosive Gastritis	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C2243090	Erosive gastropathy	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0017152	Gastritis	UMLS:C3854048	Erosive gastritis	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0267112	Acute gastric mucosal erosion	UMLS:C2243088	Erosive Gastritis	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0267112	Acute gastric mucosal erosion	UMLS:C2243090	Erosive gastropathy	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C0267112	Acute gastric mucosal erosion	UMLS:C3854048	Erosive gastritis	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C2243088	Erosive Gastritis	UMLS:C2243090	Erosive gastropathy	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C2243088	Erosive Gastritis	UMLS:C3854048	Erosive gastritis	UMLS		live		live	
+MONDO:0004966	gastritis (disease)	UMLS:C2243090	Erosive gastropathy	UMLS:C3854048	Erosive gastritis	UMLS		live		live	
+MONDO:0004992	cancer	DOID:0050686	organ system cancer	DOID:0050687	cell type cancer	DOID		live		live	
+MONDO:0004992	cancer	DOID:0050686	organ system cancer	DOID:162	cancer	DOID		live		live	
+MONDO:0004992	cancer	DOID:0050687	cell type cancer	DOID:162	cancer	DOID		live		live	
+MONDO:0005006	clear cell sarcoma of kidney	UMLS:C0334488	Clear cell sarcoma of kidney	UMLS:CN242113	CCSK	UMLS		live		live	
+MONDO:0005008	colorectal adenocarcinoma	DOID:0050861	colorectal adenocarcinoma	DOID:0050913	large intestine adenocarcinoma	DOID		live		live	
+MONDO:0005010	coronary artery disease	EFO:0000378	coronary artery disease	EFO:0001645	coronary heart disease	EFO		live		live	
+MONDO:0005012	cutaneous melanoma (disease)	UMLS:C0151779	Cutaneous melanoma	UMLS:C0153535	Malignant melanoma of skin of upper limb	UMLS		live		live	
+MONDO:0005012	cutaneous melanoma (disease)	UMLS:C0151779	Cutaneous melanoma	UMLS:C0153536	Malignant melanoma of skin of lower limb	UMLS		live		live	
+MONDO:0005012	cutaneous melanoma (disease)	UMLS:C0153535	Malignant melanoma of skin of upper limb	UMLS:C0153536	Malignant melanoma of skin of lower limb	UMLS		live		live	
+MONDO:0005015	diabetes mellitus (disease)	UMLS:C0011847	Diabetes	UMLS:C0011849	Diabetes mellitus	UMLS		live		live	
+MONDO:0005026	endometrioid adenocarcinoma	UMLS:C0206687	Endometrioid carcinoma	UMLS:C1569637	Endometrioid adenocarcinoma	UMLS		live		live	
+MONDO:0005051	invasive lobular breast carcinoma	UMLS:C0206692	Lobular carcinoma	UMLS:C0279565	Invasive Lobular Carcinoma of the Breast	UMLS		live		live	
+MONDO:0005061	lung adenocarcinoma	EFO:0000571	lung adenocarcinoma	EFO:0005288	non-small cell lung adenocarcinoma	EFO		live		live	
+MONDO:0005072	neuroblastoma	UMLS:C0027819	Neuroblastoma	UMLS:CN205405	Neuroblastoma	UMLS		live		live	
+MONDO:0005076	periodontitis	DOID:824	periodontitis	DOID:9893	periodontosis	DOID		live		live	
+MONDO:0005076	periodontitis	UMLS:C0031099	Periodontitis	UMLS:C0600298	Periodontosis	UMLS		live		live	
+MONDO:0005105	melanoma (disease)	UMLS:C0025202	Melanoma	UMLS:CN971653	Malignant melanoma	UMLS		live		live	
+MONDO:0005116	Whipple disease	UMLS:C0023788	Whipple's disease	UMLS:C2930851	Intestinal lipophagic granulomatosis	UMLS		live		live	
+MONDO:0005116	Whipple disease	UMLS:C0023788	Whipple's disease	UMLS:CN204440	Secondary non-tropical sprue	UMLS		live		live	
+MONDO:0005116	Whipple disease	UMLS:C2930851	Intestinal lipophagic granulomatosis	UMLS:CN204440	Secondary non-tropical sprue	UMLS		live		live	
+MONDO:0005125	borderline leprosy	UMLS:C0023346	Borderline leprosy	UMLS:C3251797	Midborderline leprosy	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C0741160	Ruptured aortic aneurysm	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0003486	Aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS:C0741160	Ruptured aortic aneurysm	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265010	Ruptured thoracic aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS:C0741160	Ruptured aortic aneurysm	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0265012	Ruptured abdominal aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS		live		live	
+MONDO:0005160	aortic aneurysm (disease)	UMLS:C0741160	Ruptured aortic aneurysm	UMLS:C1305122	Thoracoabdominal aortic aneurysm, ruptured	UMLS		live		live	
+MONDO:0005165	benign neoplasm	DOID:0060072	benign neoplasm	DOID:0060084	cell type benign neoplasm	DOID		live		live	
+MONDO:0005165	benign neoplasm	DOID:0060072	benign neoplasm	DOID:0060085	organ system benign neoplasm	DOID		live		live	
+MONDO:0005165	benign neoplasm	DOID:0060084	cell type benign neoplasm	DOID:0060085	organ system benign neoplasm	DOID		live		live	
+MONDO:0005173	actinic keratosis (disease)	UMLS:C0022602	Actinic keratosis	UMLS:C4282032	Senile hyperkeratosis	UMLS		live		live	
+MONDO:0005184	pancreatic ductal adenocarcinoma	DOID:3498	pancreatic ductal adenocarcinoma	DOID:3587	pancreatic ductal carcinoma	DOID		live		live	
+MONDO:0005184	pancreatic ductal adenocarcinoma	UMLS:C0887833	Pancreatic Ductal Carcinoma	UMLS:C1335302	Pancreatic ductal adenocarcinoma	UMLS		live		live	
+MONDO:0005211	ovarian serous adenocarcinoma	DOID:0050933	ovarian serous carcinoma	DOID:5744	ovary serous adenocarcinoma	DOID		live		live	
+MONDO:0005244	peripheral neuropathy	EFO:0003100	peripheral neuropathy	EFO:0004149	neuropathy	EFO		live		live	
+MONDO:0005244	peripheral neuropathy	NCIT:C119734	Peripheral Neuropathy	NCIT:C4731	Neuropathy	NCIT		live		live	
+MONDO:0005267	heart disease	UMLS:C0018799	Heart disease	UMLS:CN236661	Heart Diseases	UMLS		live		live	
+MONDO:0005267	heart disease	UMLS:C0018799	Heart disease	UMLS:CN239852	Cardiac disease	UMLS		live		live	
+MONDO:0005267	heart disease	UMLS:CN236661	Heart Diseases	UMLS:CN239852	Cardiac disease	UMLS		live		live	
+MONDO:0005296	sleep apnea syndrome	SCTID:111489007	breathing-related sleep disorder (disorder)	SCTID:73430006	sleep apnea (disorder)	SCTID		live		live	
+MONDO:0005311	atherosclerosis	NCIT:C35768	Atherosclerosis	NCIT:C35771	Atherosclerotic Cardiovascular Disease	NCIT		live		live	
+MONDO:0005313	necrotizing enterocolitis	UMLS:C0520459	Necrotizing enterocolitis	UMLS:C4082937	Necrotizing enterocolitis in fetus OR newborn	UMLS		live		live	
+MONDO:0005321	Fuchs' endothelial dystrophy	UMLS:C0016781	Fuchs' endothelial dystrophy	UMLS:CN207231	Late hereditary endothelial dystrophy	UMLS		live		live	
+MONDO:0005338	open-angle glaucoma	SCTID:46168003	pigmentary glaucoma (disorder)	SCTID:84494001	open-angle glaucoma (disorder)	SCTID		live		live	
+MONDO:0005341	skin basal cell carcinoma	UMLS:C0007117	Basal cell carcinoma	UMLS:C0206710	Basal cell neoplasm	UMLS		live		live	
+MONDO:0005341	skin basal cell carcinoma	UMLS:C0007117	Basal cell carcinoma	UMLS:C0751676	Basal Cell Cancer	UMLS		live		live	
+MONDO:0005341	skin basal cell carcinoma	UMLS:C0206710	Basal cell neoplasm	UMLS:C0751676	Basal Cell Cancer	UMLS		live		live	
+MONDO:0005345	hypospadias (disease)	UMLS:C0848558		UMLS:CN205090	Familial hypospadias	UMLS		not_present		live	
+MONDO:0005380	osteonecrosis	DOID:0080008	ischemic bone disease	DOID:10159	osteonecrosis	DOID		live		live	
+MONDO:0005380	osteonecrosis	NCIT:C34880	Bone Necrosis	NCIT:C35476	Aseptic Necrosis of Bone	NCIT		live		live	
+MONDO:0005387	primary ovarian failure	SCTID:370999003	primary hypogonadism (disorder)	SCTID:65846009	primary ovarian failure (disorder)	SCTID		live		live	
+MONDO:0005393	gout	UMLS:C0003868	Gouty arthritis	UMLS:C0018099	Gout	UMLS		live		live	
+MONDO:0005402	lymphoid leukemia (disease)	UMLS:C0023448	Lymphoid leukemia	UMLS:C0152271	Subacute lymphoid leukemia	UMLS		live		live	
+MONDO:0005417	wet macular degeneration	UMLS:C0271084	Exudative senile macular retinal degeneration	UMLS:C2237660	Wet Macular Degeneration	UMLS		live		live	
+MONDO:0005461	endometrium adenocarcinoma	UMLS:C0279763	Endometrial Adenoacanthoma	UMLS:C1153706	Endometrial adenocarcinoma	UMLS		live		live	
+MONDO:0005484	colorectal adenoma	DOID:0050860	colorectal adenoma	DOID:0050914	large intestine adenoma	DOID		live		live	
+MONDO:0005508	hereditary multiple osteochondromas	SCTID:254044004	multiple congenital exostosis (disorder)	SCTID:716742001	multiple osteochondroma of long bone (disorder)	SCTID		live		live	
+MONDO:0005519	renal pelvis carcinoma	UMLS:C0153618	Malignant Renal Pelvis Neoplasm	UMLS:C1335749	Carcinoma of the Renal Pelvis	UMLS		live		live	
+MONDO:0005526	tetanus	SCTID:276202003	infection caused by clostridium tetani (disorder)	SCTID:76902006	tetanus (disorder)	SCTID		live		live	
+MONDO:0005543	autoimmune hepatitis type 1	SCTID:197284004	chronic active hepatitis (disorder)	SCTID:721711009	autoimmune hepatitis type 1 (disorder)	SCTID		live		live	
+MONDO:0005560	brain disease	UMLS:C0006111	Brain Diseases	UMLS:C0085584	Encephalopathy	UMLS		live		live	
+MONDO:0005563	nut midline carcinoma	UMLS:C1707291	NUT Midline Carcinoma	UMLS:CN237663	NMC	UMLS		live		live	
+MONDO:0005568	cholesterol embolism	UMLS:C0149649	Cholesterol Embolism	UMLS:C0585266	Trash foot	UMLS		live		live	
+MONDO:0005570	hematological system disease	UMLS:C0018939	Hematological Diseases	UMLS:CN882913	hematological disorders and malignancies	UMLS		live		live	
+MONDO:0005575	colorectal cancer	DOID:5672	large intestine cancer	DOID:9256	colorectal cancer	DOID		live		live	
+MONDO:0005590	breast ductal adenocarcinoma	EFO:0000430	ductal adenocarcinoma	EFO:0006318	breast ductal adenocarcinoma	EFO		live		live	
+MONDO:0005601	ovarian mucinous adenocarcinoma	UMLS:C1335167	Mucinous Adenocarcinoma of the Ovary	UMLS:CN205033	Ovarian mucinous adenocarcinoma	UMLS		live		live	
+MONDO:0005628	male breast carcinoma	UMLS:C0238033	Carcinoma of male breast	UMLS:C0242787	Malignant neoplasm of male breast	UMLS		live		live	
+MONDO:0005628	male breast carcinoma	UMLS:C0238033	Carcinoma of male breast	UMLS:C0242788	Neoplasm of male breast	UMLS		live		live	
+MONDO:0005628	male breast carcinoma	UMLS:C0242787	Malignant neoplasm of male breast	UMLS:C0242788	Neoplasm of male breast	UMLS		live		live	
+MONDO:0005648	aortic valve insufficiency	UMLS:C0003504	Aortic valve insufficiency	UMLS:C0155568	Rheumatic aortic regurgitation	UMLS		live		live	
+MONDO:0005659	atrophic rhinitis	UMLS:C0030105	Ozenas	UMLS:C0035459	Atrophic rhinitis	UMLS		live		live	
+MONDO:0005663	Barre-Lieou syndrome	UMLS:C0376378	Posterior cervical sympathetic syndrome	UMLS:C2355645	Cervicocranial syndrome	UMLS		live		live	
+MONDO:0005672	blastomycosis	UMLS:C0005716	Blastomycosis	UMLS:C0005717	Gilchrist's disease	UMLS		live		live	
+MONDO:0005689	cannabis dependence	DOID:1849	cannabis dependence	DOID:9505	cannabis abuse	DOID		live		live	
+MONDO:0005689	cannabis dependence	EFO:0004218	obsolete_marijuana dependence	EFO:0007191	cannabis dependence	EFO		live		live	
+MONDO:0005689	cannabis dependence	SCTID:37344009	cannabis abuse (disorder)	SCTID:85005007	cannabis dependence (disorder)	SCTID		live		live	
+MONDO:0005692	cat-scratch disease	UMLS:C0007361	Cat scratch disease	UMLS:CN205187	Bartonellosis due to Bartonella henselae infection	UMLS		live		live	
+MONDO:0005695	central nervous system AIDS arteritis	UMLS:C0752329	Cerebral Aneurysmal Arteriopathy, AIDS-Associated	UMLS:C0752330	Central Nervous System AIDS Arteritis	UMLS		live		live	
+MONDO:0005695	central nervous system AIDS arteritis	UMLS:C0752329	Cerebral Aneurysmal Arteriopathy, AIDS-Associated	UMLS:C0752331	HIV-Associated Vasculitis of the Central Nervous System	UMLS		live		live	
+MONDO:0005695	central nervous system AIDS arteritis	UMLS:C0752330	Central Nervous System AIDS Arteritis	UMLS:C0752331	HIV-Associated Vasculitis of the Central Nervous System	UMLS		live		live	
+MONDO:0005696	central nervous system tuberculosis	UMLS:C0085388	Intracranial Tuberculoma	UMLS:C2607948	Tuberculous abscess of brain	UMLS		live		live	
+MONDO:0005706	coccidioidomycosis	UMLS:C0009186	Coccidioidomycosis	UMLS:C0700644	Primary extrapulmonary coccidioidomycosis	UMLS		live		live	
+MONDO:0005706	coccidioidomycosis	UMLS:C0009186	Coccidioidomycosis	UMLS:CN201384	Valley fever	UMLS		live		live	
+MONDO:0005706	coccidioidomycosis	UMLS:C0700644	Primary extrapulmonary coccidioidomycosis	UMLS:CN201384	Valley fever	UMLS		live		live	
+MONDO:0005710	composite lymphoma	UMLS:C0545080	Composite Lymphoma	UMLS:C1266191	Composite Hodgkin and non-Hodgkin lymphoma	UMLS		live		live	
+MONDO:0005729	dicrocoeliasis	UMLS:C0012102	Dicroceliasis	UMLS:C1737210	Disease due to Dicrocoeliidae	UMLS		live		live	
+MONDO:0005746	enterobiasis	UMLS:C0030100	Oxyuriasis	UMLS:C0086227	Enterobiasis	UMLS		live		live	
+MONDO:0005768	gastrointestinal tuberculosis	UMLS:C0041312	Gastrointestinal Tuberculosis	UMLS:C0152717	Tuberculosis of intestines, peritoneum and mesenteric glands	UMLS		live		live	
+MONDO:0005769	geniculate herpes zoster	UMLS:C0017409	Herpes zoster oticus	UMLS:C0458220	Nervus intermedius neuralgia	UMLS		live		live	
+MONDO:0005802	hymenolepiasis	UMLS:C0020413	Hymenolepiosis	UMLS:C0277045	Dwarf tapeworm infection	UMLS		live		live	
+MONDO:0005812	influenza	EFO:0001669	influenza infection	EFO:0007328	influenza	EFO		live		live	
+MONDO:0005823	legionellosis	UMLS:C0023240	Legionellosis	UMLS:CN205282	Legionnaires disease	UMLS		live		live	
+MONDO:0005848	miliary tuberculosis	UMLS:C0041321	Miliary tuberculosis	UMLS:C0152915	Acute miliary tuberculosis	UMLS		live		live	
+MONDO:0005853	malignant mixed neoplasm	EFO:0007373	mixed cell type cancer	EFO:1000356	Malignant Mixed Neoplasm	EFO		live		live	
+MONDO:0005859	mucocutaneous leishmaniasis	UMLS:C1328252	Mucocutaneous leishmaniasis	UMLS:C3495436	American cutaneous leishmaniasis	UMLS		live		live	
+MONDO:0005864	muscle cancer	UMLS:C0027095	Myosarcoma	UMLS:C0684743	Malignant Neoplasm of the Muscle	UMLS		live		live	
+MONDO:0005974	strongyloidiasis	UMLS:C0038463	Strongyloidiasis	UMLS:C0085810	Anguilluliasis	UMLS		live		live	
+MONDO:0005974	strongyloidiasis	UMLS:C0038463	Strongyloidiasis	UMLS:C0348996	Disseminated strongyloidiasis	UMLS		live		live	
+MONDO:0005974	strongyloidiasis	UMLS:C0085810	Anguilluliasis	UMLS:C0348996	Disseminated strongyloidiasis	UMLS		live		live	
+MONDO:0005990	tracheitis	UMLS:C0040584	Tracheitis	UMLS:C0149513	Acute tracheitis	UMLS		live		live	
+MONDO:0005990	tracheitis	UMLS:C0040584	Tracheitis	UMLS:C0264322	Chronic tracheitis	UMLS		live		live	
+MONDO:0005990	tracheitis	UMLS:C0149513	Acute tracheitis	UMLS:C0264322	Chronic tracheitis	UMLS		live		live	
+MONDO:0006001	urinary schistosomiasis	UMLS:C0276926	Schistosoma haematobium infection	UMLS:C1704430	Urinary schistosomiasis	UMLS		live		live	
+MONDO:0006021	Prinzmetal angina	UMLS:C0002963	Variant angina pectoris	UMLS:C2931193	Prinzmetal's variant angina	UMLS		live		live	
+MONDO:0006045	ovarian clear cell adenocarcinoma	UMLS:C1518693	Ovarian Clear Cell Adenocarcinoma	UMLS:CN205034	Ovarian clear cell adenocarcinoma	UMLS		live		live	
+MONDO:0006050	pleomorphic breast carcinoma	UMLS:C1514169	Pleomorphic Breast Carcinoma	UMLS:C2211689	Anaplastic Breast Carcinoma	UMLS		live		live	
+MONDO:0006055	sex cord-stromal tumor	EFO:0007483	sex cord-gonadal stromal tumor	EFO:1000052	sex cord-stromal tumor	EFO		live		live	
+MONDO:0006055	sex cord-stromal tumor	UMLS:C0206724	Sex cord-stromal tumor	UMLS:C1515289	Malignant Testicular Sex Cord-Stromal Tumor	UMLS		live		live	
+MONDO:0006095	atypical carcinoid tumor	UMLS:C0391970	Malignant carcinoid tumor	UMLS:C1266032	Atypical carcinoid tumor	UMLS		live		live	
+MONDO:0006230	gastric squamous cell carcinoma	UMLS:C1333789	Gastric Squamous Cell Carcinoma	UMLS:CN237470	Gastric squamous cell carcinoma	UMLS		live		live	
+MONDO:0006235	granular cell tumor	MESH:C535558	Abrikosov's tumor	MESH:D016586	Granular Cell Tumor	MESH		live		live	
+MONDO:0006238	growth hormone-producing pituitary gland adenoma	EFO:0004125	growth hormone-secreting pituitary adenoma	EFO:1000287	Growth Hormone-Producing Pituitary Gland Adenoma	EFO		live		live	
+MONDO:0006247	histiocytic and dendritic cell neoplasm	UMLS:C1334030	Histiocytic and Dendritic Cell Neoplasms	UMLS:CN206982	Histiocytic and dendritic cell tumor	UMLS		live		live	
+MONDO:0006270	lobular breast carcinoma in situ	UMLS:C0279563	Lobular carcinoma in situ of breast	UMLS:C0334381	Non-infiltrating lobular carcinoma	UMLS		live		live	
+MONDO:0006271	low grade central osteosarcoma	UMLS:C1266163	Intraosseous well differentiated osteosarcoma	UMLS:C3814534	Low grade central osteosarcoma	UMLS		live		live	
+MONDO:0006275	lung giant cell carcinoma	UMLS:C0206703	Giant cell carcinoma	UMLS:C0345960	Giant cell carcinoma of lung	UMLS		live		live	
+MONDO:0006280	lung sclerosing hemangioma	DOID:495	sclerosing hemangioma	DOID:5766	pulmonary sclerosing hemangioma	DOID		live		live	
+MONDO:0006280	lung sclerosing hemangioma	EFO:1000337	Lung Sclerosing Hemangioma	EFO:1001136	pulmonary sclerosing hemangioma	EFO		live		live	
+MONDO:0006292	malignant mesothelioma (disease)	UMLS:C0278752	Advanced Malignant Mesothelioma	UMLS:C0345967	Malignant mesothelioma	UMLS		live		live	
+MONDO:0006292	malignant mesothelioma (disease)	UMLS:C0278752	Advanced Malignant Mesothelioma	UMLS:C1332338	Asbestos-Related Malignant Mesothelioma	UMLS		live		live	
+MONDO:0006292	malignant mesothelioma (disease)	UMLS:C0345967	Malignant mesothelioma	UMLS:C1332338	Asbestos-Related Malignant Mesothelioma	UMLS		live		live	
+MONDO:0006345	palmar fibromatosis	EFO:0004229	Dupuytren Contracture	EFO:1000438	Palmar Fibromatosis	EFO		live		live	
+MONDO:0006447	testicular non-seminomatous germ cell tumor	UMLS:C1336724	Testicular Non-Seminomatous Germ Cell Tumor	UMLS:CN204702	Testicular non seminomatous germ cell tumor	UMLS		live		live	
+MONDO:0006451	thymic carcinoma	DOID:3284	thymic carcinoma	DOID:4554	type C thymoma	DOID		live		live	
+MONDO:0006451	thymic carcinoma	UMLS:C0205969	Thymic carcinoma	UMLS:C1322286	Thymoma, type C	UMLS		live		live	
+MONDO:0006451	thymic carcinoma	UMLS:C0205969	Thymic carcinoma	UMLS:CN207411	Malignant thymoma	UMLS		live		live	
+MONDO:0006451	thymic carcinoma	UMLS:C1322286	Thymoma, type C	UMLS:CN207411	Malignant thymoma	UMLS		live		live	
+MONDO:0006515	acute pancreatitis	UMLS:C0001339	Acute pancreatitis	UMLS:C0267941	Acute necrotizing pancreatitis	UMLS		live		live	
+MONDO:0006558	pemphigoid gestationis	DOID:0040098	pemphigus gestationis	DOID:14482	herpes gestationis	DOID		live		live	
+MONDO:0006576	Ludwig's angina	UMLS:C0024081	Ludwig's angina	UMLS:C3247204	Cellulitis of floor of mouth	UMLS		live		live	
+MONDO:0006581	miliaria rubra	UMLS:C0162423	Miliaria rubra	UMLS:C3241961	Miliaria crystallina	UMLS		live		live	
+MONDO:0006585	neurodermatitis	UMLS:C0027822	Neurodermatitis	UMLS:C0149922	Lichen simplex chronicus	UMLS		live		live	
+MONDO:0006633	acalculous cholecystitis	UMLS:C0267841	Acalculous cholecystitis	UMLS:C0267842	Acute cholecystitis without calculus	UMLS		live		live	
+MONDO:0006639	adrenal cortex carcinoma	DOID:3948	adrenocortical carcinoma	DOID:3959	adrenal cortical adenocarcinoma	DOID		live		live	
+MONDO:0006639	adrenal cortex carcinoma	DOID:3948	adrenocortical carcinoma	DOID:660	adrenal cortex cancer	DOID		live		live	
+MONDO:0006639	adrenal cortex carcinoma	DOID:3959	adrenal cortical adenocarcinoma	DOID:660	adrenal cortex cancer	DOID		live		live	
+MONDO:0006639	adrenal cortex carcinoma	EFO:0003093	adrenocortical carcinoma	EFO:1000796	adrenal cortex carcinoma	EFO		live		live	
+MONDO:0006640	adrenal gland hyperfunction	UMLS:C0001622	Adrenal Gland Hyperfunction	UMLS:CN205287	Hypercortisolism	UMLS		live		live	
+MONDO:0006644	alcoholic liver cirrhosis	UMLS:C0023891	Alcoholic cirrhosis of liver	UMLS:C1622502	Portal cirrhosis	UMLS		live		live	
+MONDO:0006646	angioleiomyoma	EFO:1000084	Angioleiomyoma	EFO:1000806	angiomyoma	EFO		live		live	
+MONDO:0006687	burning mouth syndrome	UMLS:C0006430	Burning mouth syndrome	UMLS:C2930806	Stomatodynia	UMLS		live		live	
+MONDO:0006687	burning mouth syndrome	UMLS:C0006430	Burning mouth syndrome	UMLS:CN242089	Stomatopyrosis	UMLS		live		live	
+MONDO:0006687	burning mouth syndrome	UMLS:C2930806	Stomatodynia	UMLS:CN242089	Stomatopyrosis	UMLS		live		live	
+MONDO:0006688	byssinosis	UMLS:C0006542	Byssinosis	UMLS:C2242894	Flax-dressers' disease	UMLS		live		live	
+MONDO:0006717	cutaneous fibrous histiocytoma	UMLS:C0002991	Cutaneous Fibrous Histiocytoma	UMLS:C0346049	Fibrohistiocytic tumor	UMLS		live		live	
+MONDO:0006745	endometrioid stromal sarcoma	UMLS:C0206630	Endometrial stromal sarcoma	UMLS:C2239246	Endometrial stromal sarcoma, high grade	UMLS		live		live	
+MONDO:0006846	malignant hypertension	UMLS:C0020540	Malignant hypertension	UMLS:C0745136	Hypertensive emergency	UMLS		live		live	
+MONDO:0006849	mastitis	UMLS:C0024894	Mastitis	UMLS:C0392317	Breast infection	UMLS		live		live	
+MONDO:0006873	nutritional deficiency disease	SCTID:363246002	nutritional deficiency associated condition (disorder)	SCTID:70241007	nutritional deficiency disorder (disorder)	SCTID		live		live	
+MONDO:0006906	pigmented villonodular synovitis	DOID:2702	pigmented villonodular synovitis	DOID:9898	villonodular synovitis	DOID		live		live	
+MONDO:0006956	rickettsiosis	SCTID:37246009	disease caused by rickettsiae (disorder)	SCTID:416829003	disease caused by genus rickettsia (disorder)	SCTID		live		live	
+MONDO:0006962	sebaceous adenocarcinoma	DOID:4839	sebaceous adenocarcinoma	DOID:4840	sebaceous carcinoma	DOID		live		live	
+MONDO:0006963	sebaceous gland neoplasm	UMLS:C0036503	Neoplasm of sebaceous gland	UMLS:C3805742	Sebaceous gland tumors	UMLS		live		live	
+MONDO:0007029	branchio-oto-renal syndrome	UMLS:C0265234	Branchio-oto-renal syndrome	UMLS:CN043574	Branchiootorenal Spectrum Disorders	UMLS		live		live	
+MONDO:0007031	familial abdominal aortic aneurysm	UMLS:C4275172	Familial abdominal aortic aneurysm	UMLS:CN206207	Familial abdominal aortic aneurysm	UMLS		live		live	
+MONDO:0007047	punctate palmoplantar keratoderma type III	GARD:0000125	Acrokeratoelastoidosis of Costa	GARD:0000133	Aganglionosis, total intestinal	GARD		live		live	
+MONDO:0007057	acroosteolysis dominant type	UMLS:C0917715	Hajdu-Cheney syndrome	UMLS:C2930971	Acroosteolysis dominant type	UMLS		live		live	
+MONDO:0007059	acrorenal syndrome	UMLS:C3495490	Acrorenal syndrome	UMLS:CN206860	Acrorenal syndrome	UMLS		live		live	
+MONDO:0007078	pseudohypoparathyroidism type 1A	GARD:0005770	Albright's hereditary osteodystrophy	GARD:0007486	Pseudohypoparathyroidism type 1A	GARD		live		live	
+MONDO:0007078	pseudohypoparathyroidism type 1A	UMLS:C2931404	Albright's hereditary osteodystrophy	UMLS:C3494506	Pseudohypoparathyroidism type Ia	UMLS		live		live	
+MONDO:0007080	glucocorticoid-remediable aldosteronism	UMLS:C1260386	Glucocorticoid-sensitive hypertension	UMLS:C3838731	Familial hyperaldosteronism type 1	UMLS		live		live	
+MONDO:0007100	familial amyloid neuropathy	DOID:0050638	transthyretin amyloidosis	DOID:0050761	paramyloidosis	DOID		live		live	
+MONDO:0007100	familial amyloid neuropathy	UMLS:C0206245	Familial amyloid polyneuropathy type I (Portuguese-Swedish-Japanese Type)	UMLS:C2751492	AMYLOIDOSIS, HEREDITARY, TRANSTHYRETIN-RELATED	UMLS		live		live	
+MONDO:0007113	Angelman syndrome	MESH:C531619	Happy puppet syndrome (formerly)	MESH:D017204	Angelman Syndrome	MESH		live		live	
+MONDO:0007124	ankyloblepharon-ectodermal defects-cleft lip/palate syndrome	GARD:0004805	Seres-Santamaria Arimany Muniz syndrome	GARD:0006571	Hay-Wells syndrome	GARD		live		live	
+MONDO:0007142	Townes-Brocks syndrome	UMLS:C0265246	Townes syndrome	UMLS:CN034849	TBS1	UMLS		live		live	
+MONDO:0007174	Lown-Ganong-Levine syndrome	UMLS:C0024054	Lown-Ganong-Levine syndrome	UMLS:C1862387	Lown-Ganong-Levine syndrome	UMLS		live		live	
+MONDO:0007204	Cole-Carpenter syndrome 1	UMLS:C4317154	COLE-CARPENTER SYNDROME 1	UMLS:CN029402		UMLS		live		not_present	
+MONDO:0007216	brachydactyly type A2	GARD:0000979	Brachydactyly type A2	GARD:0000989	Brachymesophalangy type 2	GARD		live		live	
+MONDO:0007226	brachydactyly-nystagmus-cerebellar ataxia syndrome	GARD:0000881	Biemond syndrome type 1	GARD:0000971	Biemond syndrome	GARD		live		live	
+MONDO:0007245	neurofibromatosis type 6	GARD:0001050	Cafe au lait spots, multiple	GARD:0003967	Autosomal dominant café au lait spots	GARD		live		live	
+MONDO:0007245	neurofibromatosis type 6	UMLS:C1861975	NF6	UMLS:CN035858	NF6	UMLS		live		live	
+MONDO:0007250	camptodactyly of fingers	MESH:C536852	Familial streblodactyly	MESH:C567780	Camptodactyly 1	MESH		live		live	
+MONDO:0007251	campomelic dysplasia	UMLS:C1861922	Campomelic dwarfism	UMLS:C1861923	ACAMPOMELIC CAMPOMELIC DYSPLASIA	UMLS		live		live	
+MONDO:0007256	hepatocellular carcinoma	DOID:684	hepatocellular carcinoma	DOID:686	liver carcinoma	DOID		live		live	
+MONDO:0007295	rolandic epilepsy	UMLS:C0376532	Rolandic epilepsy	UMLS:C2363129	Benign Rolandic epilepsy	UMLS		live		live	
+MONDO:0007295	rolandic epilepsy	UMLS:C0376532	Rolandic epilepsy	UMLS:CN200685	Centrotemporal epilepsy	UMLS		live		live	
+MONDO:0007295	rolandic epilepsy	UMLS:C2363129	Benign Rolandic epilepsy	UMLS:CN200685	Centrotemporal epilepsy	UMLS		live		live	
+MONDO:0007296	spinocerebellar ataxia type 31	UMLS:C1861736	SCA31	UMLS:C4274986	Spinocerebellar ataxia type 31	UMLS		live		live	
+MONDO:0007298	spinocerebellar ataxia type 29	UMLS:C1861732	SCA29	UMLS:C4274987	Spinocerebellar ataxia type 29	UMLS		live		live	
+MONDO:0007380	lattice corneal dystrophy type I	UMLS:C1690006	Lattice corneal dystrophy Type I	UMLS:CN207224	Lattice corneal dystrophy type 1	UMLS		live		live	
+MONDO:0007390	coumarin resistance	GARD:0012639	Warfarin sensitivity	GARD:0012721	Warfarin resistance	GARD		live		live	
+MONDO:0007390	coumarin resistance	UMLS:C0750384	COUMARIN RESISTANCE	UMLS:CN078029		UMLS		live		not_present	
+MONDO:0007401	craniosynostosis-Dandy-Walker malformation-hydrocephalus syndrome	GARD:0000998	Braddock Jones Superneau syndrome	GARD:0001592	Dandy-Walker malformation with sagittal craniosynostosis and hydrocephalus	GARD		live		live	
+MONDO:0007404	Cri-du-chat syndrome	UMLS:C0010314	Cri du chat syndrome	UMLS:CN776901	Deletion 5p	UMLS		live		live	
+MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0272258	Primary cryoglobulinemia	UMLS:C0340992	Cryoglobulinemic vasculitis	UMLS		live		live	
+MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0272258	Primary cryoglobulinemia	UMLS:C0343208	Essential mixed cryoglobulinemia	UMLS		live		live	
+MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0272258	Primary cryoglobulinemia	UMLS:C1852456	Primary cryoglobulinemia	UMLS		live		live	
+MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0340992	Cryoglobulinemic vasculitis	UMLS:C0343208	Essential mixed cryoglobulinemia	UMLS		live		live	
+MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0340992	Cryoglobulinemic vasculitis	UMLS:C1852456	Primary cryoglobulinemia	UMLS		live		live	
+MONDO:0007407	Cryoglobulinemic vasculitis	UMLS:C0343208	Essential mixed cryoglobulinemia	UMLS:C1852456	Primary cryoglobulinemia	UMLS		live		live	
+MONDO:0007416	Balkan nephropathy	UMLS:C0004698	Balkan nephropathy	UMLS:C4049993	Aristolochic acid nephropathy	UMLS		live		live	
+MONDO:0007436	dentin dysplasia type I	MESH:C531665	Opalescent dentin	MESH:C538215	Dentin dysplasia, type 1	MESH		live		live	
+MONDO:0007449	dermo-odonto dysplasia	UMLS:C1852144	Dermo-odonto dysplasia	UMLS:C4303591	Dermo-odonto dysplasia	UMLS		live		live	
+MONDO:0007471	Doyne honeycomb retinal dystrophy	UMLS:C1832174	DOYNE HONEYCOMB RETINAL DYSTROPHY	UMLS:C1852020	MALATTIA LEVENTINESE	UMLS		live		live	
+MONDO:0007471	Doyne honeycomb retinal dystrophy	UMLS:C1832174	DOYNE HONEYCOMB RETINAL DYSTROPHY	UMLS:CN205694	Malattia leventinese	UMLS		live		live	
+MONDO:0007471	Doyne honeycomb retinal dystrophy	UMLS:C1852020	MALATTIA LEVENTINESE	UMLS:CN205694	Malattia leventinese	UMLS		live		live	
+MONDO:0007492	early-onset generalized limb-onset dystonia	UMLS:C0013423	Dystonia musculorum deformans	UMLS:C3888090	EARLY-ONSET TORSION DYSTONIA	UMLS		live		live	
+MONDO:0007493	torsion dystonia 4	UMLS:C1851943	Hereditary whispering dysphonia	UMLS:C1860315	Hereditary whispering dysphonia	UMLS		live		live	
+MONDO:0007510	Clouston syndrome	GARD:0002056	Clouston syndrome	GARD:0004253	Patel Bixler syndrome	GARD		live		live	
+MONDO:0007517	ectrodactyly-cleft palate syndrome	UMLS:C1851848	ECTRODACTYLY-CLEFT PALATE SYNDROME	UMLS:CN229012	Ectrodactyly-cleft palate syndrome	UMLS		live		live	
+MONDO:0007561	multiple epiphyseal dysplasia type 1	UMLS:C1838280	Polyepiphyseal dysplasia type 1	UMLS:C4275061	Multiple epiphyseal dysplasia type 1	UMLS		live		live	
+MONDO:0007564	pilomatrixoma	UMLS:C0206711	Pilomatrixoma	UMLS:C0853031	Benign Hair Follicle Neoplasm	UMLS		live		live	
+MONDO:0007608	desmoid tumor	UMLS:C0079218	Aggressive fibromatosis	UMLS:C1851124	DESMOID DISEASE, HEREDITARY	UMLS		live		live	
+MONDO:0007608	desmoid tumor	UMLS:C0079218	Aggressive fibromatosis	UMLS:CN072436	Desmoid type fibromatosis	UMLS		live		live	
+MONDO:0007608	desmoid tumor	UMLS:C1851124	DESMOID DISEASE, HEREDITARY	UMLS:CN072436	Desmoid type fibromatosis	UMLS		live		live	
+MONDO:0007614	congenital fibrosis of extraocular muscles	UMLS:C1302995	Congenital fibrosis of extraocular muscles	UMLS:CN043677	Congenital fibrosis of the extraocular muscles	UMLS		live		live	
+MONDO:0007648	hereditary diffuse gastric adenocarcinoma	GARD:0010334	Diffuse gastric cancer	GARD:0010900	Hereditary diffuse gastric cancer	GARD		live		live	
+MONDO:0007650	MALT lymphoma	UMLS:C0242647	Mucosa-Associated Lymphoid Tissue Lymphoma	UMLS:C1850900	Mucosa-associated lymphoid tissue lymphoma	UMLS		live		live	
+MONDO:0007655	fissured tongue	UMLS:C0040412	Fissured tongue	UMLS:C1842051	Geographic Tongue and Fissured Tongue	UMLS		live		live	
+MONDO:0007667	subependymoma	EFO:1000553	Subependymoma	EFO:1001197	subependymal glioma	EFO		live		live	
+MONDO:0007669	renal cysts and diabetes syndrome	UMLS:C0431693	Renal cysts and diabetes syndrome	UMLS:CN206512	Renal dysfunction-early-onset diabetes syndrome	UMLS		live		live	
+MONDO:0007671	fibronectin glomerulopathy	MESH:C536826	Glomerulopathy with fibronectin deposits	MESH:C562900	Glomerulopathy with Giant Fibrillar Deposits	MESH		live		live	
+MONDO:0007686	gray platelet syndrome	UMLS:C0272302	Grey platelet syndrome	UMLS:C2717750	Platelet alpha-Granule Deficiency	UMLS		live		live	
+MONDO:0007686	gray platelet syndrome	UMLS:C0272302	Grey platelet syndrome	UMLS:CN205641	Platelet alpha-granule deficiency	UMLS		live		live	
+MONDO:0007686	gray platelet syndrome	UMLS:C2717750	Platelet alpha-Granule Deficiency	UMLS:CN205641	Platelet alpha-granule deficiency	UMLS		live		live	
+MONDO:0007713	clonic hemifacial spasm	UMLS:C1841639	Focal myoclonus of face	UMLS:C3536936	Clonic hemifacial spasm	UMLS		live		live	
+MONDO:0007716	alpha thalassemia-intellectual disability syndrome type 1	UMLS:C0475813	Alpha thalassemia-mental retardation syndrome	UMLS:C0795917	Alpha thalassemia-mental retardation syndrome	UMLS		live		live	
+MONDO:0007744	cholesterol-ester transfer protein deficiency	UMLS:C3875011	Familial hyperalphalipoproteinemia	UMLS:CN205999	Familial hyperalphalipoproteinemia	UMLS		live		live	
+MONDO:0007749	autosomal recessive infantile hypercalcemia	UMLS:C0268080	Idiopathic hypercalcemia of infancy	UMLS:C4329374	Autosomal Recessive Infantile Hypercalcemia	UMLS		live		live	
+MONDO:0007749	autosomal recessive infantile hypercalcemia	UMLS:C0268080	Idiopathic hypercalcemia of infancy	UMLS:CN203398	Familial infantile hypercalcemia with suppressed intact parathyroid hormone	UMLS		live		live	
+MONDO:0007749	autosomal recessive infantile hypercalcemia	UMLS:C4329374	Autosomal Recessive Infantile Hypercalcemia	UMLS:CN203398	Familial infantile hypercalcemia with suppressed intact parathyroid hormone	UMLS		live		live	
+MONDO:0007780	hypertelorism, Teebi type	UMLS:C0796179	Teebi syndrome	UMLS:CN199596	Teebi syndrome	UMLS		live		live	
+MONDO:0007803	multiple system atrophy	UMLS:C0037019	Shy-Drager syndrome	UMLS:C0393571		UMLS		live		not_present	
+MONDO:0007848	autosomal dominant keratitis	UMLS:C1835698	Hereditary keratitis	UMLS:C4017065	Autosomal dominant keratitis	UMLS		live		live	
+MONDO:0007848	autosomal dominant keratitis	UMLS:C1835698	Hereditary keratitis	UMLS:CN068649	Keratitis, autosomal dominant	UMLS		live		live	
+MONDO:0007848	autosomal dominant keratitis	UMLS:C4017065	Autosomal dominant keratitis	UMLS:CN068649	Keratitis, autosomal dominant	UMLS		live		live	
+MONDO:0007864	angioosteohypertrophic syndrome	UMLS:C0022739	KLIPPEL-TRENAUNAY-WEBER SYNDROME	UMLS:CN201567	Klippel-Trénaunay-Weber syndrome	UMLS		live		live	
+MONDO:0007879	larynx atresia	GARD:0003192	Larynx, congenital partial atresia of	GARD:0003194	Larynx atresia	GARD		live		live	
+MONDO:0007880	congenital laryngeal web	MESH:C537676	Gay Feinmesser Cohen syndrome	MESH:C563636	Laryngeal Web, Familial	MESH		live		live	
+MONDO:0007886	uterine corpus leiomyoma	UMLS:C0042133	Uterine fibroids	UMLS:C2242776	Plexiform leiomyoma	UMLS		live		live	
+MONDO:0007888	hereditary leiomyomatosis and renal cell cancer	UMLS:C1708350	Reed syndrome	UMLS:CN239164	Multiple Cutaneous and Uterine Leiomyomas	UMLS		live		live	
+MONDO:0007891	familial generalized lentiginosis	UMLS:C3492944	LENTIGINOSIS PROFUSA	UMLS:CN201466	Familial multiple lentigines syndrome without systemic involvement	UMLS		live		live	
+MONDO:0007893	Noonan syndrome with multiple lentigines	UMLS:C0175704	Leopard syndrome	UMLS:CN074218	LPRD1	UMLS		live		live	
+MONDO:0007896	acute monocytic leukemia	UMLS:C0023465	Acute monocytic leukemia	UMLS:C1318544	Acute Monocytic Leukemia	UMLS		live		live	
+MONDO:0007908	multiple symmetric lipomatosis	UMLS:C0023804	Multiple symmetrical lipomatosis	UMLS:C0024445	LIPOMATOSIS, FAMILIAL BENIGN CERVICAL	UMLS		live		live	
+MONDO:0007908	multiple symmetric lipomatosis	UMLS:C0023804	Multiple symmetrical lipomatosis	UMLS:CN201658	Launois-Bensaude lipomatosis	UMLS		live		live	
+MONDO:0007908	multiple symmetric lipomatosis	UMLS:C0024445	LIPOMATOSIS, FAMILIAL BENIGN CERVICAL	UMLS:CN201658	Launois-Bensaude lipomatosis	UMLS		live		live	
+MONDO:0007916	primary intestinal lymphangiectasia	UMLS:C0267372	Primary intestinal lymphangiectasia	UMLS:CN206410	Waldmann disease	UMLS		live		live	
+MONDO:0007920	Meige disease	DOID:0070213	hereditary lymphedema II	DOID:3982	Meige syndrome	DOID		live		live	
+MONDO:0007920	Meige disease	MESH:C562467	Lymphedema, Hereditary, II	MESH:D008538	Meige Syndrome	MESH		live		live	
+MONDO:0007928	Fechtner syndrome	UMLS:C0403445	Fechtner Syndrome	UMLS:CN226030	Fechtner syndrome	UMLS		live		live	
+MONDO:0007929	Epstein syndrome	UMLS:C0398641	Epstein Syndrome	UMLS:CN226018	Epstein syndrome	UMLS		live		live	
+MONDO:0007935	cystoid macular edema	UMLS:C0024440	Cystoid macular edema	UMLS:C0730317	Autosomal dominant cystoid macular edema	UMLS		live		live	
+MONDO:0007937	renal hypomagnesemia 2	UMLS:C1835171	Renal hypomagnesemia type 2	UMLS:C4511005	Autosomal dominant primary hypomagnesemia with hypocalciuria	UMLS		live		live	
+MONDO:0007947	Marfan syndrome	Orphanet:284963	Marfan syndrome type 1	Orphanet:558	Marfan syndrome	Orphanet		live		live	
+MONDO:0007947	Marfan syndrome	UMLS:C0024796	Marfan's syndrome	UMLS:CN202883	MFS1	UMLS		live		live	
+MONDO:0007959	medulloblastoma	DOID:0050902	medulloblastoma	DOID:0060104	cerebellar medulloblastoma	DOID		live		live	
+MONDO:0007959	medulloblastoma	UMLS:C0025149	Medulloblastoma	UMLS:C1334410	Localized Primitive Neuroectodermal Tumor	UMLS		live		live	
+MONDO:0008006	Mobius syndrome	UMLS:C0221060	Möbius syndrome	UMLS:C0853240	Congenital facial diplegia	UMLS		live		live	
+MONDO:0008045	spinal muscular atrophy-progressive myoclonic epilepsy syndrome	GARD:0003044	Jankovic Rivera syndrome	GARD:0003875	Myoclonus hereditary progressive distal muscular atrophy	GARD		live		live	
+MONDO:0008047	episodic ataxia type 1	UMLS:C1719788	Episodic ataxia type 1	UMLS:CN042654	Myokymia 1 with or without hypomagnesemia	UMLS		live		live	
+MONDO:0008049	myopathy, distal, infantile-onset	UMLS:C1834556	Myopathy, Distal, with Onset in Infancy	UMLS:C4011725	MYOPATHY, DISTAL, INFANTILE-ONSET	UMLS		live		live	
+MONDO:0008071	autosomal dominant progressive nephropathy with hypertension	UMLS:C0403443	Autosomal dominant progressive nephropathy with hypertension	UMLS:C3839782	Autosomal dominant progressive nephropathy with hypertension	UMLS		live		live	
+MONDO:0008083	neuronal ceroid lipofuscinosis 4B	UMLS:C1834207	CLN4B disease	UMLS:C4284284	Neuronal Ceroid Lipofuscinosis Type 4B	UMLS		live		live	
+MONDO:0008094	familial multiple nevi flammei	UMLS:C0235752		UMLS:CN205384	Familial multiple port-wine stains	UMLS		not_present		live	
+MONDO:0008136	isolated optic nerve hypoplasia	UMLS:C1833797	OPTIC NERVE HYPOPLASIA, BILATERAL	UMLS:C4510723	Isolated optic nerve hypoplasia	UMLS		live		live	
+MONDO:0008138	syndromic orbital border hypoplasia	UMLS:C1833795	Urrets-Zavalia syndrome	UMLS:C4273912	Syndromic orbital border hypoplasia	UMLS		live		live	
+MONDO:0008145	Ollier disease	UMLS:C0014084	Enchondromatosis	UMLS:C0206641	Osteochondromatosis	UMLS		live		live	
+MONDO:0008145	Ollier disease	UMLS:C0014084	Enchondromatosis	UMLS:CN203308	Dyschondroplasia	UMLS		live		live	
+MONDO:0008145	Ollier disease	UMLS:C0206641	Osteochondromatosis	UMLS:CN203308	Dyschondroplasia	UMLS		live		live	
+MONDO:0008146	osteogenesis imperfecta type 1	UMLS:CN201103	Van der Hoeve syndrome	UMLS:CN536249	Osteogenesis imperfecta type 1	UMLS		live		live	
+MONDO:0008152	multicentric carpo-tarsal osteolysis with or without nephropathy	GARD:0003818	Multicentric osteolysis nephropathy	GARD:0013042	Multicentric carpotarsal osteolysis syndrome	GARD		live		live	
+MONDO:0008165	southeast Asian ovalocytosis	UMLS:C1833690	Ovalocytosis, Hereditary Hemolytic	UMLS:C1862323	Southeast Asian ovalocytosis	UMLS		live		live	
+MONDO:0008171	nephrolithiasis	UMLS:C0156257	Calculus of kidney and ureter	UMLS:C0392525	Nephrolithiasis	UMLS		live		live	
+MONDO:0008171	nephrolithiasis	UMLS:C0156257	Calculus of kidney and ureter	UMLS:C1833683	Nephrolithiasis, calcium oxalate	UMLS		live		live	
+MONDO:0008171	nephrolithiasis	UMLS:C0392525	Nephrolithiasis	UMLS:C1833683	Nephrolithiasis, calcium oxalate	UMLS		live		live	
+MONDO:0008219	pemphigus vulgaris	GARD:0004270	Familial pemphigus vulgaris	GARD:0007355	Pemphigus vulgaris	GARD		live		live	
+MONDO:0008224	hyperkalemic periodic paralysis	UMLS:C0238357	Hyperkalemic periodic paralysis	UMLS:CN074266	HYPP	UMLS		live		live	
+MONDO:0008259	familial spontaneous pneumothorax	UMLS:C1868193	Primary spontaneous pneumothorax	UMLS:C4275252	Familial spontaneous pneumothorax	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	MEDGEN:358137		MEDGEN:881357		MEDGEN		not_present		not_present	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C1868139	Medullary cystic kidney disease 1	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4054549	Medullary Cystic Kidney Disease Type I	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:C4511620	Autosomal dominant tubulointerstitial kidney disease	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008264	autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:CN204412	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS:CN536252	Autosomal dominant medullary cystic kidney disease with or without hyperuricemia	UMLS		live		live	
+MONDO:0008272	polysyndactyly	GARD:0001616	Crossed polydactyly type 1	GARD:0009903	Preaxial polydactyly type 4	GARD		live		live	
+MONDO:0008272	polysyndactyly	UMLS:C0265553		UMLS:C1868111	Preaxial polydactyly type 4	UMLS		not_present		live	
+MONDO:0008280	Peutz-Jeghers syndrome	UMLS:C0031269	Peutz-Jeghers syndrome	UMLS:C1333088	Colonic hamartomatous polyps	UMLS		live		live	
+MONDO:0008295	sporadic porphyria cutanea tarda	UMLS:C1276127	Sporadic porphyria cutanea tarda	UMLS:C1867968	Porphyria cutanea tarda type I	UMLS		live		live	
+MONDO:0008310	progeria	UMLS:C0033300	Progeria	UMLS:CN236401	Progeria	UMLS		live		live	
+MONDO:0008346	pulmonary hemosiderosis	DOID:10328	siderosis	DOID:12118	pulmonary hemosiderosis	DOID		live		live	
+MONDO:0008346	pulmonary hemosiderosis	GARD:0006763	Idiopathic pulmonary hemosiderosis	GARD:0007645	Siderosis	GARD		live		live	
+MONDO:0008348	pulmonary nodular lymphoid hyperplasia	UMLS:C1334969	Pulmonary nodular lymphoid hyperplasia	UMLS:C1867419	Pulmonary pseudolymphoma	UMLS		live		live	
+MONDO:0008384	rheumatoid nodulosis	SCTID:402426007	rheumatoid nodulosis (disorder)	SCTID:402427003	accelerated rheumatoid nodulosis (disorder)	SCTID		live		live	
+MONDO:0008391	Robinow-Sorauf syndrome	UMLS:C1867146	ROBINOW-SORAUF SYNDROME	UMLS:CN203672	Robinow-Sorauf syndrome	UMLS		live		live	
+MONDO:0008438	hereditary spastic paraplegia 4	UMLS:C1866855	SPG4	UMLS:C4510079	Autosomal dominant spastic paraplegia type 4	UMLS		live		live	
+MONDO:0008458	spinocerebellar ataxia type 2	DOID:0050955	spinocerebellar ataxia type 2	DOID:0060204	amyotrophic lateral sclerosis type 13	DOID		live		live	
+MONDO:0008485	Sebocystomatosis	UMLS:C0259771	Steatocystoma multiplex	UMLS:C3671377	Sebocystomatosis	UMLS		live		live	
+MONDO:0008501	Sturge-Weber syndrome	UMLS:C0038505		UMLS:CN204001	Sturge-Weber-Krabbe syndrome	UMLS		not_present		live	
+MONDO:0008512	syndactyly type 1	UMLS:C1861380	Syndactyly type 1	UMLS:C4275033	Syndactyly type 1	UMLS		live		live	
+MONDO:0008546	thanatophoric dysplasia type 1	UMLS:C1300256	Thanatophoric dysplasia, type 1	UMLS:C1868678	Thanatophoric dwarfism type 1	UMLS		live		live	
+MONDO:0008547	thanatophoric dysplasia type 2	UMLS:C1300257	Thanatophoric dysplasia, type 2	UMLS:CN206542	Thanatophoric dwarfism-cloverleaf skull syndrome	UMLS		live		live	
+MONDO:0008557	Paris-Trousseau thrombocytopenia	UMLS:C1861178	THROMBOCYTOPENIA, PARIS-TROUSSEAU TYPE	UMLS:C1956093	Paris-Trousseau Thrombocytopenia	UMLS		live		live	
+MONDO:0008583	inherited torticollis (disease)	SCTID:268240006	congenital torticollis (disorder)	SCTID:70070008	torticollis (disorder)	SCTID		live		live	
+MONDO:0008592	tricho-dento-osseous syndrome	GARD:0005252	Tricho-dento-osseous syndrome 1	GARD:0007799	Tricho-dento-osseous syndrome	GARD		live		live	
+MONDO:0008633	Muckle-Wells syndrome	UMLS:C0268390	Muckle-Wells syndrome	UMLS:C1304205	Neutrophilic urticaria	UMLS		live		live	
+MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	GARD:0001217	Retinal vasculopathy with cerebral leukodystrophy	GARD:0002558	Grand Kaine Fulling syndrome	GARD		live		live	
+MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	GARD:0001217	Retinal vasculopathy with cerebral leukodystrophy	GARD:0010535	Hereditary vascular retinopathy	GARD		live		live	
+MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	GARD:0002558	Grand Kaine Fulling syndrome	GARD:0010535	Hereditary vascular retinopathy	GARD		live		live	
+MONDO:0008641	retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	SCTID:720854004	cerebroretinal vasculopathy (disorder)	SCTID:721141004	hereditary vascular retinopathy (disorder)	SCTID		live		live	
+MONDO:0008642	VACTERL/vater association	UMLS:C0220708	VATER association	UMLS:C1735591		UMLS		live		not_present	
+MONDO:0008642	VACTERL/vater association	UMLS:C0220708	VATER association	UMLS:CN206312	VATER association	UMLS		live		live	
+MONDO:0008642	VACTERL/vater association	UMLS:C1735591		UMLS:CN206312	VATER association	UMLS		not_present		live	
+MONDO:0008650	posterior fusion of lumbosacral vertebrae-blepharoptosis syndrome	GARD:0002276	Faulk Epstein Jones syndrome	GARD:0005487	Vertebral fusion posterior lumbosacral blepharoptosis	GARD		live		live	
+MONDO:0008681	WAGR syndrome	GARD:0001732	Chromosome 11p deletion	GARD:0005528	WAGR syndrome	GARD		live		live	
+MONDO:0008681	WAGR syndrome	UMLS:C0206115	WAGR syndrome	UMLS:C2931803	Deletion 11p13	UMLS		live		live	
+MONDO:0008682	Denys-Drash syndrome	UMLS:C0950121	Wilms tumor and pseudohermaphroditism	UMLS:C3151568	NEPHROTIC SYNDROME TYPE 4	UMLS		live		live	
+MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796117	PITT-ROGERS-DANKS SYNDROME	UMLS:C0796202	WITTWER SYNDROME	UMLS		live		live	
+MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796117	PITT-ROGERS-DANKS SYNDROME	UMLS:C1956097	Wolf Hirschhorn syndrome	UMLS		live		live	
+MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796117	PITT-ROGERS-DANKS SYNDROME	UMLS:CN207113	Pitt-Rogers-Danks syndrome	UMLS		live		live	
+MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796202	WITTWER SYNDROME	UMLS:C1956097	Wolf Hirschhorn syndrome	UMLS		live		live	
+MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C0796202	WITTWER SYNDROME	UMLS:CN207113	Pitt-Rogers-Danks syndrome	UMLS		live		live	
+MONDO:0008684	Wolf-Hirschhorn syndrome	UMLS:C1956097	Wolf Hirschhorn syndrome	UMLS:CN207113	Pitt-Rogers-Danks syndrome	UMLS		live		live	
+MONDO:0008698	achalasia (disease)	UMLS:C0014848	Esophageal achalasia	UMLS:C1321756	Achalasia	UMLS		live		live	
+MONDO:0008698	achalasia (disease)	UMLS:C0014848	Esophageal achalasia	UMLS:C2939435	Hypertensive lower esophageal sphincter	UMLS		live		live	
+MONDO:0008698	achalasia (disease)	UMLS:C1321756	Achalasia	UMLS:C2939435	Hypertensive lower esophageal sphincter	UMLS		live		live	
+MONDO:0008704	short-limb skeletal dysplasia with severe combined immunodeficiency	GARD:0000463	Achondroplasia and Swiss type agammaglobulinemia	GARD:0002988	Achondroplasia and severe combined immunodeficiency	GARD		live		live	
+MONDO:0008709	acrocephalopolydactyly	UMLS:C3495588	Acrocephalopolydactylous dysplasia	UMLS:CN201238	Elejalde syndrome	UMLS		live		live	
+MONDO:0008716	Acrogeria	UMLS:C0238590	Acrogeria	UMLS:C0406584	Gottron syndrome	UMLS		live		live	
+MONDO:0008728	classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	GARD:0005757	21-hydroxylase deficiency	GARD:0012665	Classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	GARD		live		live	
+MONDO:0008728	classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	SCTID:124221007	deficiency of steroid 21-monooxygenase (disorder)	SCTID:717261006	classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency (disorder)	SCTID		live		live	
+MONDO:0008747	oculocutaneous albinism type 3	GARD:0004039	Oculocutaneous albinism type 3	GARD:0009641	Rufous oculocutaneous albinism	GARD		live		live	
+MONDO:0008749	pseudohypoparathyroidism type 2	UMLS:C2932717	Pseudohypoparathyroidism Type 2	UMLS:CN206737	Pseudohypoparathyroidism type 2	UMLS		live		live	
+MONDO:0008753	alkaptonuria	UMLS:C0002066	Alkaptonuria	UMLS:C2931645	Hereditary ochronosis	UMLS		live		live	
+MONDO:0008758	mitochondrial DNA depletion syndrome 4a	DOID:0080122	mitochondrial DNA depletion syndrome 4a	DOID:1442	Alpers syndrome	DOID		live		live	
+MONDO:0008771	amelogenesis imperfecta type 1G	GARD:0000646	Amelogenesis imperfecta nephrocalcinosis	GARD:0009860	Amelogenesis imperfecta hypoplastic type, IG	GARD		live		live	
+MONDO:0008772	amelogenesis imperfecta type 2A1	MESH:C538242	Amelogenesis imperfecta pigmented hypomaturation type	MESH:C567146	Amelogenesis Imperfecta, Hypomaturation Type, Iia1	MESH		live		live	
+MONDO:0008786	pyridoxine-responsive sideroblastic anemia	UMLS:C0272027	Pyridoxine-responsive sideroblastic anemia	UMLS:C1859787	ANEMIA, SIDEROBLASTIC, PYRIDOXINE-RESPONSIVE, AUTOSOMAL RECESSIVE	UMLS		live		live	
+MONDO:0008798	nonsyndromic congenital nail disorder 4	DOID:0050643	anonychia congenita	DOID:0080082	nonsyndromic congenital nail disorder 4	DOID		live		live	
+MONDO:0008810	familial apolipoprotein C-II deficiency	UMLS:C0268199	Familial apolipoprotein C-II deficiency	UMLS:C1720779	Familial apoC-II deficiency	UMLS		live		live	
+MONDO:0008869	Seckel syndrome 1	UMLS:C1837590	Seckel Syndrome 3	UMLS:CN033164	SCKL1	UMLS		live		live	
+MONDO:0008895	hereditary arterial and articular multiple calcification syndrome	UMLS:C1859372	Calcification of joints and arteries	UMLS:C4305347	Hereditary arterial and articular multiple calcification syndrome	UMLS		live		live	
+MONDO:0008915	dilated cardiomyopathy-hypergonadotropic hypogonadism syndrome	UMLS:C0796031	Malouf syndrome	UMLS:C0796083	Najjar syndrome	UMLS		live		live	
+MONDO:0008926	COFS syndrome	GARD:0001060	Cataract-microcephaly-failure to thrive-kyphoscoliosis	GARD:0006027	Cerebro-oculo-facio-skeletal syndrome	GARD		live		live	
+MONDO:0008947	bilateral striopallidodentate calcinosis	SCTID:110997000	fahr's syndrome (disorder)	SCTID:230311004	basal ganglia degeneration with calcification (disorder)	SCTID		live		live	
+MONDO:0008947	bilateral striopallidodentate calcinosis	UMLS:C0393589	Basal ganglia degeneration with calcification	UMLS:CN852731	Primary Familial Brain Calcification	UMLS		live		live	
+MONDO:0008959	CHAND syndrome	UMLS:C0406733	Curly hair, ankyloblepharon, nail dysplasia syndrome	UMLS:CN199447	CHAND syndrome	UMLS		live		live	
+MONDO:0008974	Greenberg dysplasia	UMLS:C2931048	HEM dysplasia	UMLS:CN199524	HEM dysplasia	UMLS		live		live	
+MONDO:0008982	central areolar choroidal dystrophy	SCTID:231996009	central areolar choroidal sclerosis (disorder)	SCTID:312918002	choroidal dystrophy (disorder)	SCTID		live		live	
+MONDO:0009007	Jalili syndrome	UMLS:C3495589	Jalili syndrome	UMLS:CN200616	Cone rod dystrophy-amelogenesis imperfecta syndrome	UMLS		live		live	
+MONDO:0009008	heart defect-tongue hamartoma-polysyndactyly syndrome	GARD:0002612	Heart defect, tongue hamartoma and polysyndactyly	GARD:0004166	Orstavik Lindemann Solberg syndrome	GARD		live		live	
+MONDO:0009009	hypoplasminogenemia	UMLS:C0398621	Hypoplasminogenemia	UMLS:C1968804	Plasminogen deficiency type 1	UMLS		live		live	
+MONDO:0009025	apparent mineralocorticoid excess	UMLS:C2936861	CORTISOL 11-BETA-KETOREDUCTASE DEFICIENCY	UMLS:C3887949	Apparent mineralocorticoid excess	UMLS		live		live	
+MONDO:0009025	apparent mineralocorticoid excess	UMLS:C2936861	CORTISOL 11-BETA-KETOREDUCTASE DEFICIENCY	UMLS:CN203981	Ulick syndrome	UMLS		live		live	
+MONDO:0009025	apparent mineralocorticoid excess	UMLS:C3887949	Apparent mineralocorticoid excess	UMLS:CN203981	Ulick syndrome	UMLS		live		live	
+MONDO:0009032	cranioectodermal dysplasia	UMLS:C0432235	Cranioectodermal dysplasia	UMLS:CN016627	Sensenbrenner syndrome	UMLS		live		live	
+MONDO:0009032	cranioectodermal dysplasia	UMLS:C0432235	Cranioectodermal dysplasia	UMLS:CN119432	Sensenbrenner syndrome	UMLS		live		live	
+MONDO:0009032	cranioectodermal dysplasia	UMLS:CN016627	Sensenbrenner syndrome	UMLS:CN119432	Sensenbrenner syndrome	UMLS		live		live	
+MONDO:0009044	Crigler-Najjar syndrome	UMLS:C0010324	UGT deficiency type 1	UMLS:CN119421	UGT deficiency	UMLS		live		live	
+MONDO:0009049	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:C1857451	ACTH-INDEPENDENT MACRONODULAR ADRENAL HYPERPLASIA	UMLS:C2062388	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS		live		live	
+MONDO:0009049	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:C1857451	ACTH-INDEPENDENT MACRONODULAR ADRENAL HYPERPLASIA	UMLS:CN200644	Primary bilateral macronodular adrenal hyperplasia	UMLS		live		live	
+MONDO:0009049	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:C2062388	Cushing syndrome due to macronodular adrenal hyperplasia	UMLS:CN200644	Primary bilateral macronodular adrenal hyperplasia	UMLS		live		live	
+MONDO:0009050	Cushing disease due to pituitary adenoma	UMLS:C0221406	Pituitary-dependent Cushing's disease	UMLS:C1306214	ACTH-secreting pituitary adenoma	UMLS		live		live	
+MONDO:0009054	autosomal recessive cutis laxa type 2, classic type	DOID:0070136	autosomal dominant cutis laxa 2	DOID:0070141	autosomal recessive cutis laxa type II classic type	DOID		live		live	
+MONDO:0009058	cystathioninuria (disease)	UMLS:C0220993	Cystathioninuria	UMLS:C0268616	Gamma-cystathionase deficiency	UMLS		live		live	
+MONDO:0009058	cystathioninuria (disease)	UMLS:C0220993	Cystathioninuria	UMLS:C3495552	CYSTATHIONASE DEFICIENCY	UMLS		live		live	
+MONDO:0009058	cystathioninuria (disease)	UMLS:C0268616	Gamma-cystathionase deficiency	UMLS:C3495552	CYSTATHIONASE DEFICIENCY	UMLS		live		live	
+MONDO:0009070	D-glyceric aciduria	UMLS:C0342765	D-Glyceric aciduria	UMLS:C1291386	D-glyceric acidemia	UMLS		live		live	
+MONDO:0009109	lysinuric protein intolerance	GARD:0001853	Dibasic aminoaciduria 2	GARD:0003335	Lysinuric protein intolerance	GARD		live		live	
+MONDO:0009114	congenital sucrase-isomaltase deficiency	GARD:0006183	Congenital sucrose isomaltose malabsorption	GARD:0007710	Congenital sucrase-isomaltase deficiency	GARD		live		live	
+MONDO:0009146	ectodermal dysplasia-sensorineural deafness syndrome	MESH:C535757	Congenital ectodermal dysplasia with hearing loss	MESH:C565606	Ectodermal Dysplasia and Neurosensory Deafness	MESH		live		live	
+MONDO:0009151	Zlotogora-Ogur syndrome	GARD:0000375	Zlotogora syndrome	GARD:0001045	Bustos Simosa Pinto Cisternas syndrome	GARD		live		live	
+MONDO:0009162	Ellis-van Creveld syndrome	UMLS:C0013903	Ellis-van Creveld syndrome	UMLS:CN239258	Ellis-van Creveld Syndrome	UMLS		live		live	
+MONDO:0009196	ermine phenotype	UMLS:C0268501	BADS syndrome	UMLS:C1856899	Pigmentary disorder with hearing loss	UMLS		live		live	
+MONDO:0009197	transient erythroblastopenia of childhood	UMLS:C0238478	Transient erythroblastopenia of childhood	UMLS:C0451688	Transient acquired pure red cell aplasia	UMLS		live		live	
+MONDO:0009218	Farber lipogranulomatosis	UMLS:C0268255	Farber lipogranulomatosis	UMLS:CN204335		UMLS		live		not_present	
+MONDO:0009243	Fraser-like syndrome	UMLS:C1856708	FRASER-LIKE SYNDROME	UMLS:CN200837	Fraser-like syndrome	UMLS		live		live	
+MONDO:0009268	Gaucher disease-ophthalmoplegia-cardiovascular calcification syndrome	GARD:0002445	Gaucher-like disease	GARD:0012504	Gaucher disease - ophthalmoplegia - cardiovascular calcification	GARD		live		live	
+MONDO:0009268	Gaucher disease-ophthalmoplegia-cardiovascular calcification syndrome	UMLS:C1856476	Gaucher-like disease	UMLS:C2931585	Gaucher-like disease	UMLS		live		live	
+MONDO:0009287	glycogen storage disease due to glucose-6-phosphatase deficiency type IA	UMLS:C2919796	Glycogen storage disease type Ia	UMLS:CN069618		UMLS		live		not_present	
+MONDO:0009287	glycogen storage disease due to glucose-6-phosphatase deficiency type IA	UMLS:C2919796	Glycogen storage disease type Ia	UMLS:CN205860	Glycogenosis due to glucose-6-phosphatase deficiency type Ia	UMLS		live		live	
+MONDO:0009287	glycogen storage disease due to glucose-6-phosphatase deficiency type IA	UMLS:CN069618		UMLS:CN205860	Glycogenosis due to glucose-6-phosphatase deficiency type Ia	UMLS		not_present		live	
+MONDO:0009290	glycogen storage disease II	GARD:0002503	Glucosidase acid-1,4-alpha deficiency	GARD:0005714	Glycogen storage disease type 2	GARD		live		live	
+MONDO:0009290	glycogen storage disease II	UMLS:C0017921	Glycogenosis type II	UMLS:C1968741	GLYCOGEN STORAGE DISEASE IIIc	UMLS		live		live	
+MONDO:0009290	glycogen storage disease II	UMLS:C0017921	Glycogenosis type II	UMLS:C3695005	GLYCOGEN STORAGE DISEASE, TYPE IIIc	UMLS		live		live	
+MONDO:0009290	glycogen storage disease II	UMLS:C1968741	GLYCOGEN STORAGE DISEASE IIIc	UMLS:C3695005	GLYCOGEN STORAGE DISEASE, TYPE IIIc	UMLS		live		live	
+MONDO:0009291	glycogen storage disease III	UMLS:C0017922	Glycogen storage disease type III	UMLS:CN204781	Glycogenosis type III	UMLS		live		live	
+MONDO:0009292	glycogen storage disease due to glycogen branching enzyme deficiency	UMLS:C0017923	Glycogen storage disease type IV	UMLS:CN204783	Glycogenosis type IV	UMLS		live		live	
+MONDO:0009296	glycoprotein storage disease	UMLS:C0268220	Glycoprotein storage disorder	UMLS:C1856275	GLYCOPROTEIN STORAGE DISEASE	UMLS		live		live	
+MONDO:0009297	familial renal glucosuria	UMLS:C0017980	Renal glycosuria	UMLS:C3245525	Familial renal glucosuria	UMLS		live		live	
+MONDO:0009312	lipodystrophy due to peptidic growth factors deficiency	GARD:0004280	Peptidic growth factors deficiency	GARD:0012604	Lipodystrophy due to peptidic growth factors deficiency	GARD		live		live	
+MONDO:0009343	Hirschsprung disease with ulnar polydactyly, polysyndactyly of big toes, and ventricular septal defect	MESH:C538120	Hirschsprung disease polydactyly heart disease	MESH:C565517	Hirschsprung Disease with Ulnar Polydactyly, Polysyndactyly of Big Toes, and Ventricular Septal Defect	MESH		live		live	
+MONDO:0009351	homocarnosinosis	UMLS:C0268632	Homocarnosinase deficiency	UMLS:C3495554	Homocarnosinase deficiency	UMLS		live		live	
+MONDO:0009364	muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type A1	UMLS:C4284790	Muscular Dystrophy-Dystroglycanopathy (Congenital with Brain and Eye Anomalies) Type A, 1	UMLS:CN033898	POMT1-Related Muscle Diseases	UMLS		live		live	
+MONDO:0009370	L-2-hydroxyglutaric aciduria	UMLS:C1855995	L-2-hydroxyglutaric aciduria	UMLS:C3888081	L-2-HYDROXYGLUTARIC ACIDEMIA	UMLS		live		live	
+MONDO:0009380	Dubin-Johnson syndrome	GARD:0002793	Hyperbilirubinemia type 2	GARD:0006289	Dubin-Johnson syndrome	GARD		live		live	
+MONDO:0009383	transient familial neonatal hyperbilirubinemia	GARD:0002791	Hyperbilirubinemia transient familial neonatal	GARD:0003304	Lucey-Driscoll syndrome	GARD		live		live	
+MONDO:0009405	cervical hypertrichosis-peripheral neuropathy syndrome	UMLS:C1855902	Cervical hypertrichosis-peripheral neuropathy syndrome	UMLS:C2931676	Cervical hypertrichosis neuropathy	UMLS		live		live	
+MONDO:0009411	autoimmune polyendocrine syndrome type 1	GARD:0005558	Whitaker syndrome	GARD:0008466	Autoimmune polyglandular syndrome type 1	GARD		live		live	
+MONDO:0009414	glycogen storage disease due to hepatic glycogen synthase deficiency	GARD:0002513	Glycogen storage disease type 0, liver	GARD:0002889	Hypoglycemia with deficiency of glycogen synthetase in the liver	GARD		live		live	
+MONDO:0009414	glycogen storage disease due to hepatic glycogen synthase deficiency	UMLS:C0342748	Glycogen synthase deficiency	UMLS:C1855861	Glycogenosis type 0a	UMLS		live		live	
+MONDO:0009465	multiple intestinal atresia	Orphanet:2300	Multiple intestinal atresia	Orphanet:436252	Combined immunodeficiency-enteropathy spectrum	Orphanet		live		live	
+MONDO:0009470	Baraitser-Winter syndrome 1	UMLS:C1837819	Cerebrofrontofacial Syndrome	UMLS:C1853623	Fryns-Aftimos Syndrome	UMLS		live		live	
+MONDO:0009476	atresia of small intestine	GARD:0000140	Atresia of small intestine	GARD:0006799	Jejunal atresia	GARD		live		live	
+MONDO:0009477	Stromme syndrome	Orphanet:444069	Lethal fetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	Orphanet:506307	Stromme syndrome	Orphanet		live		live	
+MONDO:0009504	mitochondrial DNA depletion syndrome 9	MESH:C538134	Lactic acidosis congenital infantile	MESH:C566885	Lactic Acidosis, Fatal Infantile	MESH		live		live	
+MONDO:0009510	Laron syndrome with immunodeficiency	UMLS:C1855548	Short stature due to STAT5b deficiency	UMLS:C4510411	Laron syndrome with immunodeficiency	UMLS		live		live	
+MONDO:0009512	lethal Larsen-like syndrome	UMLS:C1855535	Lethal Larsen-like syndrome	UMLS:C4304741	Lethal Larsen-like syndrome	UMLS		live		live	
+MONDO:0009520	3-hydroxy-3-methylglutaric aciduria	UMLS:C0268601	HMG-CoA lyase deficiency	UMLS:C1533587	Hydroxymethylglutaric aciduria	UMLS		live		live	
+MONDO:0009522	Leukomelanoderma-infantilism-intellectual disability-hypodontia-hypotrichosis syndrome	UMLS:C0406729	Berlin syndrome	UMLS:C1855504	Ectodermal dysplasia, Berlin type	UMLS		live		live	
+MONDO:0009529	pyruvate dehydrogenase E3 deficiency	UMLS:C0268193	E3-deficient maple syrup urine disease	UMLS:CN043137	Dihydrolipoamide Dehydrogenase E3 Deficiency	UMLS		live		live	
+MONDO:0009557	mandibuloacral dysplasia with type A lipodystrophy	UMLS:CN206381	Mandibuloacral dysplasia with type A lipodystrophy	UMLS:CN236772	Mandibuloacral dysplasia with type A lipodystrophy	UMLS		live		live	
+MONDO:0009591	metachromatic leukodystrophy, juvenile form	GARD:0003230	Metachromatic leukodystrophy	GARD:0004545	Pseudoarylsulfatase A deficiency	GARD		live		live	
+MONDO:0009609	methylcobalamin deficiency type cblG	GARD:0002733	Homocystinuria due to defect in methylation cbl g	GARD:0003577	Methylcobalamin deficiency cbl G type	GARD		live		live	
+MONDO:0009610	3-methylglutaconic aciduria type 1	UMLS:C0342727	MGA1	UMLS:C0342728	3-Methylglutaconic aciduria type 1	UMLS		live		live	
+MONDO:0009611	3-methylglutaconic aciduria type 4	UMLS:C0574085	3-Methylglutaconic aciduria type 4	UMLS:C1855126	MGA4	UMLS		live		live	
+MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	SCTID:73843004	cobalamin a disease (disorder)	SCTID:82245003	cobalamin b disease (disorder)	SCTID		live		live	
+MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	UMLS:C0342721	Cobalamin A disease	UMLS:C0342722	Cobalamin B disease	UMLS		live		live	
+MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	UMLS:C0342721	Cobalamin A disease	UMLS:C1855109	Vitamin B12-responsive methylmalonic aciduria type cblA	UMLS		live		live	
+MONDO:0009613	vitamin B12-responsive methylmalonic acidemia type cblA	UMLS:C0342722	Cobalamin B disease	UMLS:C1855109	Vitamin B12-responsive methylmalonic aciduria type cblA	UMLS		live		live	
+MONDO:0009623	Nijmegen breakage syndrome	UMLS:C0398791	Nijmegen breakage syndrome	UMLS:CN860323	Nijmegen Breakage Syndrome	UMLS		live		live	
+MONDO:0009626	pseudo-TORCH syndrome	GARD:0000815	Baraitser Brett Piesowicz syndrome	GARD:0012426	Congenital intrauterine infection-like syndrome	GARD		live		live	
+MONDO:0009634	microtia with meatal atresia and conductive deafness	GARD:0000357	Gupta Patton syndrome	GARD:0003657	Microtia, meatal atresia and conductive deafness	GARD		live		live	
+MONDO:0009636	mitochondrial DNA depletion syndrome 3	UMLS:C3151513	Mitochondrial DNA depletion syndrome, hepatocerebral form due to DGUOK deficiency	UMLS:C4310935	MITOCHONDRIAL DNA DEPLETION SYNDROME 3	UMLS		live		live	
+MONDO:0009640	mitochondrial complex I deficiency	UMLS:C1838979	MITOCHONDRIAL COMPLEX I DEFICIENCY	UMLS:C2936907	Isolated NADH-CoQ reductase deficiency	UMLS		live		live	
+MONDO:0009650	inclusion-cell disease	UMLS:C0020725	Mucolipidosis type II	UMLS:C2673377	N-acetylglucosamine 1-phosphotransferase deficiency	UMLS		live		live	
+MONDO:0009653	mucolipidosis type IV	UMLS:C0238286	Mucolipidosis type IV	UMLS:CN716584	MLIV	UMLS		live		live	
+MONDO:0009655	Sanfilippo syndrome type A	GARD:0002649	Heparane sulfamidase deficiency	GARD:0007071	Mucopolysaccharidosis type IIIA	GARD		live		live	
+MONDO:0009664	mulibrey nanism	UMLS:C0524582	Pericardial constriction-growth failure syndrome	UMLS:C2931895	Pericardial Constriction And Growth Failure	UMLS		live		live	
+MONDO:0009665	biotinidase deficiency	UMLS:C0220754	Deficiency of biotinidase	UMLS:CN043572	Biotin-Responsive Multiple Carboxylase Deficiencies	UMLS		live		live	
+MONDO:0009666	holocarboxylase synthetase deficiency	SCTID:15307001	biotin-(propionyl-coenzyme a-carboxylase) ligase deficiency (disorder)	SCTID:360369003	holocarboxylase synthase deficiency (disorder)	SCTID		live		live	
+MONDO:0009669	Werdnig-Hoffmann disease	DOID:0060160	survival motor neuron spinal muscular atrophy	DOID:13137	Werdnig-Hoffmann disease	DOID		live		live	
+MONDO:0009672	juvenile spinal muscular atrophy	UMLS:C0152109	Juvenile spinal muscular atrophy	UMLS:C0700595	Spinal Muscular Atrophy of Childhood	UMLS		live		live	
+MONDO:0009675	autosomal recessive limb-girdle muscular dystrophy type 2A	GARD:0001057	Limb-girdle muscular dystrophy type 2A	GARD:0003845	Muscular dystrophy limb girdle type 2A, Erb type	GARD		live		live	
+MONDO:0009680	congenital muscular dystrophy-infantile cataract-hypogonadism syndrome	GARD:0000835	Bassoe syndrome	GARD:0003842	Muscular dystrophy, congenital, infantile with cataract and hypogonadism	GARD		live		live	
+MONDO:0009680	congenital muscular dystrophy-infantile cataract-hypogonadism syndrome	UMLS:C1850864	Bassoe syndrome	UMLS:C2931578	Bassoe syndrome	UMLS		live		live	
+MONDO:0009692	primary myelofibrosis	UMLS:C0001815	Primary myelofibrosis	UMLS:C0948968	Osteomyelofibrosis	UMLS		live		live	
+MONDO:0009692	primary myelofibrosis	UMLS:C0001815	Primary myelofibrosis	UMLS:C2355576	Megakaryocytic myelosclerosis	UMLS		live		live	
+MONDO:0009692	primary myelofibrosis	UMLS:C0948968	Osteomyelofibrosis	UMLS:C2355576	Megakaryocytic myelosclerosis	UMLS		live		live	
+MONDO:0009725	nemaline myopathy 2	UMLS:C1850569	NEMALINE MYOPATHY 2	UMLS:CN187052	Nemaline myopathy 2, autosomal recessive	UMLS		live		live	
+MONDO:0009727	atelosteogenesis type II	UMLS:C1850554	Atelosteogenesis type 2	UMLS:C1850555	DE LA CHAPELLE DYSPLASIA	UMLS		live		live	
+MONDO:0009728	nephronophthisis 1	UMLS:C1855681	Juvenile nephronophthisis	UMLS:CN205459	juvenile nephronophthisis	UMLS		live		live	
+MONDO:0009738	sialidosis type 2	UMLS:C3888317	Sialidosis, type 2	UMLS:CN206285	Infantile dysmorphic sialidosis	UMLS		live		live	
+MONDO:0009748	hereditary sensory and autonomic neuropathy with spastic paraplegia	UMLS:C1850395	HSAN with spastic paraplegia	UMLS:C4303565	Hereditary sensory and autonomic neuropathy with spastic paraplegia	UMLS		live		live	
+MONDO:0009796	gyrate atrophy	GARD:0006556	Gyrate atrophy of choroid and retina	GARD:0007272	Ornithinemia	GARD		live		live	
+MONDO:0009796	gyrate atrophy	MESH:C538071	Fuchs atrophia gyrata chorioideae et retinae	MESH:D015799	Gyrate Atrophy	MESH		live		live	
+MONDO:0009810	autosomal recessive distal osteolysis syndrome	GARD:0004144	Osteolysis syndrome recessive	GARD:0004299	Petit-Fryns syndrome	GARD		live		live	
+MONDO:0009810	autosomal recessive distal osteolysis syndrome	UMLS:C1850143	Distal osteolysis-short stature-intellectual disability syndrome	UMLS:C4275111	Autosomal recessive distal osteolysis syndrome	UMLS		live		live	
+MONDO:0009833	Shwachman-Diamond syndrome	DOID:0060479	Shwachman-Diamond syndrome	DOID:0080023	Shwachman-Diamond type metaphyseal dysplasia	DOID		live		live	
+MONDO:0009840	Partington-Anderson syndrome	UMLS:C1850075	PARTINGTON-ANDERSON SYNDROME	UMLS:CN202825	Partington-Anderson syndrome	UMLS		live		live	
+MONDO:0009855	d-bifunctional protein deficiency	UMLS:C0342870		UMLS:C1533628	Pseudo-Zellweger syndrome	UMLS		not_present		live	
+MONDO:0009855	d-bifunctional protein deficiency	UMLS:C0342870		UMLS:CN203333	Pseudo-Zellweger syndrome	UMLS		not_present		live	
+MONDO:0009855	d-bifunctional protein deficiency	UMLS:C1533628	Pseudo-Zellweger syndrome	UMLS:CN203333	Pseudo-Zellweger syndrome	UMLS		live		live	
+MONDO:0009856	Peters plus syndrome	DOID:0070312	obsolete Peters-Plus Syndrome	DOID:0080201	Peters plus syndrome	DOID		deprecated		live	
+MONDO:0009869	isolated Pierre-Robin syndrome	GARD:0004347	Pierre Robin sequence	GARD:0004354	Pierre Robin syndrome skeletal dysplasia polydactyly	GARD		live		live	
+MONDO:0009916	46,XY disorder of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency	MESH:C537805	17-Hydroxysteroid Dehydrogenase Deficiency	MESH:C564868	Polycystic Ovarian Disease due to 17-Ketosteroid Reductase Deficiency	MESH		live		live	
+MONDO:0009925	inherited pseudoxanthoma elasticum	SCTID:402782006	inherited pseudoxanthoma elasticum (disorder)	SCTID:72744008	gronblad-strandberg syndrome (disorder)	SCTID		live		live	
+MONDO:0009934	congenital alveolar capillary dysplasia	MESH:C536590	Alveolar capillary dysplasia	MESH:D010547	Persistent Fetal Circulation Syndrome	MESH		live		live	
+MONDO:0009945	pyridoxine-dependent epilepsy	UMLS:C1849508	Pyridoxine-dependent epilepsy	UMLS:CN203406		UMLS		live		not_present	
+MONDO:0009949	pyruvate carboxylase deficiency disease	UMLS:C0034341	Pyruvate Carboxylase Deficiency Disease	UMLS:C2931141	LEIGH NECROTIZING ENCEPHALOPATHY DUE TO PYRUVATE CARBOXYLASE DEFICIENCY	UMLS		live		live	
+MONDO:0009949	pyruvate carboxylase deficiency disease	UMLS:C0034341	Pyruvate Carboxylase Deficiency Disease	UMLS:CN203409	Leigh syndrome due to pyruvate carboxylase deficiency	UMLS		live		live	
+MONDO:0009949	pyruvate carboxylase deficiency disease	UMLS:C2931141	LEIGH NECROTIZING ENCEPHALOPATHY DUE TO PYRUVATE CARBOXYLASE DEFICIENCY	UMLS:CN203409	Leigh syndrome due to pyruvate carboxylase deficiency	UMLS		live		live	
+MONDO:0009952	radioulnar synostosis-developmental delay-hypotonia syndrome	MESH:C538217	Der Kaloustian Mcintosh Silver syndrome	MESH:C564856	Radioulnar Synostosis, Unilateral, with Developmental Retardation and Hypotonia	MESH		live		live	
+MONDO:0009968	renal tubular acidosis, distal, with progressive nerve deafness	SCTID:236532003	renal tubular acidosis with progressive nerve deafness (disorder)	SCTID:722468005	distal renal tubular acidosis co-occurrent with sensorineural deafness (disorder)	SCTID		live		live	
+MONDO:0009968	renal tubular acidosis, distal, with progressive nerve deafness	UMLS:C0403554	RENAL TUBULAR ACIDOSIS, DISTAL, WITH PROGRESSIVE NERVE DEAFNESS	UMLS:C4302514	Distal renal tubular acidosis co-occurrent with sensorineural deafness	UMLS		live		live	
+MONDO:0009971	newborn respiratory distress syndrome	UMLS:C0020192	Hyaline membrane disease	UMLS:C0035220	Respiratory distress syndrome of newborn	UMLS		live		live	
+MONDO:0009971	newborn respiratory distress syndrome	UMLS:C0020192	Hyaline membrane disease	UMLS:C1968593	Neonatal respiratory distress syndrome	UMLS		live		live	
+MONDO:0009971	newborn respiratory distress syndrome	UMLS:C0035220	Respiratory distress syndrome of newborn	UMLS:C1968593	Neonatal respiratory distress syndrome	UMLS		live		live	
+MONDO:0009974	familial hemophagocytic lymphohistiocytosis type 1	UMLS:C0272199	Lymphocytosis, Familial Hemophagocytic	UMLS:CN034020	FHL1	UMLS		live		live	
+MONDO:0009974	familial hemophagocytic lymphohistiocytosis type 1	UMLS:C0272199	Lymphocytosis, Familial Hemophagocytic	UMLS:CN205265	Familial HLH	UMLS		live		live	
+MONDO:0009974	familial hemophagocytic lymphohistiocytosis type 1	UMLS:CN034020	FHL1	UMLS:CN205265	Familial HLH	UMLS		live		live	
+MONDO:0010004	EEC syndrome	UMLS:C0406704	Rudiger syndrome 1	UMLS:CN776907	Ectrodactyly-ectodermal dysplasia-cleft lip/palate syndrome	UMLS		live		live	
+MONDO:0010006	Sandhoff disease	GARD:0002521	GM2 gangliosidosis, 0 variant	GARD:0007604	Sandhoff disease	GARD		live		live	
+MONDO:0010033	generalized peeling skin syndrome	UMLS:C4305156	Generalized peeling skin syndrome	UMLS:CN202304	Generalized deciduous skin	UMLS		live		live	
+MONDO:0010043	hereditary spastic paraplegia 17	UMLS:C2931276	Silver syndrome	UMLS:CN074197	SPG17	UMLS		live		live	
+MONDO:0010047	hereditary spastic paraplegia 5A	UMLS:C1849115	SPG5A	UMLS:C2931357	Spastic paraplegia type 5B, recessive	UMLS		live		live	
+MONDO:0010060	infantile onset spinocerebellar ataxia	DOID:0050556	infantile onset spinocerebellar ataxia	DOID:0080126	mitochondrial DNA depletion syndrome 7	DOID		deprecated		live	
+MONDO:0010104	non-eruption of teeth-maxillary hypoplasia-genu valgum syndrome	GARD:0005027	Stoelinga de Koomen Davis syndrome	GARD:0005127	Teeth noneruption of with maxillary hypoplasia and genu valgum	GARD		live		live	
+MONDO:0010109	tetraamelia with ectodermal dysplasia and lacrimal duct abnormalities	GARD:0003348	Madokoro Ohdo Sonoda syndrome	GARD:0005146	Tetraamelia with ectodermal dysplasia and lacrimal duct abnormalities	GARD		live		live	
+MONDO:0010128	thyrocerebrorenal syndrome	UMLS:C1848813	Cutler-Bass-Romshe syndrome	UMLS:C4518579	Thyrocerebrorenal syndrome	UMLS		live		live	
+MONDO:0010139	isolated thyroid-stimulating hormone deficiency	UMLS:C0271789	Isolated TSH deficiency	UMLS:C4082174	Isolated thyrotropin deficiency	UMLS		live		live	
+MONDO:0010142	hypothyroidism due to TSH receptor mutations	UMLS:C3493776	HYPOTHYROIDISM, CONGENITAL, NONGOITROUS, 1	UMLS:CN206435	Hypothyroidism due to TSH receptor mutations	UMLS		live		live	
+MONDO:0010148	Mounier-Kuhn syndrome	GARD:0003793	Mounier-Kuhn syndrome	GARD:0005234	Tracheobronchomegaly	GARD		live		live	
+MONDO:0010148	Mounier-Kuhn syndrome	UMLS:C0040587	Tracheobronchomegaly	UMLS:C2713583	Congenital tracheobronchomegaly	UMLS		live		live	
+MONDO:0010159	constitutional mismatch repair deficiency syndrome	UMLS:C0265325	CMMR-D syndrome	UMLS:C4321324	Constitutional Mismatch Repair Deficiency Syndrome	UMLS		live		live	
+MONDO:0010164	phocomelia, Schinzel type	GARD:0005124	Teebi Naguib Al Awadi syndrome	GARD:0009212	Al-Awadi-Raas-Rothschild syndrome	GARD		live		live	
+MONDO:0010165	ulna hypoplasia-intellectual disability syndrome	UMLS:C1848650	Ulna hypoplasia-intellectual disability syndrome	UMLS:C2931370	Ulna hypoplasia with mental retardation	UMLS		live		live	
+MONDO:0010168	Usher syndrome type 1	GARD:0005435	Usher syndrome, type 1	GARD:0005436	Usher syndrome, type 1B	GARD		live		live	
+MONDO:0010193	Weaver syndrome	UMLS:C0265210	Weaver syndrome	UMLS:CN036342	Mental retardation, microcephaly, weight deficiency, unusual facies, clinodactyly, bone hypoplasia, and cleft palate	UMLS		live		live	
+MONDO:0010217	de Sanctis-Cacchione syndrome	UMLS:C0265201	De Sanctis-Cacchione syndrome	UMLS:CN199649	De Sanctis-Cacchione syndrome	UMLS		live		live	
+MONDO:0010225	Dent disease type 1	UMLS:C4305530	Dent disease type 1	UMLS:CN206679	Nephrolithiasis type 1	UMLS		live		live	
+MONDO:0010237	X-linked intellectual disability-plagiocephaly syndrome	GARD:0002765	Hyde Forster Mccarthy Berry syndrome	GARD:0004377	Plagiocephaly and X-linked mental retardation	GARD		live		live	
+MONDO:0010239	lissencephaly type 1 due to doublecortin gene mutation	UMLS:C1848199	X-linked lissencephaly type 1	UMLS:C4275012	Lissencephaly type 1 due to doublecortin gene mutation	UMLS		live		live	
+MONDO:0010247	X-linked cerebral adrenoleukodystrophy	UMLS:CN036464	Childhood cerebral ALD	UMLS:CN199389	X-linked cerebral adrenoleukodystrophy	UMLS		live		live	
+MONDO:0010270	syndromic X-linked intellectual disability 7	UMLS:C1846170	X-linked intellectual disability, Ahmad type	UMLS:C4304916	Syndromic X-linked intellectual disability type 7	UMLS		live		live	
+MONDO:0010277	syndromic X-linked intellectual disability Shashi type	UMLS:C1846145	Syndromic X-linked intellectual disability type 11	UMLS:C4305085	Syndromic X-linked intellectual disability type 11	UMLS		live		live	
+MONDO:0010298	Lesch-Nyhan syndrome	UMLS:C0023374	Lesch-Nyhan syndrome	UMLS:CN205196	Hypoxanthine guanine phosphoribosyltransferase deficiency, grade IV	UMLS		live		live	
+MONDO:0010306	X-linked intellectual disability, Cabezas type	UMLS:C1845845	Mental Retardation, X-Linked, with Short Stature	UMLS:C1845861	Cabezas syndrome	UMLS		live		live	
+MONDO:0010311	Becker muscular dystrophy	UMLS:C0699741	Benign congenital myopathy	UMLS:C3490459	Benign Pseudohypertrophic Muscular Dystrophy	UMLS		live		live	
+MONDO:0010337	X-linked intellectual disability-cerebellar hypoplasia syndrome	GARD:0009947	Mental retardation x-linked with cerebellar hypoplasia and distinctive facial appearance	GARD:0013093	OPHN1 syndrome	GARD		live		live	
+MONDO:0010355	syndromic X-linked intellectual disability Claes-Jensen type	UMLS:C1845243	Syndromic X-linked intellectual disability due to JARID1C mutation	UMLS:C4304915	Syndromic X-linked intellectual disability due to jumonji at-rich interactive domain 1c mutation	UMLS		live		live	
+MONDO:0010359	Dent disease type 2	UMLS:C1845167	Nephrolithiasis type 2	UMLS:C4305529	Dent disease type 2	UMLS		live		live	
+MONDO:0010378	X-linked hereditary sensory and autonomic neuropathy with deafness	UMLS:C1845095	X-linked auditory neuropathy with peripheral sensory neuropathy type 1	UMLS:C4304400	X-linked hereditary sensory and autonomic neuropathy with deafness	UMLS		live		live	
+MONDO:0010403	albinism-deafness syndrome	SCTID:722285005	albinism with deafness syndrome (disorder)	SCTID:74320008	woolf's syndrome (disorder)	SCTID		live		live	
+MONDO:0010437	severe X-linked mitochondrial encephalomyopathy	UMLS:C3151753	Mitochondrial encephalomyopathy due to combined oxidative phosphorylation defect 6	UMLS:C4302745	Severe X-linked mitochondrial encephalomyopathy	UMLS		live		live	
+MONDO:0010476	neurodegeneration with brain iron accumulation 5	UMLS:C3550973	Neurodegeneration with brain iron accumulation type 5	UMLS:CN168656	BPAN	UMLS		live		live	
+MONDO:0010491	X-linked acrogigantism due to Xq26 microduplication	UMLS:C3891556	CHROMOSOME Xq26.3 DUPLICATION SYNDROME	UMLS:CN237731	X-LAG (X-linked acrogigantism) due to dup(X)q(26)	UMLS		live		live	
+MONDO:0010517	ciliary dyskinesia, primary, 36, X-linked; CILD36	UMLS:C4478372	CILIARY DYSKINESIA, PRIMARY, 36, X-LINKED	UMLS:CN240511		UMLS		live		not_present	
+MONDO:0010524	X-linked sideroblastic anemia with ataxia	DOID:0050554	X-linked sideroblastic anemia with ataxia	DOID:0060064	obsolete sideroblastic anemia with spinocerebellar ataxia	DOID		live		deprecated	
+MONDO:0010524	X-linked sideroblastic anemia with ataxia	UMLS:C1845028	Pagon-Bird-Detter syndrome	UMLS:C4304338	X-linked sideroblastic anemia with spinocerebellar ataxia	UMLS		live		live	
+MONDO:0010542	dilated cardiomyopathy 3B	DOID:0060561	DMD-related dilated cardiomyopathy	DOID:0110461	X-linked dilated cardiomyopathy	DOID		deprecated		live	
+MONDO:0010555	X-linked chondrodysplasia punctata 1	UMLS:C1844853	Brachytelephalangic chondrodysplasia punctata	UMLS:C3669395	X-Linked Chondrodysplasia Punctata 1	UMLS		live		live	
+MONDO:0010561	Coffin-Lowry syndrome	GARD:0006123	Coffin-Lowry syndrome	GARD:0008589	Coffin syndrome 1	GARD		live		live	
+MONDO:0010561	Coffin-Lowry syndrome	MESH:C536435	Coffin syndrome 1	MESH:D038921	Coffin-Lowry Syndrome	MESH		live		live	
+MONDO:0010576	X-linked mixed deafness with perilymphatic gusher	GARD:0001694	Deafness mixed with perilymphatic Gusher, X-linked	GARD:0004504	Deafness, X-linked 2	GARD		live		live	
+MONDO:0010602	hemophilia A	UMLS:C0019069	Hemophilia A	UMLS:CN239112	AUTOSOMAL HEMOPHILIA A	UMLS		live		live	
+MONDO:0010626	X-linked hyper-IgM syndrome	DOID:0060022	CD40 ligand deficiency	DOID:6620	X-linked hyper IgM syndrome	DOID		live		live	
+MONDO:0010680	X-linked Emery-Dreifuss muscular dystrophy	UMLS:C0751337	EMERY-DREIFUSS MUSCULAR DYSTROPHY, X-LINKED	UMLS:CN069573	Emerinopathy	UMLS		live		live	
+MONDO:0010684	X-linked myopathy with excessive autophagy	UMLS:C1839615	X-linked myopathy with excessive autophagy	UMLS:C2931230	Vacuolar myopathy	UMLS		live		live	
+MONDO:0010702	orofaciodigital syndrome I	UMLS:C1510460	OROFACIODIGITAL SYNDROME I	UMLS:C2698658	Orofaciodigital Syndrome Type 1	UMLS		live		live	
+MONDO:0010713	properdin deficiency	GARD:0004513	Properdin deficiency	GARD:0009913	Properdin deficiency, X-linked	GARD		live		live	
+MONDO:0010765	46,XY complete gonadal dysgenesis	UMLS:C0018054	46,XY Gonadal Dysgenesis	UMLS:C2936694	Swyer syndrome	UMLS		live		live	
+MONDO:0010766	46,XX testicular disorder of sex development	UMLS:C2936419		UMLS:CN205000	XX, male syndrome	UMLS		not_present		live	
+MONDO:0010771	histiocytoid cardiomyopathy	UMLS:C1708371	Oncocytic cardiomyopathy	UMLS:CN239812	Congenital cardiomyopathy	UMLS		live		live	
+MONDO:0010785	maternally-inherited diabetes and deafness	UMLS:C0342289	Mitochondrial diabetes	UMLS:C4330695	Mitochondrial Diabetes	UMLS		live		live	
+MONDO:0010801	Spondylocamptodactyly syndrome	UMLS:C1838781	Spondylocamptodactyly syndrome	UMLS:C4274762	Spondylocamptodactyly syndrome	UMLS		live		live	
+MONDO:0010831	familial caudal dysgenesis	GARD:0000215	Familial caudal dysgenesis	GARD:0004751	Sacral defect with anterior meningocele	GARD		live		live	
+MONDO:0010870	tibial muscular dystrophy	UMLS:C1450052	Tibial muscular dystrophy	UMLS:C1838244	Tardive tibial muscular dystrophy	UMLS		live		live	
+MONDO:0010878	hereditary spastic paraplegia 6	UMLS:C1838192	SPG6	UMLS:C4518537	Autosomal dominant spastic paraplegia type 6	UMLS		live		live	
+MONDO:0010895	ABCD syndrome	UMLS:C1838099	ABCD SYNDROME	UMLS:CN206498	ABCD syndrome	UMLS		live		live	
+MONDO:0010907	familial hypertryptophanemia	UMLS:C1833562		UMLS:C2931837	Familial hypertryptophanemia	UMLS		not_present		live	
+MONDO:0010913	Caroli disease	UMLS:C0162510	Caroli disease	UMLS:C1833541	Caroli disease	UMLS		live		live	
+MONDO:0010924	D-2-hydroxyglutaric aciduria	UMLS:C1833429	D-2-hydroxyglutaric aciduria	UMLS:CN233040		UMLS		live		not_present	
+MONDO:0010938	T-B+ severe combined immunodeficiency due to JAK3 deficiency	UMLS:C1833275	T-B+ SCID due to JAK3 deficiency	UMLS:C4273742	Severe combined immunodeficiency T-cell negative B-cell positive due to janus kinase-3 deficiency	UMLS		live		live	
+MONDO:0010961	obesity due to prohormone convertase i deficiency	UMLS:C1833053	PCI deficiency	UMLS:C4302878	Obesity due to prohormone convertase I deficiency	UMLS		live		live	
+MONDO:0011014	pleuropulmonary blastoma	UMLS:C1266144	Pleuropulmonary blastoma	UMLS:CN072455	PPB	UMLS		live		live	
+MONDO:0011042	Martinez-Frias syndrome	UMLS:C1832443	MARTINEZ-FRIAS SYNDROME	UMLS:CN199270	Martínez-Frías syndrome	UMLS		live		live	
+MONDO:0011045	MMEP syndrome	UMLS:C1832440	Microcephaly-microphthalmia-ectrodactyly of lower limbs-prognathism syndrome	UMLS:C4275099	MMEP syndrome	UMLS		live		live	
+MONDO:0011052	amelia cleft lip palate hydrocephalus iris coloboma	GARD:0000388	Brachial amelia, forebrain defects and facial clefts	GARD:0000641	Amelia cleft lip palate hydrocephalus iris coloboma	GARD		live		live	
+MONDO:0011055	distal monosomy 10p	UMLS:C1832431	Telomeric deletion 10p	UMLS:C4304502	Distal monosomy 10p	UMLS		live		live	
+MONDO:0011057	cerebrovascular disorder	SCTID:230690007	cerebrovascular accident (disorder)	SCTID:62914000	cerebrovascular disease (disorder)	SCTID		live		live	
+MONDO:0011091	Charcot-Marie-tooth disease type 2D	UMLS:C1832274	CMT2D	UMLS:C4274109	Autosomal dominant Charcot-Marie-Tooth disease type 2D	UMLS		live		live	
+MONDO:0011108	StC<ve-Wiedemann syndrome	UMLS:C0432240	Stuve-Wiedemann dysplasia	UMLS:C0796176	Stüve-Wiedemann/Schwartz-Jampel type 2 syndrome	UMLS		live		live	
+MONDO:0011142	Ehlers-Danlos syndrome, musculocontractural type	GARD:0000545	Adducted thumbs Dundar type	GARD:0008486	Musculocontractural Ehlers-Danlos syndrome	GARD		live		live	
+MONDO:0011150	acroosteolysis-keloid-like lesions-premature aging syndrome	GARD:0004276	Penttinen-Aula syndrome	GARD:0004498	Progeroid syndrome, Penttinen type	GARD		live		live	
+MONDO:0011166	lymphedema-atrial septal defects-facial changes syndrome	MESH:C535539	Irons Bhan syndrome	MESH:C567398	Lymphedema, Cardiac Septal Defects, And Characteristic Facies	MESH		live		live	
+MONDO:0011225	severe combined immunodeficiency due to DCLRE1C deficiency	DOID:0060006	artemis deficiency	DOID:0090012	severe combined immunodeficiency with sensitivity to ionizing radiation	DOID		deprecated		live	
+MONDO:0011236	hyperinsulinism due to glucokinase deficiency	GARD:0002818	Hyperinsulinism due to glucokinase deficiency	GARD:0009930	Hyperinsulinemic hypoglycemia familial 3	GARD		live		live	
+MONDO:0011330	spinocerebellar ataxia type 10	UMLS:C1963674	SCA10	UMLS:C4275023	Spinocerebellar ataxia type 10	UMLS		live		live	
+MONDO:0011359	acromelic frontonasal dysostosis	GARD:0002393	Frontonasal dysplasia acromelic	GARD:0005539	Acromelic frontonasal dysostosis	GARD		live		live	
+MONDO:0011377	long QT syndrome 3	UMLS:C1859062	LONG QT SYNDROME 3	UMLS:C2931401	Long QT syndrome type 3	UMLS		live		live	
+MONDO:0011380	leukoencephalopathy with vanishing white matter	UMLS:C1858991	Cree leukoencephalopathy	UMLS:CN199219	Myelinosis centralis diffusa	UMLS		live		live	
+MONDO:0011381	dominant beta-thalassemia	UMLS:C1858990	Inclusion body beta-thalassemia	UMLS:C4274391	Dominant beta-thalassemia	UMLS		live		live	
+MONDO:0011383	autoimmune lymphoproliferative syndrome type 2A	UMLS:C1519709	Type 2 Autoimmune Lymphoproliferative Syndrome	UMLS:C1858968	AUTOIMMUNE LYMPHOPROLIFERATIVE SYNDROME, TYPE IIA	UMLS		live		live	
+MONDO:0011408	hereditary spastic paraplegia 10	UMLS:C1858712	SPG10	UMLS:C4518536	Autosomal dominant spastic paraplegia type 10	UMLS		live		live	
+MONDO:0011430	pulverulent cataract	UMLS:C1833118	Pulverulent cataract	UMLS:C1852438	Coppock-like cataract	UMLS		live		live	
+MONDO:0011430	pulverulent cataract	UMLS:C1833118	Pulverulent cataract	UMLS:CN207240	Coppock-like cataract	UMLS		live		live	
+MONDO:0011430	pulverulent cataract	UMLS:C1852438	Coppock-like cataract	UMLS:CN207240	Coppock-like cataract	UMLS		live		live	
+MONDO:0011439	spinocerebellar ataxia type 12	UMLS:C1858501	SCA12	UMLS:C4304885	Spinocerebellar ataxia type 12	UMLS		live		live	
+MONDO:0011464	spinocerebellar ataxia type 11	UMLS:C1858351	SCA11	UMLS:C4304886	Spinocerebellar ataxia type 11	UMLS		live		live	
+MONDO:0011527	Charcot-Marie-tooth disease type 4E	GARD:0006170	Congenital hypomyelination neuropathy	GARD:0009203	Charcot-Marie-Tooth disease type 4E	GARD		live		live	
+MONDO:0011529	spinocerebellar ataxia type 13	UMLS:C1854488	SCA13	UMLS:C4304884	Spinocerebellar ataxia type 13	UMLS		live		live	
+MONDO:0011540	spinocerebellar ataxia type 14	UMLS:C1854369	SCA14	UMLS:C4304883	Spinocerebellar ataxia type 14	UMLS		live		live	
+MONDO:0011576	familial hyperaldosteronism type II	UMLS:C1854107	Familial hyperaldosteronism type 2	UMLS:C3839212	Familial hyperaldosteronism type 2	UMLS		live		live	
+MONDO:0011582	multiple mitochondrial dysfunctions syndrome 1	UMLS:C3276432	MULTIPLE MITOCHONDRIAL DYSFUNCTIONS SYNDROME 1	UMLS:CN226135	NFU1 deficiency	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751494	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ARCTIC VARIANT	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C2751536	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C3888307	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, FLEMISH VARIANT	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS		live		live	
+MONDO:0011583	cerebral amyloid angiopathy, APP-related	UMLS:C3888308	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, ITALIAN VARIANT	UMLS:C3888309	CEREBRAL AMYLOID ANGIOPATHY, APP-RELATED, IOWA VARIANT	UMLS		live		live	
+MONDO:0011599	birdshot chorioretinopathy	UMLS:C0339402	Birdshot chorioretinitis	UMLS:C1853959	Vitiliginous choroiditis	UMLS		live		live	
+MONDO:0011601	neonatal intrahepatic cholestasis due to citrin deficiency	UMLS:C1853942	Neonatal intrahepatic cholestasis caused by citrin deficiency	UMLS:C4274030	Neonatal intrahepatic cholestasis due to citrin deficiency	UMLS		live		live	
+MONDO:0011606	baby rattle pelvis dysplasia	MESH:C537794	Baby rattle pelvic dysplasia	MESH:C565282	Baby Rattle Pelvis Dysplasia	MESH		live		live	
+MONDO:0011639	Diamond-Blackfan anemia 15 with mandibulofacial dysostosis	UMLS:C1853576	Diamond-Blackfan Anemia With Microtia And Cleft Palate	UMLS:C4225411	DIAMOND-BLACKFAN ANEMIA 15 WITH MANDIBULOFACIAL DYSOSTOSIS	UMLS		live		live	
+MONDO:0011642	carnitine acetyltransferase deficiency	UMLS:C1443228	Deficiency of carnitine acetyltransferase	UMLS:CN035113	CRAT	UMLS		live		live	
+MONDO:0011655	alveolar soft part sarcoma (disease)	NCIT:C3750	Alveolar Soft Part Sarcoma	NCIT:C7943	Adult Alveolar Soft Part Sarcoma	NCIT		live		live	
+MONDO:0011655	alveolar soft part sarcoma (disease)	UMLS:C0206657	Alveolar soft part sarcoma	UMLS:C0279544	Adult Alveolar Soft-Part Sarcoma	UMLS		live		live	
+MONDO:0011687	Charcot-Marie-tooth disease axonal type 2F	UMLS:C1847823	CMT2F	UMLS:C4304675	Autosomal dominant Charcot-Marie-Tooth disease type 2F	UMLS		live		live	
+MONDO:0011694	spinocerebellar ataxia type 15/16	UMLS:C1847725	SCA15/16	UMLS:C4274322	Spinocerebellar ataxia type 15/16	UMLS		live		live	
+MONDO:0011719	gastrointestinal stromal tumor	UMLS:C0238198	Gastrointestinal stromal tumor	UMLS:C3179349	Gastrointestinal stromal sarcoma	UMLS		live		live	
+MONDO:0011724	encephalopathy due to GLUT1 deficiency	UMLS:C1847501	Glut1-DS	UMLS:CN030711	GLUT1DS1	UMLS		live		live	
+MONDO:0011752	nephronophthisis 4	UMLS:C1847013	NEPHRONOPHTHISIS 4	UMLS:C2959367	Nephronophthisis type 4	UMLS		live		live	
+MONDO:0011765	multiple epiphyseal dysplasia type 5	UMLS:C1846843	Bilateral hereditary micro-epiphyseal dysplasia	UMLS:C4275060	Multiple epiphyseal dysplasia type 5	UMLS		live		live	
+MONDO:0011773	anauxetic dysplasia	UMLS:C1846796	Spondyloepimetaphyseal dysplasia, anauxetic type	UMLS:CN029084	ANXD1	UMLS		live		live	
+MONDO:0011803	hereditary spastic paraplegia 7	UMLS:C1846564	SPG7	UMLS:C3711370	Spastic paraplegia type 7	UMLS		live		live	
+MONDO:0011819	spinocerebellar ataxia type 19/22	MESH:C537198	Spinocerebellar ataxia 19	MESH:C542540	Spinocerebellar ataxia 22	MESH		live		live	
+MONDO:0011833	spinocerebellar ataxia type 21	UMLS:C1843891	SCA21	UMLS:C4305144	Spinocerebellar ataxia type 21	UMLS		live		live	
+MONDO:0011834	spinocerebellar ataxia type 18	UMLS:C1843884	SCA18	UMLS:C4304848	Spinocerebellar ataxia type 18	UMLS		live		live	
+MONDO:0011859	distal myopathy with early respiratory muscle involvement	UMLS:C1843633	Distal myopathy with early respiratory muscle involvement	UMLS:C4518808	Distal myopathy with early respiratory muscle involvement	UMLS		live		live	
+MONDO:0011865	COL4A1-related familial vascular leukoencephalopathy	MESH:C531642	Familial vascular leukoencephalopathy	MESH:C564372	Brain Small Vessel Disease with Hemorrhage	MESH		live		live	
+MONDO:0011868	lethal congenital contracture syndrome 2	UMLS:C1843478	Multiple contracture syndrome, Israeli-Bedouin type	UMLS:C4275145	Lethal congenital contracture syndrome type 2	UMLS		live		live	
+MONDO:0011899	Noonan syndrome-like disorder with loose anagen hair	UMLS:C1843181	Noonan syndrome-like disorder with loose anagen hair	UMLS:C3501846	Tosti syndrome	UMLS		live		live	
+MONDO:0011936	microphthalmia with brain and digit anomalies	UMLS:C1864689	Syndromic microphthalmia type 6	UMLS:C4303070	Microphthalmia with brain and digit anomaly	UMLS		live		live	
+MONDO:0011937	peeling skin syndrome 4	UMLS:C1842797	Exfoliative Ichthyosis, Autosomal Recessive, Ichthyosis Bullosa of Siemens-like	UMLS:C4225407	PEELING SKIN SYNDROME 4	UMLS		live		live	
+MONDO:0011961	hereditary sensory and autonomic neuropathy type 1B	UMLS:C1842586	Hereditary sensory and autonomic neuropathy type IB	UMLS:C4303567	Hereditary sensory and autonomic neuropathy type 1B	UMLS		live		live	
+MONDO:0011986	tropical pancreatitis	UMLS:C1842402	Tropical calcific chronic pancreatitis	UMLS:C4510860	Tropical calcific chronic pancreatitis	UMLS		live		live	
+MONDO:0011992	hereditary spastic paraplegia 25	UMLS:C2936860	Autosomal recessive spastic paraplegia-disc herniation syndrome	UMLS:C4518003	Autosomal recessive spastic paraplegia type 25	UMLS		live		live	
+MONDO:0012017	Parkes Weber syndrome	UMLS:CN074207	RASA1-Related Disorders	UMLS:CN206396	Parkes Weber syndrome	UMLS		live		live	
+MONDO:0012032	Braddock syndrome	UMLS:C1842082	Vater-like syndrome with pulmonary hypertension, abnormal ears and growth deficiency	UMLS:C4303988	Braddock syndrome	UMLS		live		live	
+MONDO:0012049	orofaciodigital syndrome VII	UMLS:C0796100	OROFACIODIGITAL SYNDROME VII	UMLS:CN206429	Orofaciodigital syndrome type 7	UMLS		live		live	
+MONDO:0012070	autosomal dominant Charcot-Marie-tooth disease type 2G	UMLS:C1837805	CMT2G	UMLS:C4304674	Autosomal dominant Charcot-Marie-Tooth disease type 2G	UMLS		live		live	
+MONDO:0012081	15q11q13 microduplication syndrome	UMLS:C2675336	Trisomy 15q11q13	UMLS:C4304726	15q11q13 microduplication syndrome	UMLS		live		live	
+MONDO:0012089	ichthyosis prematurity syndrome	UMLS:C1504431	Idiopathic pneumonia syndrome	UMLS:C1837610	IPS	UMLS		live		live	
+MONDO:0012096	Charcot-Marie-tooth disease axonal type 2L	UMLS:C1837552	CMT2L	UMLS:C4304673	Autosomal dominant Charcot-Marie-Tooth disease type 2L	UMLS		live		live	
+MONDO:0012099	AICA-ribosiduria	UMLS:C1837530	ATIC deficiency	UMLS:C4510943	5-amino-4-imidazole carboxamide ribosiduria	UMLS		live		live	
+MONDO:0012105	granulomatosis with polyangiitis	UMLS:C3495801	Granulomatosis with polyangiitis	UMLS:C4050407	Pauci-Immune Glomerulonephritis associated with Granulomatosis with Polyangiitis	UMLS		live		live	
+MONDO:0012110	growth delay due to insulin-like growth factor type 1 deficiency	UMLS:C1837475	Growth delay-deafness- intellectual disability syndrome	UMLS:C4518327	Growth delay due to insulin-like growth factor type 1 deficiency	UMLS		live		live	
+MONDO:0012116	spinocerebellar ataxia type 8	UMLS:C1837454	SCA8	UMLS:C4275024	Spinocerebellar ataxia type 8	UMLS		live		live	
+MONDO:0012156	myasthenic syndrome, congenital, 1B, fast-channel	UMLS:C1837122	Myasthenic Syndrome, Congenital, Fast-Channel	UMLS:C4225405	MYASTHENIC SYNDROME, CONGENITAL, 1B, FAST-CHANNEL	UMLS		live		live	
+MONDO:0012165	BNAR syndrome	UMLS:C2750433	Bifid nose with or without anorectal and renal anomalies	UMLS:C4303547	BNAR syndrome	UMLS		live		live	
+MONDO:0012173	long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:C3711645	Long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:CN074230	LCHAD deficiency	UMLS		live		live	
+MONDO:0012173	long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:C3711645	Long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:CN239369	LCHAD Deficiency	UMLS		live		live	
+MONDO:0012173	long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	UMLS:CN074230	LCHAD deficiency	UMLS:CN239369	LCHAD Deficiency	UMLS		live		live	
+MONDO:0012177	posterior column ataxia-retinitis pigmentosa syndrome	UMLS:C1836916	PCARP	UMLS:C4510304	Autosomal recessive posterior column ataxia and retinitis pigmentosa	UMLS		live		live	
+MONDO:0012198	PCWH syndrome	UMLS:C1836727	Peripheral demyelinating neuropathy-central dysmyelinating leukodystrophy-Hirschsprung disease-Waardenburg syndrome	UMLS:CN239463		UMLS		live		not_present	
+MONDO:0012204	familial pseudohyperkalemia	UMLS:C1836705	Familial pseudohyperkalemia	UMLS:C4273970	Familial pseudohyperkalemia	UMLS		live		live	
+MONDO:0012213	hereditary spastic paraplegia 26	UMLS:C1836632	GM2 synthase deficiency	UMLS:C4511959	Autosomal recessive spastic paraplegia type 26	UMLS		live		live	
+MONDO:0012221	alpha-N-acetylgalactosaminidase deficiency type 1	GARD:0000116	Schindler disease type 1	GARD:0003903	N-acetyl-alpha-D-galactosaminidase deficiency type III	GARD		live		live	
+MONDO:0012247	spinocerebellar ataxia type 27	UMLS:C1836383	SCA27	UMLS:C4304846	Spinocerebellar ataxia type 27	UMLS		live		live	
+MONDO:0012251	MEDNIK syndrome	UMLS:C1836330	Intellectual disability-enteropathy-deafness-peripheral neuropathy-ichthyosis-keratodermia syndrome	UMLS:CN229776	MEDNIK Syndrome	UMLS		live		live	
+MONDO:0012315	distal 10q deletion syndrome	UMLS:C2674937	Telomeric deletion 10q	UMLS:C4305277	Distal monosomy 10q	UMLS		live		live	
+MONDO:0012328	trichilemmal cyst	UMLS:C1864801	TRICHILEMMAL CYST 1	UMLS:C2266788	Trichilemmal cyst	UMLS		live		live	
+MONDO:0012342	7q11.23 microduplication syndrome	UMLS:C1857844	Trisomy 7q11.23	UMLS:C4512054	7q11.23 microduplication syndrome	UMLS		live		live	
+MONDO:0012359	combined immunodeficiency due to partial RAG1 deficiency	UMLS:C1835931	Combined immunodeficiency with expansion of gamma delta T cells	UMLS:C4510944	Combined immunodeficiency due to partial RAG1 deficiency	UMLS		live		live	
+MONDO:0012382	hyperinsulinemic hypoglycemia, familial, 4	UMLS:C1864948	HYPERINSULINEMIC HYPOGLYCEMIA, FAMILIAL, 4	UMLS:C4303473	Hyperinsulinism due to short chain 3-hydroxyacyl-coenzyme A dehydrogenase deficiency	UMLS		live		live	
+MONDO:0012391	neuronal ceroid lipofuscinosis 8 northern epilepsy variant	GARD:0002163	Epilepsy mental deterioration Finnish type	GARD:0004010	Northern epilepsy	GARD		live		live	
+MONDO:0012396	exercise-induced hyperinsulinism	UMLS:C1864902	Hyperinsulinism due to monocarboxylate transporter 1 deficiency	UMLS:C1864904	Exercise-induced hyperinsulinism	UMLS		live		live	
+MONDO:0012411	giant axonal neuropathy 2	UMLS:C1864695	Giant Axonal Neuropathy, Autosomal Dominant	UMLS:CN226146	HMSN2 with giant axons	UMLS		live		live	
+MONDO:0012413	syndromic microphthalmia type 5	UMLS:C1864690	Syndromic microphthalmia/anophthalmia due to OTX2 mutation	UMLS:C4305151	Syndromic microphthalmia type 5	UMLS		live		live	
+MONDO:0012435	3-methylglutaconic aciduria type 5	GARD:0010344	3 methylglutaconic aciduria type V	GARD:0012964	DCMA syndrome	GARD		live		live	
+MONDO:0012435	3-methylglutaconic aciduria type 5	UMLS:C1857776	MGA5	UMLS:C4039473	3-methylglutaconic aciduria type 5	UMLS		live		live	
+MONDO:0012449	spinocerebellar ataxia type 23	UMLS:C1853250	SCA23	UMLS:C4305146	Spinocerebellar ataxia type 23	UMLS		live		live	
+MONDO:0012450	spinocerebellar ataxia type 28	UMLS:C1853249	SCA28	UMLS:C4274988	Spinocerebellar ataxia type 28	UMLS		live		live	
+MONDO:0012465	hypercoagulability syndrome due to glycosylphosphatidylinositol deficiency	UMLS:C1853205	PIGM-CDG	UMLS:C4510605	Hypercoagulability syndrome due to glycosylphosphatidylinositol deficiency	UMLS		live		live	
+MONDO:0012475	cone dystrophy with supernormal rod response	UMLS:C1835897	Cone dystrophy with supernormal scotopic electroretinogram	UMLS:C4304714	Cone dystrophy with supernormal rod response	UMLS		live		live	
+MONDO:0012496	Koolen de Vries syndrome	DOID:0050880	Koolen de Vries syndrome	DOID:0070076	obsolete Koolen-De Vries syndrome	DOID		live		deprecated	
+MONDO:0012496	Koolen de Vries syndrome	UMLS:C1864871	CHROMOSOME 17q21.31 DELETION SYNDROME	UMLS:CN776874	KdVS	UMLS		live		live	
+MONDO:0012549	autosomal recessive ataxia, Beauce type	UMLS:C1853116	SCAR8	UMLS:C3683483	Autosomal Recessive Cerebellar Ataxia Type 1	UMLS		live		live	
+MONDO:0012552	multiple endocrine neoplasia type 4	UMLS:C1970712	MEN4	UMLS:C4274947	Multiple endocrine neoplasia type 4	UMLS		live		live	
+MONDO:0012557	cardiomyopathy-hypotonia-lactic acidosis syndrome	UMLS:C1835845	Cardiomyopathy-hypotonia-lactic acidosis syndrome	UMLS:C4305259	Hypertrophic cardiomyopathy with hypotonia and lactic acidosis syndrome	UMLS		live		live	
+MONDO:0012559	primary immunodeficiency syndrome due to p14 deficiency	UMLS:C1835829	Primary immunodeficiency syndrome with short stature	UMLS:C4305256	Primary immunodeficiency syndrome due to p14 deficiency	UMLS		live		live	
+MONDO:0012570	body skin hyperlaxity due to vitamin K-dependent coagulation factor deficiency	UMLS:C1835813	Pseudoxanthoma elasticum-like syndrome	UMLS:C4049241	Pseudoxanthoma elasticum-like syndrome	UMLS		live		live	
+MONDO:0012643	hereditary spastic paraplegia 32	UMLS:C1970009	SPG32	UMLS:C4511958	Autosomal recessive spastic paraplegia type 32	UMLS		live		live	
+MONDO:0012656	lethal congenital contracture syndrome 3	UMLS:C1969655	LCCS3	UMLS:C4275144	Lethal congenital contracture syndrome type 3	UMLS		live		live	
+MONDO:0012664	spastic ataxia 3	UMLS:C1969645	SPAX3	UMLS:CN230089	Spastic Ataxia 3	UMLS		live		live	
+MONDO:0012718	hypotonia with lactic acidemia and hyperammonemia	UMLS:C2673642	Combined oxidative phosphorylation defect type 5	UMLS:C4510567	Combined oxidative phosphorylation defect type 5	UMLS		live		live	
+MONDO:0012719	encephalopathy due to prosaposin deficiency	UMLS:C2673635	Combined prosaposin deficiency	UMLS:C4303785	Encephalopathy due to prosaposin deficiency	UMLS		live		live	
+MONDO:0012724	familial cold autoinflammatory syndrome 2	UMLS:C2673198	NAPS12	UMLS:C3897034	NALP12-Associated Hereditary Periodic Fever Syndrome	UMLS		live		live	
+MONDO:0012733	autosomal recessive bestrophinopathy	UMLS:C2678493	Bestrophinopathy	UMLS:C3888198	Autosomal recessive bestrophinopathy	UMLS		live		live	
+MONDO:0012740	chromosome 22q11.2 deletion syndrome, distal	UMLS:C2678480	Distal monosomy 22q11.2	UMLS:C4518343	Distal 22q11.2 microdeletion syndrome	UMLS		live		live	
+MONDO:0012756	proximal 16p11.2 microdeletion syndrome	SCTID:699307007	chromosome 16p11.2 deletion syndrome (disorder)	SCTID:718227006	proximal 16p11.2 microdeletion syndrome (disorder)	SCTID		live		live	
+MONDO:0012784	autosomal recessive ataxia due to ubiquinone deficiency	UMLS:C2677589	SCAR9	UMLS:C4511089	Autosomal recessive ataxia due to ubiquinone deficiency	UMLS		live		live	
+MONDO:0012787	hereditary spastic paraplegia 39	UMLS:C2677586	Spastic paraplegia due to neuropathy target esterase mutation	UMLS:C4304963	Autosomal recessive spastic paraplegia type 39	UMLS		live		live	
+MONDO:0012830	chromosome 10q23 deletion syndrome	UMLS:C2677102	Chromosome 10q23 Deletion Syndrome	UMLS:CN202618	Monosomy 10q22.3q23.3	UMLS		live		live	
+MONDO:0012864	chromosome 2q32-q33 deletion syndrome	UMLS:C2676739	Monosomy 2q32q33	UMLS:C4304531	2q32q33 microdeletion syndrome	UMLS		live		live	
+MONDO:0012885	SRD5A3-CDG	UMLS:C3150191	CDG syndrome type Iq	UMLS:C4317224	Congenital disorder of glycosylation type 1q	UMLS		live		live	
+MONDO:0012912	pseudopseudohypoparathyroidism	Orphanet:665	Albright hereditary osteodystrophy	Orphanet:79445	Pseudopseudohypoparathyroidism	Orphanet		live		live	
+MONDO:0012916	chromosome 2p16.1-p15 deletion syndrome	UMLS:C2675875	Monosomy 2p15p16.1	UMLS:C4304538	2p15p16.1 microdeletion syndrome	UMLS		live		live	
+MONDO:0012927	chromosome 1q41-q42 deletion syndrome	UMLS:C2675857	Monosomy 1q41q42	UMLS:C4274528	1q41q42 microdeletion syndrome	UMLS		live		live	
+MONDO:0012948	chromosome 6pter-p24 deletion syndrome	UMLS:C2675486	Monosomy 6p25	UMLS:C4305276	Distal monosomy 6p	UMLS		live		live	
+MONDO:0012977	autosomal recessive nonsyndromic deafness 1B	UMLS:C2675235	DEAFNESS, AUTOSOMAL RECESSIVE 1B	UMLS:CN674504	Autosomal recessive deafness Type 1B	UMLS		live		live	
+MONDO:0012980	endocrine-cerebro-osteodysplasia syndrome	UMLS:C2675227	ECO syndrome	UMLS:C4509819	Endocrine-cerebro-osteodysplasia syndrome	UMLS		live		live	
+MONDO:0012991	Kahrizi syndrome	UMLS:C2675185	KAHRIZI SYNDROME	UMLS:CN200191	Kahrizi syndrome	UMLS		live		live	
+MONDO:0012992	pancreatic insufficiency-anemia-hyperostosis syndrome	UMLS:C2675184	Pancreatic insufficiency-anemia-hyperostosis syndrome	UMLS:C4302747	Pancreatic insufficiency, dyserythropoietic anemia, calvarial hyperostosis syndrome	UMLS		live		live	
+MONDO:0013025	chromosome 6q24-q25 deletion syndrome	UMLS:C3150215	Monosomy 6q25	UMLS:C4304527	6q25 microdeletion syndrome	UMLS		live		live	
+MONDO:0013056	epileptic encephalopathy with global cerebral demyelination	UMLS:C2751855	Mitochondrial aspartate-glutamate carrier 1 deficiency	UMLS:C4512050	Epileptic encephalopathy with global cerebral demyelination	UMLS		live		live	
+MONDO:0013090	chromosome 19q13.11 deletion syndrome	UMLS:C2751651	Monosomy 19q13.11	UMLS:C4304577	19q13.11 microdeletion syndrome	UMLS		live		live	
+MONDO:0013099	combined pituitary hormone deficiencies, genetic form	GARD:0002252	Familial hypopituitarism	GARD:0010602	Combined pituitary hormone deficiencies, genetic forms	GARD		live		live	
+MONDO:0013132	hereditary spastic paraplegia 36	UMLS:C2936879	SPG36	UMLS:C4510078	Autosomal dominant spastic paraplegia type 36	UMLS		live		live	
+MONDO:0013182	chromosome 17p13.3 duplication syndrome	UMLS:C2750748	Trisomy 17p13.3	UMLS:C4304641	17p13.3 microduplication syndrome	UMLS		live		live	
+MONDO:0013184	congenital diarrhea 5 with tufting enteropathy	UMLS:C2750737	Intestinal epithelial dysplasia	UMLS:C4275062	Intestinal epithelial dysplasia	UMLS		live		live	
+MONDO:0013209	non-alcoholic fatty liver disease	EFO:0003095	non-alcoholic fatty liver disease	EFO:1001248	non-alcoholic fatty liver	EFO		live		live	
+MONDO:0013212	Charcot-Marie-tooth disease axonal type 2N	UMLS:C2750090	CMT2N	UMLS:C4304671	Autosomal dominant Charcot-Marie-Tooth disease type 2N	UMLS		live		live	
+MONDO:0013229	hot water reflex epilepsy	UMLS:C0393729	Immersion-related epilepsy	UMLS:CN200053	Hot water reflex epilepsy	UMLS		live		live	
+MONDO:0013238	chromosome 17q23.1-q23.2 deletion syndrome	UMLS:C3150607	Monosomy 17q23.1q23.2	UMLS:C4304591	17q23.1q23.2 microdeletion syndrome	UMLS		live		live	
+MONDO:0013241	spinocerebellar ataxia type 30	UMLS:C2936793	SCA30	UMLS:C4304845	Spinocerebellar ataxia type 30	UMLS		live		live	
+MONDO:0013256	chromosome 15q24 deletion syndrome	UMLS:C3150674	CHROMOSOME 15q24 DELETION SYNDROME	UMLS:CN237818	Chromosome 15q24 deletion syndrome	UMLS		live		live	
+MONDO:0013267	distal 16p11.2 microdeletion syndrome	UMLS:C3150701	Distal monosomy 16p11.2	UMLS:C4518824	Distal 16p11.2 microdeletion syndrome	UMLS		live		live	
+MONDO:0013272	chromosome 14q11-q22 deletion syndrome	UMLS:C3150707	Monosomy 14q11.2	UMLS:C4304999	14q11.2 microdeletion syndrome	UMLS		live		live	
+MONDO:0013273	chromosome 16p13.3 duplication syndrome	UMLS:C3150708	Trisomy 16pter	UMLS:C4518796	16p13.3 microduplication syndrome	UMLS		live		live	
+MONDO:0013275	hemolytic anemia due to glucophosphate isomerase deficiency	UMLS:C3150730	Hemolytic anemia due to glucophosphate isomerase deficiency	UMLS:CN072763	Glucosephosphate isomerase deficiency	UMLS		live		live	
+MONDO:0013280	myxoid liposarcoma	DOID:5363	myxoid liposarcoma	DOID:5709	mixed-type liposarcoma	DOID		live		live	
+MONDO:0013292	chromosome 4q21 deletion syndrome	UMLS:C3150756	Monosomy 4q21	UMLS:C4304530	4q21 microdeletion syndrome	UMLS		live		live	
+MONDO:0013296	myeloid neoplasm associated with FGFR1 rearrangement	UMLS:C2827362	Myeloid and Lymphoid Neoplasms with FGFR1 Rearrangement	UMLS:C3150773	Stem cell leukemia/lymphoma	UMLS		live		live	
+MONDO:0013298	chromosome 17q21.31 duplication syndrome	UMLS:C3150787	Trisomy 17q21.31	UMLS:C4274345	17q21.31 microduplication syndrome	UMLS		live		live	
+MONDO:0013308	Noonan syndrome-like disorder with juvenile myelomonocytic leukemia	UMLS:C3150803	NOONAN SYNDROME-LIKE DISORDER WITH OR WITHOUT JUVENILE MYELOMONOCYTIC LEUKEMIA	UMLS:C4016301	NOONAN SYNDROME-LIKE DISORDER WITH JUVENILE MYELOMONOCYTIC LEUKEMIA	UMLS		live		live	
+MONDO:0013320	chromosome 16p12.2-p11.2 deletion syndrome	UMLS:C3150858	Monosomy 16p11.2p12.2	UMLS:C4304597	16p11.2p12.2 microdeletion syndrome	UMLS		live		live	
+MONDO:0013325	COG5-CDG	GARD:0001173	CDG syndrome type 3	GARD:0012348	COG5-CDG (CDG-IIi)	GARD		live		live	
+MONDO:0013336	chromosome 19p13.13 deletion syndrome	UMLS:C3150894	CHROMOSOME 19p13.13 DELETION SYNDROME	UMLS:CN204595	Monosomy 19p13.13	UMLS		live		live	
+MONDO:0013352	intellectual disability-severe speech delay-mild dysmorphism syndrome	UMLS:C3150923	MENTAL RETARDATION WITH LANGUAGE IMPAIRMENT AND AUTISTIC FEATURES	UMLS:CN204965	Intellectual disability-severe speech delay-mild dysmorphism syndrome	UMLS		live		live	
+MONDO:0013354	spastic ataxia 4	UMLS:C3150925	SPAX4	UMLS:CN230090	Spastic Ataxia 4	UMLS		live		live	
+MONDO:0013359	familial hyperaldosteronism type III	UMLS:C3150933	Familial hyperaldosteronism type 3	UMLS:C3838758	Familial hyperaldosteronism type 3	UMLS		live		live	
+MONDO:0013396	chromosome 1p32-p31 deletion syndrome	UMLS:C3151036	CHROMOSOME 1p32-p31 DELETION SYNDROME	UMLS:CN226149	Monosomy 1p31p32	UMLS		live		live	
+MONDO:0013404	hypermethioninemia with deficiency of S-adenosylhomocysteine hydrolase	UMLS:C3151058	Hypermethioninemia due to S-adenosylhomocysteine hydrolase deficiency	UMLS:C4510276	Psychomotor retardation due to S-adenosylhomocysteine hydrolase deficiency	UMLS		live		live	
+MONDO:0013408	FADD-related immunodeficiency	UMLS:C3151062	FADD-related immunodeficiency	UMLS:C4509831	FADD-related immunodeficiency	UMLS		live		live	
+MONDO:0013417	complement component 3 deficiency	UMLS:C1332655	C3 DEFICIENCY	UMLS:C3151071	C3 deficiency	UMLS		live		live	
+MONDO:0013424	3p- syndrome	GARD:0000037	Chromosome 3p deletion	GARD:0003750	Chromosome 3p- syndrome	GARD		live		live	
+MONDO:0013439	congenital bile acid synthesis defect 3	UMLS:C3151147	BASD3	UMLS:C4304715	Congenital bile acid synthesis defect type 3	UMLS		live		live	
+MONDO:0013485	spinocerebellar ataxia type 35	UMLS:C4304822	Spinocerebellar ataxia type 35	UMLS:CN202597	SCA35	UMLS		live		live	
+MONDO:0013486	spinocerebellar ataxia type 32	UMLS:C3151343	SCA32	UMLS:C4304844	Spinocerebellar ataxia type 32	UMLS		live		live	
+MONDO:0013500	immunodeficiency 51	UMLS:C3151402	CANDIDIASIS, FAMILIAL, 5	UMLS:C4310803	IMMUNODEFICIENCY 51	UMLS		live		live	
+MONDO:0013550	distal myopathy with posterior leg and anterior hand involvement	UMLS:C3279722	Distal ABD-filaminopathy	UMLS:C4518807	Distal myopathy with posterior leg and anterior hand involvement	UMLS		live		live	
+MONDO:0013560	Hermansky-Pudlak syndrome 8	UMLS:C3888026	HERMANSKY-PUDLAK SYNDROME 8	UMLS:CN201510	HPS8	UMLS		live		live	
+MONDO:0013570	combined oxidative phosphorylation defect type 8	UMLS:C3279793	COXPD8	UMLS:C4518839	Combined oxidative phosphorylation defect type 8	UMLS		live		live	
+MONDO:0013609	Meckel syndrome, type 10	UMLS:C3280036	MECKEL SYNDROME, TYPE 10	UMLS:CN620433	JBTS34	UMLS		live		live	
+MONDO:0013646	chromosome 8q21.11 deletion syndrome	UMLS:C3280231	Monosomy 8q21.11	UMLS:C4305343	8q21.11 microdeletion syndrome	UMLS		live		live	
+MONDO:0013648	familial progressive hyperpigmentation	UMLS:C1840392	Familial progressive hyperpigmentation	UMLS:CN205811	Universal melanosis	UMLS		live		live	
+MONDO:0013673	Wolfram-like syndrome	UMLS:C3280358	Wolfram-like syndrome	UMLS:C4518338	Wolfram-like syndrome	UMLS		live		live	
+MONDO:0013688	linear and whorled nevoid hypermelanosis	UMLS:C0263579	Pigmented hairy epidermal nevus	UMLS:C1304501	Linear and whorled nevoid hypermelanosis	UMLS		live		live	
+MONDO:0013737	hereditary spastic paraplegia 46	UMLS:C2828721	SPG46	UMLS:C4510081	Autosomal recessive spastic paraplegia type 46	UMLS		live		live	
+MONDO:0013758	Charcot-Marie-tooth disease dominant intermediate E	UMLS:C3280845	Charcot-Marie-Tooth disease-nephropathy syndrome	UMLS:C4302667	Autosomal dominant intermediate Charcot-Marie-Tooth disease type E	UMLS		live		live	
+MONDO:0013797	chromosome 17q12 deletion syndrome	UMLS:C3281138	Monosomy 17q12	UMLS:C4518822	17q12 microdeletion syndrome	UMLS		live		live	
+MONDO:0013851	autosomal dominant aplasia and myelodysplasia	UMLS:C3808553	BONE MARROW FAILURE SYNDROME 1	UMLS:CN203751	Autosomal dominant aplastic anemia and myelodysplasia	UMLS		live		live	
+MONDO:0013869	adenine phosphoribosyltransferase deficiency	GARD:0000546	Adenine phosphoribosyltransferase deficiency	GARD:0010666	Dihydroxyadeninuria	GARD		live		live	
+MONDO:0013892	C3 glomerulonephritis	UMLS:C3553720	C3 glomerulonephritis	UMLS:C4055342	C3 Glomerulonephritis	UMLS		live		live	
+MONDO:0013892	C3 glomerulonephritis	UMLS:C3553720	C3 glomerulonephritis	UMLS:CN187045		UMLS		live		not_present	
+MONDO:0013892	C3 glomerulonephritis	UMLS:C4055342	C3 Glomerulonephritis	UMLS:CN187045		UMLS		live		not_present	
+MONDO:0013918	distal tetrasomy 15q	UMLS:C3553858	TETRASOMY 15q26	UMLS:CN203770	Tetrasomy 15q26	UMLS		live		live	
+MONDO:0013962	hereditary spastic paraplegia 53	UMLS:C3539494	SPG53	UMLS:C4510082	Autosomal recessive spastic paraplegia type 53	UMLS		live		live	
+MONDO:0014018	hereditary spastic paraplegia 54	UMLS:C3539495	SPG54	UMLS:C4510083	Autosomal recessive spastic paraplegia type 54	UMLS		live		live	
+MONDO:0014020	hereditary spastic paraplegia 55	UMLS:C3539506	SPG55	UMLS:C4510214	Autosomal recessive spastic paraplegia type 55	UMLS		live		live	
+MONDO:0014021	familial episodic pain syndrome with predominantly upper body involvement	UMLS:C3808667	EPISODIC PAIN SYNDROME, FAMILIAL, 1	UMLS:CN204968	Familial episodic pain syndrome with predominantly upper body involvement	UMLS		live		live	
+MONDO:0014043	microcephalic primordial dwarfism due to ZNF335 deficiency	UMLS:C3554499	Microcephalic primordial dwarfism, Walsh type	UMLS:C4510378	Microcephalic primordial dwarfism due to ZNF335 deficiency	UMLS		live		live	
+MONDO:0014070	oculocutaneous albinism type 7	UMLS:C3808786	ALBINISM, OCULOCUTANEOUS, TYPE VII	UMLS:CN204524	OCA7	UMLS		live		live	
+MONDO:0014076	dyskeratosis congenita, autosomal recessive 5	DOID:0070020	autosomal dominant dyskeratosis congenita 4	DOID:0070022	autosomal recessive dyskeratosis congenita 5	DOID		live		live	
+MONDO:0014094	severe congenital hypochromic anemia with ringed sideroblasts	UMLS:C3808920	Severe congenital hypochromic sideroblastic anemia	UMLS:C4511137	Severe congenital hypochromic anemia with ringed sideroblasts	UMLS		live		live	
+MONDO:0014185	chromosome 3q13.31 deletion syndrome	UMLS:C3809490	CHROMOSOME 3q13.31 DELETION SYNDROME	UMLS:CN036884	Monosomy 3q13	UMLS		live		live	
+MONDO:0014225	hemochromatosis type 5	Orphanet:247790	FTH1-related iron overload	Orphanet:447792	Hemochromatosis type 5	Orphanet		live		live	
+MONDO:0014225	hemochromatosis type 5	UMLS:C1851316	FTH1-associated iron overload	UMLS:CN181217	HFE5	UMLS		live		live	
+MONDO:0014225	hemochromatosis type 5	UMLS:C1851316	FTH1-associated iron overload	UMLS:CN237708	Hemochromatosis type 5	UMLS		live		live	
+MONDO:0014225	hemochromatosis type 5	UMLS:CN181217	HFE5	UMLS:CN237708	Hemochromatosis type 5	UMLS		live		live	
+MONDO:0014253	autoimmune lymphoproliferative syndrome type 3	UMLS:C1519711	Type 3 Autoimmune Lymphoproliferative Syndrome	UMLS:C3809928	AUTOIMMUNE LYMPHOPROLIFERATIVE SYNDROME, TYPE III	UMLS		live		live	
+MONDO:0014276	combined immunodeficiency due to CD3gamma deficiency	UMLS:C3810107	Combined immunodeficiency due to CD3gamma deficiency	UMLS:C4510864	Combined immunodeficiency due to CD3gamma deficiency	UMLS		live		live	
+MONDO:0014295	hereditary spastic paraplegia 57	UMLS:C3714897	Spastic paraplegia due to partial TFG deficiency	UMLS:C4510084	Autosomal recessive spastic paraplegia type 57	UMLS		live		live	
+MONDO:0014303	hereditary spastic paraplegia 64	UMLS:C3810289	SPG64	UMLS:C4511960	Autosomal recessive spastic paraplegia type 64	UMLS		live		live	
+MONDO:0014304	hereditary spastic paraplegia 61	UMLS:C3810294	SPG61	UMLS:C4511962	Autosomal recessive spastic paraplegia type 61	UMLS		live		live	
+MONDO:0014381	cholestasis, progressive familial intrahepatic, 4	UMLS:C2931067	CHOLESTASIS, PROGRESSIVE FAMILIAL INTRAHEPATIC, 4	UMLS:CN776838	TJP2 deficit	UMLS		live		live	
+MONDO:0014405	STING-associated vasculopathy with onset in infancy	UMLS:C4014722	SAVI	UMLS:C4040879	STING-associated vasculopathy with onset in infancy	UMLS		live		live	
+MONDO:0014410	spinocerebellar ataxia type 37	UMLS:C3889636	Spinocerebellar ataxia with altered vertical eye movements	UMLS:C4304821	Spinocerebellar ataxia type 37	UMLS		live		live	
+MONDO:0014417	spinocerebellar ataxia type 38	UMLS:C4014812	SCA38	UMLS:C4518337	Spinocerebellar ataxia type 38	UMLS		live		live	
+MONDO:0014452	familial dysfibrinogenemia	UMLS:C1260903	Dysfibrinogenemia	UMLS:CN207171	Familial dysfibrinogenemia	UMLS		live		live	
+MONDO:0014475	spinocerebellar ataxia type 40	UMLS:C4518336	Spinocerebellar ataxia type 40	UMLS:CN219009		UMLS		live		not_present	
+MONDO:0014475	spinocerebellar ataxia type 40	UMLS:C4518336	Spinocerebellar ataxia type 40	UMLS:CN237494	SCA40	UMLS		live		live	
+MONDO:0014475	spinocerebellar ataxia type 40	UMLS:CN219009		UMLS:CN237494	SCA40	UMLS		not_present		live	
+MONDO:0014512	PURA-related severe neonatal hypotonia-seizures-encephalopathy syndrome due to a point mutation	UMLS:C4015357	MENTAL RETARDATION, AUTOSOMAL DOMINANT 31	UMLS:CN237609	PURA-related severe neonatal hypotonia-seizures-encephalopathy syndrome due to a point mutation	UMLS		live		live	
+MONDO:0014529	cerebellar-facial-dental syndrome	UMLS:C4015495	Cerebellofaciodental syndrome	UMLS:CN221667	cerebellar-facial-dental syndrome	UMLS		live		live	
+MONDO:0014546	myopathy due to calsequestrin and SERCA1 protein overload	UMLS:C4015624	Myopathy due to calsequestrin and SERCA1 protein overload	UMLS:C4510368	Myopathy due to calsequestrin and SERCA1 protein overload	UMLS		live		live	
+MONDO:0014645	BENTA disease	UMLS:CN231446	BENTA	UMLS:CN242071	B-cell expansion with NF-kB and T-cell anergy disease	UMLS		live		live	
+MONDO:0014669	cone-rod dystrophy 21	UMLS:C4049066	CONE-ROD DYSTROPHY 21	UMLS:CN231743	CORD21	UMLS		live		live	
+MONDO:0014700	neurodevelopmental disorder-craniofacial dysmorphism-cardiac defect-hip dysplasia syndrome due to a point mutation	UMLS:C4225274	AU-KLINE SYNDROME	UMLS:CN237748	Au-Kline syndrome	UMLS		live		live	
+MONDO:0014717	early-onset Lafora body disease	UMLS:C4225258	Early-onset Lafora body disease	UMLS:C4518574	Early-onset Lafora body disease	UMLS		live		live	
+MONDO:0014720	autosomal dominant optic atrophy plus syndrome	UMLS:C1852267	Optic atrophy-deafness-polyneuropathy-myopathy syndrome	UMLS:C4275164	Autosomal dominant optic atrophy plus syndrome	UMLS		live		live	
+MONDO:0014741	facial dysmorphism-developmental delay-behavioral abnormalities syndrome due to WAC point mutation	UMLS:C4225239	DESANTO-SHINAWI SYNDROME	UMLS:CN242167	Facial dysmorphism-developmental delay-behavioral abnormalities syndrome due to WAC point mutation	UMLS		live		live	
+MONDO:0014746	SLC39A8-CDG	UMLS:C4225234	CDG2N	UMLS:CN234734	SLC39A8 deficiency	UMLS		live		live	
+MONDO:0014822	15q14 microdeletion syndrome	UMLS:C4225666	Monosomy 15q14	UMLS:C4305230	15q14 microdeletion syndrome	UMLS		live		live	
+MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:C4310473	HYPERCALCEMIA, INFANTILE, 2	UMLS:CN262351		UMLS		live		not_present	
+MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:C4310473	HYPERCALCEMIA, INFANTILE, 2	UMLS:CN774236		UMLS		live		not_present	
+MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:C4310473	HYPERCALCEMIA, INFANTILE, 2	UMLS:CN847585		UMLS		live		not_present	
+MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:CN262351		UMLS:CN774236		UMLS		not_present		not_present	
+MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:CN262351		UMLS:CN847585		UMLS		not_present		not_present	
+MONDO:0014851	hypercalcemia, infantile, 2; HCINF2	UMLS:CN774236		UMLS:CN847585		UMLS		not_present		not_present	
+MONDO:0014884	cholestasis, progressive familial intrahepatic, 5; PFIC5	UMLS:C4310747	CHOLESTASIS, PROGRESSIVE FAMILIAL INTRAHEPATIC, 5	UMLS:CN776839	PFIC5	UMLS		live		live	
+MONDO:0014977	autosomal recessive limb-girdle muscular dystrophy type 2Z	UMLS:C4310660	MUSCULAR DYSTROPHY, LIMB-GIRDLE, TYPE 2Z	UMLS:CN776834	LGMD2Z	UMLS		live		live	
+MONDO:0015011	optic atrophy 11; OPA11	UMLS:C4310628	OPTIC ATROPHY 11	UMLS:CN230145	Optic Atrophy Type 11	UMLS		live		live	
+MONDO:0015023	nemaline myopathy 11	UMLS:C4479186	NEMALINE MYOPATHY 11, AUTOSOMAL RECESSIVE	UMLS:C4479695	NEMALINE MYOPATHY 11	UMLS		live		live	
+MONDO:0015023	nemaline myopathy 11	UMLS:C4479186	NEMALINE MYOPATHY 11, AUTOSOMAL RECESSIVE	UMLS:CN240509		UMLS		live		not_present	
+MONDO:0015023	nemaline myopathy 11	UMLS:C4479695	NEMALINE MYOPATHY 11	UMLS:CN240509		UMLS		live		not_present	
+MONDO:0015025	epileptic encephalopathy, early infantile, 51; EIEE51	UMLS:C4479208	EPILEPTIC ENCEPHALOPATHY, EARLY INFANTILE, 51	UMLS:CN240510		UMLS		live		not_present	
+MONDO:0015035	lissencephaly with cerebellar hypoplasia type B	UMLS:C4274993	Lissencephaly with cerebellar hypoplasia type B	UMLS:CN228901	Lissencephaly with cerebellar hypoplasia type B	UMLS		live		live	
+MONDO:0015036	lissencephaly with cerebellar hypoplasia type C	UMLS:C4274992	Lissencephaly with cerebellar hypoplasia type C	UMLS:CN228902	Lissencephaly with cerebellar hypoplasia type C	UMLS		live		live	
+MONDO:0015037	lissencephaly with cerebellar hypoplasia type D	UMLS:C4274991	Lissencephaly with cerebellar hypoplasia type D	UMLS:CN228903	Lissencephaly with cerebellar hypoplasia type D	UMLS		live		live	
+MONDO:0015039	lissencephaly with cerebellar hypoplasia type F	UMLS:C4274989	Lissencephaly with cerebellar hypoplasia type F	UMLS:CN228905	Lissencephaly with cerebellar hypoplasia type F	UMLS		live		live	
+MONDO:0015062	gastric neuroendocrine tumor, well differentiated, low or intermediate grade	UMLS:C3272399	Gastric Neuroendocrine Tumor	UMLS:CN197355	GNET	UMLS		live		live	
+MONDO:0015071	middle ear neuroendocrine tumor	UMLS:C4305468	Neuroendocrine tumor of middle ear	UMLS:CN197364	Middle ear neuroendocrine tumor	UMLS		live		live	
+MONDO:0015072	liver neuroendocrine carcinoma	UMLS:C3273031	Liver Neuroendocrine Carcinoma	UMLS:CN197365	Primary hepatic neuroendocrine carcinoma	UMLS		live		live	
+MONDO:0015073	gallbladder neuroendocrine tumor, grade 1/2	UMLS:C3273116	Gallbladder Neuroendocrine Tumor	UMLS:CN197366	Gallbladder neuroendocrine tumor	UMLS		live		live	
+MONDO:0015084	FRAXF syndrome	UMLS:C4274329	FRAXF syndrome	UMLS:CN197382	FRAXF syndrome	UMLS		live		live	
+MONDO:0015137	periodic fever syndrome	UMLS:C0015974	Periodic fever syndrome	UMLS:C3889979	Periodic Fever Syndrome	UMLS		live		live	
+MONDO:0015150	complex hereditary spastic paraplegia	UMLS:C0393556	Complicated hereditary spastic paraplegia	UMLS:CN197491	Complicated hereditary spastic paraplegia	UMLS		live		live	
+MONDO:0015151	autosomal dominant limb-girdle muscular dystrophy	UMLS:CN043626	Limb-Girdle Muscular Dystrophy, Autosomal Dominant	UMLS:CN228919	Autosomal dominant limb-girdle muscular dystrophy	UMLS		live		live	
+MONDO:0015185	intestinal polyposis syndrome	UMLS:C0345891	Intestinal polyposis syndrome	UMLS:CN197525	Intestinal polyposis syndrome	UMLS		live		live	
+MONDO:0015193	hydrops fetalis (disease)	GARD:0002301	Fetal edema	GARD:0002783	Hydrops fetalis	GARD		live		live	
+MONDO:0015205	isolated lissencephaly type 1 without known genetic defects	UMLS:C4275151	Isolated lissencephaly type 1 without known genetic defect	UMLS:CN226623	Isolated lissencephaly type 1 without known genetic defects	UMLS		live		live	
+MONDO:0015231	Bartter syndrome	UMLS:C0004775	Salt-wasting tubulopathy, Henle's loop type	UMLS:C0085570	Hypokalemic alkalosis	UMLS		live		live	
+MONDO:0015240	digitotalar dysmorphism	UMLS:C0220662	Distal arthrogryposis type 1	UMLS:C1852085	DIGITOTALAR DYSMORPHISM	UMLS		live		live	
+MONDO:0015240	digitotalar dysmorphism	UMLS:C0220662	Distal arthrogryposis type 1	UMLS:CN197602	Distal arthrogryposis type 1	UMLS		live		live	
+MONDO:0015240	digitotalar dysmorphism	UMLS:C1852085	DIGITOTALAR DYSMORPHISM	UMLS:CN197602	Distal arthrogryposis type 1	UMLS		live		live	
+MONDO:0015241	arthrogryposis-like syndrome	GARD:0000783	Arthrogryposis like disorder	GARD:0003150	Kuskokwim disease	GARD		live		live	
+MONDO:0015253	Diamond-Blackfan anemia	UMLS:C0265265	Aase syndrome	UMLS:C1260899	Diamond-Blackfan anemia	UMLS		live		live	
+MONDO:0015277	medullary thyroid gland carcinoma	UMLS:C0206693	Medullary carcinoma	UMLS:C0238462	Medullary thyroid carcinoma	UMLS		live		live	
+MONDO:0015288	herpes simplex virus keratitis	UMLS:C0019357	Herpetic keratitis	UMLS:C0022570	Dendritic Keratitis	UMLS		live		live	
+MONDO:0015294	nephrogenic systemic fibrosis	UMLS:C1619692	Nephrogenic fibrosing dermopathy	UMLS:C3888044	Nephrogenic systemic fibrosis	UMLS		live		live	
+MONDO:0015302	nodular cutaneous amyloidosis	UMLS:C0546394	Primary localized cutaneous nodular amyloidosis	UMLS:C4274331	Primary localized cutaneous nodular amyloidosis	UMLS		live		live	
+MONDO:0015304	arachnoiditis	UMLS:C0003708	Arachnoiditis	UMLS:C0270617	Adhesive arachnoiditis	UMLS		live		live	
+MONDO:0015346	Jeavons syndrome	UMLS:C4274731	Jeavons syndrome	UMLS:CN199399	Eyelid myoclonia with and without absences	UMLS		live		live	
+MONDO:0015350	17q11.2 microduplication syndrome	UMLS:C4304642	17q11.2 microduplication syndrome	UMLS:CN199408	Trisomy 17q11.2	UMLS		live		live	
+MONDO:0015354	hereditary sensory and autonomic neuropathy with deafness and global delay	UMLS:C4303566	Hereditary sensory and autonomic neuropathy with deafness and global delay	UMLS:CN226662	HSAN with deafness and global delay	UMLS		live		live	
+MONDO:0015356	hereditary neoplastic syndrome	UMLS:C0027672	Hereditary neoplastic syndrome	UMLS:CN199448	Inherited cancer-predisposing syndrome	UMLS		live		live	
+MONDO:0015356	hereditary neoplastic syndrome	UMLS:C0027672	Hereditary neoplastic syndrome	UMLS:CN882908	Hereditary Cancer Syndrome	UMLS		live		live	
+MONDO:0015356	hereditary neoplastic syndrome	UMLS:CN199448	Inherited cancer-predisposing syndrome	UMLS:CN882908	Hereditary Cancer Syndrome	UMLS		live		live	
+MONDO:0015367	Charlie M syndrome	UMLS:C4518555	Charlie M syndrome	UMLS:CN199458	Charlie M syndrome	UMLS		live		live	
+MONDO:0015372	autosomal dominant macrothrombocytopenia	UMLS:C4304021	Autosomal dominant macrothrombocytopenia	UMLS:CN199474	Autosomal dominant macrothrombocytopenia	UMLS		live		live	
+MONDO:0015399	glossopalatine ankylosis	UMLS:C4303569	Glossopalatine ankylosis	UMLS:CN199497	Cosack syndrome	UMLS		live		live	
+MONDO:0015405	cerebrofacial arteriovenous metameric syndrome	UMLS:C3839265	Cerebrofacial arteriovenous metameric syndrome	UMLS:CN199500	CAMS	UMLS		live		live	
+MONDO:0015406	cerebrofacial arteriovenous metameric syndrome type 1	UMLS:C3840102	Cerebrofacial arteriovenous metameric syndrome type 1	UMLS:CN199501	CAMS1	UMLS		live		live	
+MONDO:0015407	cerebrofacial arteriovenous metameric syndrome type 3	UMLS:C3838691	Cerebrofacial arteriovenous metameric syndrome type 3	UMLS:CN199502	CAMS3	UMLS		live		live	
+MONDO:0015425	lethal recessive chondrodysplasia	UMLS:C4304745	Lethal recessive chondrodysplasia	UMLS:CN199522	Maroteaux-Stanescu-Cousin syndrome	UMLS		live		live	
+MONDO:0015426	Desbuquois dysplasia	UMLS:C0432242	Desbuquois syndrome	UMLS:CN239270	Desbuquois Dysplasia	UMLS		live		live	
+MONDO:0015431	ring chromosome 10	UMLS:C0265438	Ring chromosome 10 syndrome	UMLS:CN037257	Chromosome 10, ring	UMLS		live		live	
+MONDO:0015446	atypical coarctation of aorta	UMLS:C3496579	Middle aortic syndrome	UMLS:C3805239	Middle aortic syndrome	UMLS		live		live	
+MONDO:0015457	corpus callosum agenesis-double urinary collecting system syndrome	GARD:0000852	Ben Ari Shuper Mimouni syndrome	GARD:0001536	Corpus callosum agenesis double urinary collecting	GARD		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153393	Malignant neoplasm of superior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153394	Malignant tumor of posterior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153395	Malignant tumor of lateral wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C0153396	Malignant tumor of anterior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C2931822	Nasopharyngeal carcinoma	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C3647449	Primary malignant neoplasm of anterior wall of nasopharynx	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015459	nasopharyngeal carcinoma	UMLS:C3665551	Malignant neoplasm of nasopharyngeal wall	UMLS:CN199582	Nasopharyngeal carcinoma	UMLS		live		live	
+MONDO:0015474	cryptosporidiosis	UMLS:C0010418	Cryptosporidiosis	UMLS:C0520796	Cryptosporidial gastroenteritis	UMLS		live		live	
+MONDO:0015484	cysticercosis	UMLS:C0010678	Cysticercosis	UMLS:C0338437	Neurocysticercosis	UMLS		live		live	
+MONDO:0015540	hemophagocytic syndrome	NCIT:C34792	Hemophagocytic Lymphohistiocytosis	NCIT:C35439	Hemophagocytic Syndrome	NCIT		live		live	
+MONDO:0015540	hemophagocytic syndrome	UMLS:C0024291	Hemophagocytic lymphohistiocytosis	UMLS:C3887558	Hemophagocytic syndrome	UMLS		live		live	
+MONDO:0015542	secondary hemophagocytic lymphohistiocytosis	UMLS:C0019068	Reactive Hemophagocytic Syndrome	UMLS:C4054044	Secondary Hemophagocytic Lymphohistiocytosis	UMLS		live		live	
+MONDO:0015542	secondary hemophagocytic lymphohistiocytosis	UMLS:C0019068	Reactive Hemophagocytic Syndrome	UMLS:CN199700	Reactive hemophagocytic syndrome	UMLS		live		live	
+MONDO:0015542	secondary hemophagocytic lymphohistiocytosis	UMLS:C4054044	Secondary Hemophagocytic Lymphohistiocytosis	UMLS:CN199700	Reactive hemophagocytic syndrome	UMLS		live		live	
+MONDO:0015552	acral dystrophic epidermolysis bullosa	UMLS:C4518087	Acral dystrophic epidermolysis bullosa	UMLS:CN199731	DEB-ac	UMLS		live		live	
+MONDO:0015564	Castleman disease	GARD:0000673	Angiofollicular lymph hyperplasia	GARD:0012656	Castleman disease	GARD		live		live	
+MONDO:0015564	Castleman disease	UMLS:C0017531	Angiolymphoid hyperplasia	UMLS:C2931179	Angiofollicular ganglionic hyperplasia	UMLS		live		live	
+MONDO:0015564	Castleman disease	UMLS:C0017531	Angiolymphoid hyperplasia	UMLS:CN199886	Angiofollicular lymph hyperplasia	UMLS		live		live	
+MONDO:0015564	Castleman disease	UMLS:C2931179	Angiofollicular ganglionic hyperplasia	UMLS:CN199886	Angiofollicular lymph hyperplasia	UMLS		live		live	
+MONDO:0015583	2p21 microdeletion syndrome	UMLS:C4304537	2p21 microdeletion syndrome	UMLS:CN199952	2p21 deletion syndrome	UMLS		live		live	
+MONDO:0015612	Dent disease	UMLS:C0878681	Dent's disease	UMLS:CN239269	Dent Disease	UMLS		live		live	
+MONDO:0015629	von willebrand disease type 2B	SCTID:359717002	hereditary von willebrand disease type 2b (disorder)	SCTID:359721009	von willebrand disease type 2b (disorder)	SCTID		live		live	
+MONDO:0015630	von willebrand disease type 2M	SCTID:359725000	hereditary von willebrand disease type 2m (disorder)	SCTID:359729006	von willebrand disease type 2m (disorder)	SCTID		live		live	
+MONDO:0015633	Bazex syndrome	UMLS:C0406355	Acrokeratosis paraneoplastica of Bazex	UMLS:CN200039	Acrokeratosis paraneoplastica of Bazex	UMLS		live		live	
+MONDO:0015663	diencephalic syndrome	UMLS:C0271889	Diencephalic syndrome of infancy	UMLS:C0342436	Diencephalic syndrome	UMLS		live		live	
+MONDO:0015663	diencephalic syndrome	UMLS:C0271889	Diencephalic syndrome of infancy	UMLS:CN200089	Russell syndrome	UMLS		live		live	
+MONDO:0015663	diencephalic syndrome	UMLS:C0342436	Diencephalic syndrome	UMLS:CN200089	Russell syndrome	UMLS		live		live	
+MONDO:0015665	scleromyxedema	UMLS:C0263390	Scleromyxedema	UMLS:CN200092	Generalized papular and sclerodermoid lichen myxedematosus	UMLS		live		live	
+MONDO:0015681	childhood disintegrative disorder	UMLS:C0236791		UMLS:CN072151	Childhood disintegrative disorder	UMLS		not_present		live	
+MONDO:0015692	refractory anemia with excess blasts in transformation	UMLS:C0280028	Refractory anemia with excess blasts in transformation	UMLS:CN200189	RAEB-t	UMLS		live		live	
+MONDO:0015826	autosomal dominant spondylocostal dysostosis	UMLS:C4274761	Autosomal dominant spondylocostal dysostosis	UMLS:CN200437	Autosomal dominant spondylocostal dysplasia	UMLS		live		live	
+MONDO:0015892	growth hormone insensitivity syndrome	UMLS:C0271568	Short stature due to growth hormone resistance	UMLS:C4318479	Growth Hormone Insensitivity Syndromes	UMLS		live		live	
+MONDO:0015892	growth hormone insensitivity syndrome	UMLS:C0271568	Short stature due to growth hormone resistance	UMLS:CN200504	Short stature due to a defect in growth hormone receptor or post-receptor pathway	UMLS		live		live	
+MONDO:0015892	growth hormone insensitivity syndrome	UMLS:C4318479	Growth Hormone Insensitivity Syndromes	UMLS:CN200504	Short stature due to a defect in growth hormone receptor or post-receptor pathway	UMLS		live		live	
+MONDO:0015898	adrenogenital syndrome	UMLS:C0302280	Adrenogenital syndrome	UMLS:CN200506	Adrenogenital syndrome	UMLS		live		live	
+MONDO:0015908	chromomycosis	UMLS:C0008582	Chromoblastomycosis	UMLS:C3245522	Mossy foot disease	UMLS		live		live	
+MONDO:0015924	pulmonary arterial hypertension	UMLS:C2973725	Pulmonary arterial hypertension	UMLS:CN200519	PAH	UMLS		live		live	
+MONDO:0015943	eosinophilic granulomatosis with polyangiitis	GARD:0005776	Allergic angiitis	GARD:0006111	Eosinophilic granulomatosis with polyangiitis	GARD		live		live	
+MONDO:0015995	melorheostosis with osteopoikilosis	GARD:0003690	Melorheostosis with osteopoikilosis	GARD:0003800	MSBD syndrome	GARD		live		live	
+MONDO:0015995	melorheostosis with osteopoikilosis	UMLS:C2931505	Mixed sclerosing bone dystrophy	UMLS:CN200621	Mixed sclerosing bone dystrophy	UMLS		live		live	
+MONDO:0015999	primary pigmented nodular adrenocortical disease	UMLS:C4304832	Primary pigmented nodular adrenocortical disease	UMLS:CN200645	PPNAD	UMLS		live		live	
+MONDO:0016002	Ehlers-Danlos syndrome, kyphoscoliotic type	UMLS:C0268342	Ehlers-Danlos syndrome, oculoscoliotic type	UMLS:CN202461	Nevo syndrome	UMLS		live		live	
+MONDO:0016005	indomethacin embryofetopathy	UMLS:C4275138	Indomethacin embryofetopathy	UMLS:CN200656	Fetal indomethacin syndrome	UMLS		live		live	
+MONDO:0016011	fetal alcohol syndrome	DOID:0050665	fetal alcohol syndrome	DOID:0050667	alcohol-related neurodevelopmental disorder	DOID		live		live	
+MONDO:0016021	early infantile epileptic encephalopathy	DOID:0050709	early infantile epileptic encephalopathy	DOID:2481	infantile epileptic encephalopathy	DOID		live		live	
+MONDO:0016022	early myoclonic encephalopathy	UMLS:C0014550	Myoclonic epilepsy	UMLS:C0270855	Early myoclonic encephalopathy	UMLS		live		live	
+MONDO:0016033	Cornelia de Lange syndrome	UMLS:C0270972	Cornelia de Lange syndrome	UMLS:CN239271	Cornelia de Lange Syndrome	UMLS		live		live	
+MONDO:0016035	Nelson syndrome	MESH:C531754	Ridges-off-the-end syndrome	MESH:D009347	Nelson Syndrome	MESH		live		live	
+MONDO:0016086	osteochondritis of tarsal/metatarsal bone	UMLS:C0158444	Juvenile osteochondrosis of foot	UMLS:CN200840	Osteochondrosis of the tarsal bone	UMLS		live		live	
+MONDO:0016087	progressive non-infectious anterior vertebral fusion	UMLS:C4304839	Progressive non-infectious anterior vertebral fusion	UMLS:CN200850	Copenhagen syndrome	UMLS		live		live	
+MONDO:0016096	malignant non-dysgerminomatous germ cell tumor of ovary	UMLS:C3640983	Ovarian Non-Dysgerminomatous Germ Cell Tumor	UMLS:CN200863	Non-dysgerminomatous germ cell cancer of ovary	UMLS		live		live	
+MONDO:0016122	periodic paralysis (disease)	UMLS:C1279412	Periodic paralysis	UMLS:CN231077	Periodic paralysis	UMLS		live		live	
+MONDO:0016145	qualitative or quantitative defects of dysferlin	GARD:0002003	Dysferlinopathy	GARD:0002031	Dystrophinopathy	GARD		live		live	
+MONDO:0016208	solitary rectal ulcer syndrome	UMLS:C4274343	Solitary rectal ulcer syndrome	UMLS:CN200964	Solitary rectal ulcer syndrome	UMLS		live		live	
+MONDO:0016216	adult hepatocellular carcinoma	UMLS:C0279607	Adult Hepatocellular Carcinoma	UMLS:CN200978	Adult HCC	UMLS		live		live	
+MONDO:0016223	infantile hemangioma of rare localization	UMLS:C3839613	Infantile hemangioma of rare localization	UMLS:CN226884	Infantile hemangioma of rare localization	UMLS		live		live	
+MONDO:0016239	cystinosis	UMLS:C0010690		UMLS:CN035091	Protein defect of cystin transport	UMLS		not_present		live	
+MONDO:0016242	hemoglobin c disease	MESH:C531699	Hb C disease	MESH:D006445	Hemoglobin C Disease	MESH		live		live	
+MONDO:0016244	atypical hemolytic-uremic syndrome	GARD:0006240	D-minus hemolytic uremic syndrome (D-HUS)	GARD:0008702	Atypical hemolytic uremic syndrome	GARD		live		live	
+MONDO:0016264	autoimmune hepatitis	UMLS:C0241910	Autoimmune hepatitis	UMLS:C1332355	Autoimmune Hepatitis with Centrilobular Necrosis	UMLS		live		live	
+MONDO:0016281	46,XX ovotesticular disorder of sex development	UMLS:C2748895		UMLS:CN776920	True hermaphroditism	UMLS		not_present		live	
+MONDO:0016282	rhabdomyosarcoma of the cervix uteri	UMLS:C4289809	Cervical Rhabdomyosarcoma	UMLS:CN201072	Cervical rhabdomyosarcoma	UMLS		live		live	
+MONDO:0016283	leiomyosarcoma of the cervix uteri	UMLS:C4289817	Cervical Leiomyosarcoma	UMLS:CN201073	Cervical leiomyosarcoma	UMLS		live		live	
+MONDO:0016317	limbic encephalitis with NMDA receptor antibodies	UMLS:C4274344	Limbic encephalitis with N-methyl-D-aspartate receptor antibodies	UMLS:CN201135	Limbic encephalitis with N-methyl-D-aspartate receptor antibodies	UMLS		live		live	
+MONDO:0016333	familial dilated cardiomyopathy	GARD:0000221	Dilated cardiomyopathy	GARD:0002905	Familial dilated cardiomyopathy	GARD		live		live	
+MONDO:0016342	familial isolated arrhythmogenic right ventricular dysplasia	UMLS:C4274968	Familial isolated arrhythmogenic right ventricular dysplasia	UMLS:CN226907	Familial isolated arrhythmogenic ventricular dysplasia	UMLS		live		live	
+MONDO:0016364	Joubert syndrome with ocular defect	UMLS:C4274118	Joubert syndrome with ocular defect	UMLS:CN201217	Joubert syndrome with retinopathy	UMLS		live		live	
+MONDO:0016422	autoimmune polyendocrinopathy type 3	UMLS:C1535942	Autoimmune polyglandular syndrome type 3	UMLS:C3266027	Autoimmune polyendocrine syndrome type 3	UMLS		live		live	
+MONDO:0016423	autoimmune polyendocrinopathy type 4	UMLS:C3266026	Autoimmune polyendocrine syndrome type 4	UMLS:CN201378	Autoimmune polyglandular syndrome type 4	UMLS		live		live	
+MONDO:0016431	autosomal dominant Charcot-Marie-tooth disease type 2M	UMLS:C4304672	Autosomal dominant Charcot-Marie-Tooth disease type 2M	UMLS:CN201389	CMT2M	UMLS		live		live	
+MONDO:0016440	elastofibroma dorsi	UMLS:C0334460	Elastofibroma	UMLS:CN226932	Elastofibroma dorsi	UMLS		live		live	
+MONDO:0016443	papular elastorrhexis	UMLS:C0406816	Eruptive collagenoma	UMLS:C0473584	Nevus anelasticus	UMLS		live		live	
+MONDO:0016445	familial anetoderma	UMLS:C4518793	Hereditary anetoderma	UMLS:CN226934	Hereditary macular atrophy	UMLS		live		live	
+MONDO:0016458	8q12 microduplication syndrome	UMLS:C4304504	8q12 microduplication syndrome	UMLS:CN201422	Trisomy 8q12	UMLS		live		live	
+MONDO:0016460	Polyvalvular heart disease syndrome	UMLS:C4509918	Polyvalvular heart disease syndrome	UMLS:CN201425	PHD syndrome	UMLS		live		live	
+MONDO:0016461	5q35 microduplication syndrome	UMLS:C4304526	5q35 microduplication syndrome	UMLS:CN201426	Trisomy 5q35	UMLS		live		live	
+MONDO:0016473	familial rhabdoid tumor	UMLS:C2985524	Rhabdoid Tumor Predisposition Syndrome	UMLS:CN201468	Rhabdoid tumor predisposition syndrome	UMLS		live		live	
+MONDO:0016505	aldosterone-producing adrenal cortex adenoma	UMLS:C1706762	Aldosterone-Producing Adrenal Cortex Adenoma	UMLS:CN226945	Pure aldosterone-secreting adrenocortical carcinoma	UMLS		live		live	
+MONDO:0016525	familial hyperaldosteronism	UMLS:C3713420	Familial hyperaldosteronism	UMLS:CN229602	FH	UMLS		live		live	
+MONDO:0016528	limb body wall complex	UMLS:C4274839	Limb body wall complex	UMLS:CN201594	LBWC syndrome	UMLS		live		live	
+MONDO:0016561	1q44 microdeletion syndrome	UMLS:C4304540	1q44 microdeletion syndrome	UMLS:CN201644	Monosomy 1q44	UMLS		live		live	
+MONDO:0016570	primary pulmonary lymphoma	UMLS:C0519063	Primary pulmonary lymphoma	UMLS:C4273669	Primary pulmonary lymphoma	UMLS		live		live	
+MONDO:0016575	primary ciliary dyskinesia	DOID:0050144	Kartagener syndrome	DOID:9562	primary ciliary dyskinesia	DOID		live		live	
+MONDO:0016575	primary ciliary dyskinesia	MESH:D002925	Ciliary Motility Disorders	MESH:D007619	Kartagener Syndrome	MESH		live		live	
+MONDO:0016575	primary ciliary dyskinesia	SCTID:42402006	kartagener syndrome (disorder)	SCTID:86204009	immotile cilia syndrome (disorder)	SCTID		live		live	
+MONDO:0016577	biliary atresia with splenic malformation syndrome	UMLS:C4274029	Biliary atresia with splenic malformation syndrome	UMLS:CN201730	BASM syndrome	UMLS		live		live	
+MONDO:0016587	arrhythmogenic right ventricular cardiomyopathy	UMLS:C0349788	Arrhythmogenic right ventricular dysplasia	UMLS:CN221565	Arrhythmogenic right ventricular dysplasia/cardiomyopathy	UMLS		live		live	
+MONDO:0016587	arrhythmogenic right ventricular cardiomyopathy	UMLS:C0349788	Arrhythmogenic right ventricular dysplasia	UMLS:CN239850		UMLS		live		not_present	
+MONDO:0016587	arrhythmogenic right ventricular cardiomyopathy	UMLS:CN221565	Arrhythmogenic right ventricular dysplasia/cardiomyopathy	UMLS:CN239850		UMLS		live		not_present	
+MONDO:0016652	2q31.1 microdeletion syndrome	UMLS:C4274647	2q31.1 microdeletion syndrome	UMLS:CN201880	Monosomy 2q31.1	UMLS		live		live	
+MONDO:0016655	6p22 microdeletion syndrome	UMLS:C4304528	6p22 microdeletion syndrome	UMLS:CN201884	Monosomy 6p22	UMLS		live		live	
+MONDO:0016657	8p11.2 deletion syndrome	UMLS:C4304505	8p11.2 deletion syndrome	UMLS:CN201887	Monosomy 8p11.2	UMLS		live		live	
+MONDO:0016682	giant cell glioblastoma	UMLS:C0334588	Giant cell glioblastoma	UMLS:C0334593	Monstrocellular sarcoma	UMLS		live		live	
+MONDO:0016698	ependymoma	UMLS:C0014474	Ependymoma	UMLS:CN201941	Ependymoma	UMLS		live		live	
+MONDO:0016706	chordoid glioma of the third ventricle	DOID:3773	third ventricle chordoid glioma	DOID:3774	chordoid glioma	DOID		live		live	
+MONDO:0016710	medulloblastoma with extensive nodularity	UMLS:C1334970	Medulloblastoma with extensive nodularity	UMLS:CN201957	MBEN	UMLS		live		live	
+MONDO:0016727	extraventricular neurocytoma	UMLS:C2985175	Extraventricular neurocytoma	UMLS:CN201975	EVN	UMLS		live		live	
+MONDO:0016729	mixed neuronal-glial tumor	UMLS:C0474844	Neuronal and mixed neuronal-glial tumor	UMLS:CN201977	Mixed neuronal-glial tumor	UMLS		live		live	
+MONDO:0016736	rosette-forming glioneuronal tumor of fourth ventricule	UMLS:C4331262	Rosette-forming glioneuronal tumor	UMLS:CN201984	Dysembryoplastic neuroepithelial tumor of cerebellum	UMLS		live		live	
+MONDO:0016740	choriocarcinoma of the central nervous system	UMLS:C1332876	Central Nervous System Choriocarcinoma	UMLS:CN201988	Choriocarcinoma of the central nervous system	UMLS		live		live	
+MONDO:0016742	mixed germ cell tumor of central nervous system	UMLS:C1334785	Central Nervous System Mixed Germ Cell Tumor	UMLS:CN201989	Mixed germ cell tumor of CNS	UMLS		live		live	
+MONDO:0016747	primary melanoma of the central nervous system	UMLS:C0349626	Malignant melanoma of meninges	UMLS:CN201994	Primary melanoma of the central nervous system	UMLS		live		live	
+MONDO:0016765	19p13.12 microdeletion syndrome	UMLS:C4304579	19p13.12 microdeletion syndrome	UMLS:CN202023	Monosomy 19p13.12	UMLS		live		live	
+MONDO:0016796	mitochondrial DNA depletion syndrome, encephalomyopathic form	UMLS:CN202052	mtDNA depletion syndrome, encephalomyopathic form	UMLS:CN230130	Mitochondrial DNA Depletion Syndrome, Encephalomyopathic Form	UMLS		live		live	
+MONDO:0016808	mitochondrial DNA depletion syndrome, hepatocerebral form	UMLS:C3711385	Deoxyguanosine Kinase Deficiency	UMLS:CN069134	Deoxyguanosine kinase deficiency	UMLS		live		live	
+MONDO:0016809	spinocerebellar ataxia with epilepsy	UMLS:C1843852	Spinocerebellar ataxia with epilepsy	UMLS:CN202060	SCAE	UMLS		live		live	
+MONDO:0016829	familial visceral myopathy	UMLS:C0266833	Familial visceral myopathy	UMLS:C1835084	MEGADUODENUM AND/OR MEGACYSTIS	UMLS		live		live	
+MONDO:0016829	familial visceral myopathy	UMLS:C0266833	Familial visceral myopathy	UMLS:CN202146	Megaduodenum and/or megacystis	UMLS		live		live	
+MONDO:0016829	familial visceral myopathy	UMLS:C1835084	MEGADUODENUM AND/OR MEGACYSTIS	UMLS:CN202146	Megaduodenum and/or megacystis	UMLS		live		live	
+MONDO:0016833	14q12 microdeletion syndrome	UMLS:C4305240	14q12 microdeletion syndrome	UMLS:CN202163	Monosomy 14q12	UMLS		live		live	
+MONDO:0016834	16p11.2p12.2 microduplication syndrome	UMLS:C4518821	16p11.2p12.2 microduplication syndrome	UMLS:CN202168	Trisomy 16p11.2p12.2	UMLS		live		live	
+MONDO:0016836	16p13.11 microdeletion syndrome	UMLS:C4304596	16p13.11 microdeletion syndrome	UMLS:CN202172	Monosomy 16p13.11	UMLS		live		live	
+MONDO:0016837	16p13.11 microduplication syndrome	UMLS:C4304595	16p13.11 microduplication syndrome	UMLS:CN202173	Trisomy 16p13.11	UMLS		live		live	
+MONDO:0016838	16q24.3 microdeletion syndrome	UMLS:C4304594	16q24.3 microdeletion syndrome	UMLS:CN202174	Monosomy 16q24.3	UMLS		live		live	
+MONDO:0016841	20p12.3 microdeletion syndrome	UMLS:C4304539	20p12.3 microdeletion syndrome	UMLS:CN202180	Monosomy 20p12.3	UMLS		live		live	
+MONDO:0016842	paternal 20q13.2q13.3 microdeletion syndrome	UMLS:C4510306	Paternal 20q13.2q13.3 microdeletion syndrome	UMLS:CN202182	Paternal monosomy 20q13.2q13.3	UMLS		live		live	
+MONDO:0016843	20q13.33 microdeletion syndrome	UMLS:C4518823	20q13.33 microdeletion syndrome	UMLS:CN202183	Monosomy 20q13.33	UMLS		live		live	
+MONDO:0016850	atypical Norrie disease due to monosomy Xp11.3	UMLS:C4518083	Atypical Norrie disease due to monosomy Xp11.3	UMLS:CN202196	Atypical Norrie disease due to del(X)(p11.3)	UMLS		live		live	
+MONDO:0016862	Alagille syndrome due to a JAG1 point mutation	UMLS:C1956125	ALAGILLE SYNDROME 1	UMLS:CN202206	Syndromic bile duct paucity due to a JAG1 point mutation	UMLS		live		live	
+MONDO:0016971	limb-girdle muscular dystrophy	UMLS:C0270950	Erb's muscular dystrophy	UMLS:C0686353	Limb-girdle muscular dystrophy	UMLS		live		live	
+MONDO:0016974	thymoma type B	UMLS:C1328042	Thymoma Type B	UMLS:CN202276	Primary thymic epithelial tumor type B	UMLS		live		live	
+MONDO:0016982	angiosarcoma (disease)	EFO:0003967	vascular sarcoma	EFO:0003968	angiosarcoma	EFO		live		live	
+MONDO:0016985	nevus of Ito	UMLS:C0022283		UMLS:CN202288	Nevus fuscocaeruleus acromiodeltoideus	UMLS		not_present		live	
+MONDO:0017048	pseudomyxoma peritonei	GARD:0002448	Gelatinous ascites	GARD:0007488	Pseudomyxoma peritonei	GARD		live		live	
+MONDO:0017050	intraocular medulloepithelioma	UMLS:C1883694	Intraocular Medulloepithelioma	UMLS:CN202409	Orbital medulloepithelioma	UMLS		live		live	
+MONDO:0017147	idiopathic pulmonary arterial hypertension	UMLS:C3203102	Idiopathic pulmonary arterial hypertension	UMLS:CN202574	Primary pulmonary arterial hypertension	UMLS		live		live	
+MONDO:0017151	pulmonary arterial hypertension associated with connective tissue disease	UMLS:C3697982	Pulmonary arterial hypertension associated with connective tissue disease	UMLS:CN202578	PAH associated with connective tissue disease	UMLS		live		live	
+MONDO:0017152	pulmonary arterial hypertension associated with congenital heart disease	UMLS:C3697119	Pulmonary arterial hypertension associated with congenital heart disease	UMLS:CN243982		UMLS		live		not_present	
+MONDO:0017157	pulmonary hypertension owing to lung disease and/or hypoxia	UMLS:C3698136	Pulmonary hypertension due to lung disease and/or hypoxia	UMLS:CN202580	Pulmonary hypertension due to lung disease and/or hypoxia	UMLS		live		live	
+MONDO:0017161	frontotemporal dementia with motor neuron disease	UMLS:C3888102	Frontotemporal Dementia With Motor Neuron Disease	UMLS:CN239493	Frontotemporal dementia with amyotrophic lateral sclerosis	UMLS		live		live	
+MONDO:0017178	osteochondritis dissecans (disease)	Orphanet:251262	Familial osteochondritis dissecans	Orphanet:2764	Osteochondritis dissecans	Orphanet		live		live	
+MONDO:0017184	autosomal dominant hyperinsulinism due to SUR1 deficiency	UMLS:C4274080	Autosomal dominant hyperinsulinism due to SUR1 deficiency	UMLS:CN202625	Autosomal dominant hyperinsulinemic hypoglycemia due to SUR1 deficiency	UMLS		live		live	
+MONDO:0017185	autosomal dominant hyperinsulinism due to Kir6.2 deficiency	UMLS:C4274081	Autosomal dominant hyperinsulinism due to Kir6.2 deficiency	UMLS:CN202626	Dominant KATP hyperinsulinism due to Kir6.2 deficiency	UMLS		live		live	
+MONDO:0017198	osteopetrosis (disease)	OMIMPS:259700	Osteopetrosis, autosomal recessive	OMIMPS:607634	Osteopetrosis, autosomal dominant	OMIMPS		live		live	
+MONDO:0017199	osteoporosis-macrocephaly-blindness-joint hyperlaxity syndrome	UMLS:C4274786	Heide syndrome	UMLS:CN202651	Heide syndrome	UMLS		live		live	
+MONDO:0017219	microform holoprosencephaly	UMLS:CN202701	Holoprosencéphalie, minor form	UMLS:CN236719	microform holoprosencephaly	UMLS		live		live	
+MONDO:0017227	autoimmune pancreatitis type 1	UMLS:C4302243	Autoimmune pancreatitis type 1	UMLS:CN202712	IgG4-related pancreatitis	UMLS		live		live	
+MONDO:0017233	familial Alzheimer-like prion disease	UMLS:C4303482	Familial Alzheimer-like prion disease	UMLS:CN202723	Familial Alzheimer-like prion disease	UMLS		live		live	
+MONDO:0017264	syndromic recessive X-linked ichthyosis	UMLS:C4274085	Syndromic recessive X-linked ichthyosis	UMLS:CN202782	Syndromic recessive X-linked ichthyosis	UMLS		live		live	
+MONDO:0017276	frontotemporal dementia	UMLS:C0338451	Frontotemporal dementia	UMLS:C0520716	Pallidopontonigral degeneration	UMLS		live		live	
+MONDO:0017278	autoimmune polyendocrinopathy	NCIT:C129726	Autoimmune Polyglandular Syndrome	NCIT:C84576	Autoimmune Polyendocrinopathy Syndrome	NCIT		live		live	
+MONDO:0017278	autoimmune polyendocrinopathy	UMLS:C0085409	Autoimmune polyendocrinopathy	UMLS:C4316913	Autoimmune Polyglandular Syndrome	UMLS		live		live	
+MONDO:0017282	alveolar echinococcosis	UMLS:C0152069	Echinococcus multilocularis infection	UMLS:C0948954		UMLS		live		not_present	
+MONDO:0017288	DICER1 syndrome	UMLS:C3839822	DICER1 syndrome	UMLS:CN202862	Pleuro-pulmonary blastoma familial tumor susceptibility syndrome	UMLS		live		live	
+MONDO:0017288	DICER1 syndrome	UMLS:C3839822	DICER1 syndrome	UMLS:CN240512		UMLS		live		not_present	
+MONDO:0017288	DICER1 syndrome	UMLS:CN202862	Pleuro-pulmonary blastoma familial tumor susceptibility syndrome	UMLS:CN240512		UMLS		live		not_present	
+MONDO:0017290	familial intrahepatic cholestasis	UMLS:CN227107	Familial intrahepatic cholestasis	UMLS:CN239338	Familial Intrahepatic Cholestasis	UMLS		live		live	
+MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	UMLS:C1266047	Fetal adenocarcinoma	UMLS:C1708045	Fetal Lung Adenocarcinoma	UMLS		live		live	
+MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	UMLS:C1266047	Fetal adenocarcinoma	UMLS:CN202865	WDFA	UMLS		live		live	
+MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	UMLS:C1708045	Fetal Lung Adenocarcinoma	UMLS:CN202865	WDFA	UMLS		live		live	
+MONDO:0017308	Marfan syndrome type 2	UMLS:C2698016	Marfan Syndrome Type II	UMLS:C2931058	MFS2	UMLS		live		live	
+MONDO:0017309	neonatal Marfan syndrome	UMLS:CN202885	Neonatal MFS	UMLS:CN536247	Neonatal Marfan syndrome	UMLS		live		live	
+MONDO:0017312	Perrault syndrome	UMLS:C0685838	XX gonodal dysgenesis-deafness syndrome	UMLS:CN239459		UMLS		live		not_present	
+MONDO:0017323	hypocalcemic rickets	UMLS:C4302195	Hypocalcemic rickets	UMLS:C4329608	Calcium Deficiency Rickets	UMLS		live		live	
+MONDO:0017327	primary non-gestational choriocarcinoma of ovary	UMLS:C4274424	Primary non-gestational choriocarcinoma of ovary	UMLS:CN202967	Primary non-gestational ovarian choriocarcinoma	UMLS		live		live	
+MONDO:0017334	12q15q21.1 microdeletion syndrome	UMLS:C4518344	12q15q21.1 microdeletion syndrome	UMLS:CN202984	Monosomy 12q15q21.1	UMLS		live		live	
+MONDO:0017338	fatal multiple mitochondrial dysfunctions syndrome	UMLS:C3502075	Multiple mitochondrial dysfunctions syndrome	UMLS:CN202994	Fatal multiple mitochondrial dysfunctions syndrome	UMLS		live		live	
+MONDO:0017338	fatal multiple mitochondrial dysfunctions syndrome	UMLS:C3502075	Multiple mitochondrial dysfunctions syndrome	UMLS:CN234684		UMLS		live		not_present	
+MONDO:0017338	fatal multiple mitochondrial dysfunctions syndrome	UMLS:CN202994	Fatal multiple mitochondrial dysfunctions syndrome	UMLS:CN234684		UMLS		live		not_present	
+MONDO:0017340	juvenile nasopharyngeal angiofibroma (disease)	UMLS:C1367536	Nasopharyngeal angiofibroma	UMLS:CN202999	JNA	UMLS		live		live	
+MONDO:0017376	reactive arthritis	UMLS:C0035012	Reiter's syndrome	UMLS:C0085435	Reactive arthritis	UMLS		live		live	
+MONDO:0017376	reactive arthritis	UMLS:C0035012	Reiter's syndrome	UMLS:CN203069	Reiter disease	UMLS		live		live	
+MONDO:0017376	reactive arthritis	UMLS:C0085435	Reactive arthritis	UMLS:CN203069	Reiter disease	UMLS		live		live	
+MONDO:0017385	malignant migrating partial seizures of infancy	UMLS:CN203114	Migrating partial seizures of infancy	UMLS:CN240507	Malignant migrating partial seizures of infancy	UMLS		live		live	
+MONDO:0017394	ketamine-induced biliary dilatation	UMLS:C4512018	Ketamine-induced biliary dilatation	UMLS:CN227122	Ketamine-induced biliary dilatation	UMLS		live		live	
+MONDO:0017405	1p21.3 microdeletion syndrome	UMLS:C4304578	1p21.3 microdeletion syndrome	UMLS:CN203152	Monosomy 1p21.3	UMLS		live		live	
+MONDO:0017408	rapid-onset childhood obesity-hypothalamic dysfunction-hypoventilation-autonomic dysregulation syndrome	UMLS:C4053506	Rapid-Onset Obesity with Hypothalamic Dysfunction, Hypoventilation, and Autonomic Dysregulation	UMLS:CN203158	Rapid-onset childhood obesity-hypothalamic dysfunction-hypoventilation-autonomic dysregulation-neural tumors syndrome	UMLS		live		live	
+MONDO:0017409	fetal cytomegalovirus syndrome	GARD:0001409	CMV antenatal infection	GARD:0001480	Congenital cytomegalovirus	GARD		live		live	
+MONDO:0017418	chronic intestinal failure	UMLS:C4274352	Chronic intestinal failure	UMLS:CN203168	CIF	UMLS		live		live	
+MONDO:0017453	fetal parvovirus syndrome	GARD:0002310	Fetal parvovirus syndrome	GARD:0004236	Parvovirus antenatal infection	GARD		live		live	
+MONDO:0017568	Prata-Liberal-Goncalves syndrome	UMLS:C2931761	Acrodysplasia scoliosis	UMLS:CN203304	Brachydactyly-scoliosis-carpal fusion syndrome	UMLS		live		live	
+MONDO:0017571	Proteus-like syndrome	GARD:0004525	Proteus like syndrome mental retardation eye defect	GARD:0012801	Proteus-like syndrome	GARD		live		live	
+MONDO:0017576	46,XX disorder of sex development	UMLS:C2936403		UMLS:CN776919	Female pseudohermaphroditism	UMLS		not_present		live	
+MONDO:0017593	juvenile amyotrophic lateral sclerosis	UMLS:C3468114	Juvenile amyotrophic lateral sclerosis	UMLS:CN239582	Juvenile Lou Gehrig disease	UMLS		live		live	
+MONDO:0017607	caudal regression sequence	UMLS:C1838568	Sacral regression syndrome	UMLS:C1867774	SACRAL AGENESIS SYNDROME	UMLS		live		live	
+MONDO:0017694	glycogen storage disease due to acid maltase deficiency, infantile onset	UMLS:C3888924	Glycogen storage disease due to acid maltase deficiency, infantile onset	UMLS:CN203590	Glycogenosis type II, infantile onset	UMLS		live		live	
+MONDO:0017762	disorder of copper metabolism	UMLS:C0012714	Disorder of copper metabolism	UMLS:CN043585	Copper Transport Disorders	UMLS		live		live	
+MONDO:0017770	Robinow-like syndrome	UMLS:C4302956	Robinow-like syndrome	UMLS:CN203671	Saal-Greenstein syndrome	UMLS		live		live	
+MONDO:0017775	melioidosis	UMLS:C0025229	Melioidosis	UMLS:C0348970	Acute and fulminating melioidosis	UMLS		live		live	
+MONDO:0017775	melioidosis	UMLS:C0025229	Melioidosis	UMLS:C0348971	Subacute and chronic melioidosis	UMLS		live		live	
+MONDO:0017775	melioidosis	UMLS:C0348970	Acute and fulminating melioidosis	UMLS:C0348971	Subacute and chronic melioidosis	UMLS		live		live	
+MONDO:0017795	ameloblastoma	UMLS:C0002448	Ameloblastoma	UMLS:C0563212	Ameloblastoma of jaw	UMLS		live		live	
+MONDO:0017807	growing teratoma syndrome	UMLS:C3891714	Growing Teratoma Syndrome	UMLS:CN203773	Growing teratoma syndrome	UMLS		live		live	
+MONDO:0017810	variant ABeta2M amyloidosis	UMLS:C4302669	Autosomal dominant beta2-microglobulinic amyloidosis	UMLS:CN203779	Autosomal dominant beta2-microglobulinic amyloidosis	UMLS		live		live	
+MONDO:0017816	primary systemic amyloidosis	UMLS:C0268380	Systemic amyloidosis	UMLS:C0281479	Primary Systemic Amyloidosis	UMLS		live		live	
+MONDO:0017824	familial isolated pituitary adenoma	UMLS:CN239192	Familial Isolated Pituitary Adenomas	UMLS:CN244420	FIPA	UMLS		live		live	
+MONDO:0017851	erythrokeratodermia variabilis	MESH:C536154	Keratoderma palmoplantaris transgrediens	MESH:D056266	Erythrokeratodermia Variabilis	MESH		live		live	
+MONDO:0017851	erythrokeratodermia variabilis	Orphanet:316	Progressive symmetric erythrokeratodermia	Orphanet:317	Erythrokeratodermia variabilis	Orphanet		live		live	
+MONDO:0017858	acute erythroid leukemia	GARD:0009620	Acute erythroid leukemia	GARD:0009750	Di Guglielmo's syndrome	GARD		live		live	
+MONDO:0017872	Lujo hemorrhagic fever	UMLS:C4274433	Lujo hemorrhagic fever	UMLS:CN203921	Zambian hemorrhagic fever	UMLS		live		live	
+MONDO:0017878	Chapare hemorrhagic fever	UMLS:C4274434	Chapare hemorrhagic fever	UMLS:CN203927	Chapare hemorrhagic fever	UMLS		live		live	
+MONDO:0017884	papillary renal cell carcinoma	GARD:0009572	Papillary renal cell carcinoma	GARD:0009575	Chromophil renal cell carcinoma	GARD		live		live	
+MONDO:0017884	papillary renal cell carcinoma	Orphanet:319298	Papillary renal cell carcinoma	Orphanet:47044	Hereditary papillary renal cell carcinoma	Orphanet		live		live	
+MONDO:0017884	papillary renal cell carcinoma	UMLS:C1306837	Papillary renal cell carcinoma	UMLS:C1336078	Sporadic Papillary Renal Cell Carcinoma	UMLS		live		live	
+MONDO:0017884	papillary renal cell carcinoma	UMLS:C1306837	Papillary renal cell carcinoma	UMLS:CN205129	HPRCC	UMLS		live		live	
+MONDO:0017884	papillary renal cell carcinoma	UMLS:C1336078	Sporadic Papillary Renal Cell Carcinoma	UMLS:CN205129	HPRCC	UMLS		live		live	
+MONDO:0017885	chromophobe renal cell carcinoma	UMLS:C1266042	Chromophobe cell renal carcinoma	UMLS:C3887514	Chromophobe carcinoma	UMLS		live		live	
+MONDO:0017895	familial papillary or follicular thyroid carcinoma	UMLS:C3896673	Familial Nonmedullary Thyroid Gland Carcinoma	UMLS:CN227215	Familial pure nonmedullary thyroid carcinoma	UMLS		live		live	
+MONDO:0017905	X-linked mendelian susceptibility to mycobacterial diseases	UMLS:C4304413	X-linked mendelian susceptibility to mycobacterial disease	UMLS:CN203967	X-linked MSMD	UMLS		live		live	
+MONDO:0017985	congenital radioulnar synostosis	GARD:0004630	Radio-ulnar synostosis type 1	GARD:0010876	Congenital radioulnar synostosis	GARD		live		live	
+MONDO:0017991	Takayasu arteritis	NCIT:C34391	Aortic Arch Syndrome	NCIT:C35062	Takayasu Arteritis	NCIT		live		live	
+MONDO:0018018	wild type ATTR amyloidosis	UMLS:C0342623	Senile systemic amyloidosis	UMLS:CN204235	Wild type ATTR-related amyloidosis	UMLS		live		live	
+MONDO:0018023	hemoglobin M disease	UMLS:C3665425	Hemoglobin M disease	UMLS:CN204238	M hemoglobinopathy	UMLS		live		live	
+MONDO:0018065	isolated trigonocephaly	UMLS:CN236409	Trigonocephaly, nonsyndromic	UMLS:CN239481	Nonsyndromic Trigonocephaly	UMLS		live		live	
+MONDO:0018070	familial multiple fibrofolliculoma	UMLS:C4509837	Familial multiple fibrofolliculoma	UMLS:CN204388	Familial multiple fibrofolliculoma	UMLS		live		live	
+MONDO:0018076	tuberculosis	UMLS:C0041296	Tuberculosis	UMLS:C0151332	Active tuberculosis	UMLS		live		live	
+MONDO:0018081	hemorrhagic fever-renal syndrome	UMLS:C2930957	Hantavirosis	UMLS:CN204401	Hantavirus fever	UMLS		live		live	
+MONDO:0018087	viral hemorrhagic fever	UMLS:C0019104	Viral hemorrhagic fever	UMLS:CN204409	Viral hemorrhagic fever	UMLS		live		live	
+MONDO:0018101	familial primary hypomagnesemia with normocalciuria and normocalcemia	UMLS:C4510731	Familial primary hypomagnesemia with normocalciuria and normocalcemia	UMLS:CN204443	Familial primary hypomagnesemia with normocalciuria and normocalcemia	UMLS		live		live	
+MONDO:0018105	Wolfram syndrome	UMLS:C0043207	Wolfram syndrome	UMLS:CN184630	Wolfram syndrome	UMLS		live		live	
+MONDO:0018130	brain dopamine-serotonin vesicular transport disease	UMLS:C4303546	Brain dopamine-serotonin vesicular transport disease	UMLS:CN204508	Brain dopamine-serotonin vesicular transport disease	UMLS		live		live	
+MONDO:0018133	attenuated Chédiak-Higashi syndrome	UMLS:C4304022	Attenuated Chédiak-Higashi syndrome	UMLS:CN204519	Atypical Chédiak-Higashi syndrome	UMLS		live		live	
+MONDO:0018151	coenzyme Q10 deficiency	UMLS:C1843920	Coenzyme Q10 deficiency	UMLS:CN229570	CoQ10 deficiency	UMLS		live		live	
+MONDO:0018166	oral submucous fibrosis	UMLS:C0029171	Oral Cavity Submucous Fibrosis	UMLS:C0029172	Oral submucous fibrosis	UMLS		live		live	
+MONDO:0018172	malignant sex cord stromal tumor of ovary	UMLS:C1334609	Malignant Ovarian Sex Cord-Stromal Tumor	UMLS:CN204631	Malignant ovarian sex cord-stromal tumor	UMLS		live		live	
+MONDO:0018177	glioblastoma (disease)	ONCOTREE:GB	glioblastoma	ONCOTREE:GBM	glioblastoma multiforme	ONCOTREE		live		live	
+MONDO:0018177	glioblastoma (disease)	UMLS:C0017636	Glioblastoma	UMLS:C1621958	Glioblastoma multiforme	UMLS		live		live	
+MONDO:0018177	glioblastoma (disease)	UMLS:C0017636	Glioblastoma	UMLS:CN227279	Glioblastoma multiforme	UMLS		live		live	
+MONDO:0018177	glioblastoma (disease)	UMLS:C1621958	Glioblastoma multiforme	UMLS:CN227279	Glioblastoma multiforme	UMLS		live		live	
+MONDO:0018201	extragonadal germ cell tumor	UMLS:C0262963	Tumor of the Extragonadal Germ Cell	UMLS:CN204711	Extragonadal germ cell tumor	UMLS		live		live	
+MONDO:0018227	hypocomplementemic urticarial vasculitis	UMLS:C0343206	Hypocomplementemic urticarial vasculitis	UMLS:CN204757	McDuffie syndrome	UMLS		live		live	
+MONDO:0018256	acute myeloid leukemia with t(8;16)(p11;p13) translocation	UMLS:C4511003	Acute myeloid leukemia with t(8;16)(p11;p13) translocation	UMLS:CN204831	AML with t(8;16)(p11;p13) translocation	UMLS		live		live	
+MONDO:0018263	fetal carbamazepine syndrome	UMLS:C0432370	Fetal carbamazepine syndrome	UMLS:CN204839	Fetal carbamazepine syndrome	UMLS		live		live	
+MONDO:0018268	Medich giant platelet syndrome	UMLS:C4305375	Medich giant platelet syndrome	UMLS:CN204847	Medich macrothrombocytopenia	UMLS		live		live	
+MONDO:0018270	extraskeletal Ewing sarcoma	UMLS:C0279980	Extraosseous Ewing's Sarcoma	UMLS:CN204849	Extraskeletal Ewing tumor	UMLS		live		live	
+MONDO:0018271	peripheral primitive neuroectodermal tumor	UMLS:C0684337	Peripheral PNET	UMLS:C3489398	Peripheral neuroepithelioma	UMLS		live		live	
+MONDO:0018301	interstitial cystitis	DOID:13949	interstitial cystitis	DOID:1678	chronic interstitial cystitis	DOID		live		live	
+MONDO:0018301	interstitial cystitis	SCTID:111409009	ulcerative cystitis (disorder)	SCTID:197834003	chronic interstitial cystitis (disorder)	SCTID		live		live	
+MONDO:0018301	interstitial cystitis	UMLS:C0282488	Interstitial cystitis	UMLS:C0600040	Chronic interstitial cystitis	UMLS		live		live	
+MONDO:0018301	interstitial cystitis	UMLS:C0282488	Interstitial cystitis	UMLS:C1720830	Painful Bladder Syndrome	UMLS		live		live	
+MONDO:0018301	interstitial cystitis	UMLS:C0282488	Interstitial cystitis	UMLS:CN204884	Interstitial cystitis/painful bladder syndrome	UMLS		live		live	
+MONDO:0018301	interstitial cystitis	UMLS:C0600040	Chronic interstitial cystitis	UMLS:C1720830	Painful Bladder Syndrome	UMLS		live		live	
+MONDO:0018301	interstitial cystitis	UMLS:C0600040	Chronic interstitial cystitis	UMLS:CN204884	Interstitial cystitis/painful bladder syndrome	UMLS		live		live	
+MONDO:0018301	interstitial cystitis	UMLS:C1720830	Painful Bladder Syndrome	UMLS:CN204884	Interstitial cystitis/painful bladder syndrome	UMLS		live		live	
+MONDO:0018308	liver mesenchymal hamartoma	UMLS:C0334091	Biliary hamartoma	UMLS:C1333971	Mesenchymal hamartoma of liver	UMLS		live		live	
+MONDO:0018309	Hirschsprung disease	UMLS:C0019569	Hirschsprung's disease	UMLS:C3661523	Congenital Intestinal Aganglionosis	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0019621	Langerhans cell histiocytosis	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432547	Letterer-Siwe disease of lymph nodes of head, face AND/OR neck	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432548	Letterer-Siwe disease of intrathoracic lymph nodes	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432549	Letterer-Siwe disease of intra-abdominal lymph nodes	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432550	Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432551	Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432552	Letterer-Siwe disease of intrapelvic lymph nodes	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018310	Langerhans cell histiocytosis	UMLS:C0432553	Letterer-Siwe disease of spleen	UMLS:C0432554	Letterer-Siwe disease of lymph nodes of multiple sites	UMLS		live		live	
+MONDO:0018319	familial episodic pain syndrome	UMLS:CN204967	FEPS	UMLS:CN228162	Familial episodic pain syndrome	UMLS		live		live	
+MONDO:0018321	atypical juvenile parkinsonism	UMLS:C4510873	Atypical juvenile parkinsonism	UMLS:CN204972	Atypical juvenile parkinsonism	UMLS		live		live	
+MONDO:0018334	chronic hiccup	UMLS:C0744898	Chronic hiccups	UMLS:CN205022	Chronic hiccup	UMLS		live		live	
+MONDO:0018342	Joubert syndrome with Jeune asphyxiating thoracic dystrophy	UMLS:C4518774	Joubert syndrome with Jeune asphyxiating thoracic dystrophy	UMLS:CN225944	Joubert syndrome with JATD	UMLS		live		live	
+MONDO:0018369	immature ovarian teratoma	UMLS:C0346182	Immature teratoma of ovary	UMLS:CN205036	Ovarian malignant teratoma	UMLS		live		live	
+MONDO:0018408	cystic echinococcosis	UMLS:C0153290	Echinococcus granulosus infection of lung	UMLS:C0153291	Echinococcus granulosus infection of thyroid	UMLS		live		live	
+MONDO:0018408	cystic echinococcosis	UMLS:C0153290	Echinococcus granulosus infection of lung	UMLS:C4303092	Cystic echinococcosis	UMLS		live		live	
+MONDO:0018408	cystic echinococcosis	UMLS:C0153291	Echinococcus granulosus infection of thyroid	UMLS:C4303092	Cystic echinococcosis	UMLS		live		live	
+MONDO:0018458	familial hypocalciuric hypercalcemia	UMLS:C0342637	Familial benign hypocalciuric hypercalcemia	UMLS:C1809471	Familial benign hypercalcemia	UMLS		live		live	
+MONDO:0018471	generalized eruptive keratoacanthoma	UMLS:C0345985	Generalized eruptive keratoacanthoma	UMLS:CN237455	Grzybowski syndrome	UMLS		live		live	
+MONDO:0018473	hyperlipoproteinemia type 3	UMLS:C0020479	Remnant disease	UMLS:C1862561	BROAD-BETALIPOPROTEINEMIA	UMLS		live		live	
+MONDO:0018479	congenital adrenal hyperplasia	UMLS:C0001627	Congenital adrenal hyperplasia	UMLS:C0701163	Adrenogenital disorder	UMLS		live		live	
+MONDO:0018481	undifferentiated carcinoma of esophagus	UMLS:C2188058	Esophageal Undifferentiated Carcinoma	UMLS:CN237469	Undifferentiated esophageal carcinoma	UMLS		live		live	
+MONDO:0018485	glycogen storage disease due to acid maltase deficiency, late-onset	UMLS:C0342753	Alpha-1,4-glucosidase acid deficiency, late onset	UMLS:C3888925	Pompe disease, late onset	UMLS		live		live	
+MONDO:0018504	undifferentiated carcinoma of stomach	UMLS:C1336858	Undifferentiated Carcinoma of the Stomach	UMLS:CN237509	Undifferentiated gastric carcinoma	UMLS		live		live	
+MONDO:0018509	squamous cell carcinoma of the small intestine	UMLS:C1710111	Small Intestinal Squamous Cell Carcinoma	UMLS:CN237514	Squamous cell carcinoma of the small bowel	UMLS		live		live	
+MONDO:0018510	small intestine neuroendocrine neoplasm	UMLS:C1336005	Small Intestinal Neuroendocrine Neoplasm	UMLS:CN237515	Neuroendocrine neoplasm of the small intestine	UMLS		live		live	
+MONDO:0018513	squamous cell carcinoma of colon	UMLS:C1333100	Squamous Cell Colon Carcinoma	UMLS:CN237518	Squamous cell carcinoma of colon	UMLS		live		live	
+MONDO:0018521	squamous cell carcinoma of pancreas	UMLS:C2675993	Pancreatic squamous cell carcinoma	UMLS:CN237524	Pancreatic squamous cell carcinoma	UMLS		live		live	
+MONDO:0018523	pancreatic mucinous cystadenoma	DOID:7235	pancreatic mucinous cystadenoma	DOID:7735	pancreatic colloid cystadenoma	DOID		live		live	
+MONDO:0018540	PFAPA syndrome	UMLS:C4082167	Periodic Fever, Aphthous Stomatitis, Pharyngitis, Adenitis Syndrome	UMLS:CN205072	Marshall syndrome with periodic fever	UMLS		live		live	
+MONDO:0018541	familial hypoaldosteronism	UMLS:C4275180	Familial hypoaldosteronism	UMLS:CN205074	Familial hypoaldosteronism	UMLS		live		live	
+MONDO:0018555	hypogonadotropic hypogonadism	DOID:0090070	hypogonadotropic hypogonadism	DOID:7455	hypogonadotropism	DOID		live		live	
+MONDO:0018592	cutaneous polyarteritis nodosa	UMLS:C0343190	Cutaneous polyarteritis nodosa	UMLS:CN242143	Cutaneous periarteritis nodosa	UMLS		live		live	
+MONDO:0018602	necrotizing soft tissue infection	UMLS:C2732890	Necrotizing soft tissue infection	UMLS:CN237632	Necrotizing soft tissue infection	UMLS		live		live	
+MONDO:0018604	familial colorectal cancer type X	UMLS:C3896578	Familial Colorectal Cancer Type X	UMLS:CN237636	FCCTX	UMLS		live		live	
+MONDO:0018607	combined hamartoma of the retina and retinal pigment epithelium	UMLS:C1862062	Combined hamartoma of the retina and retinal pigment epithelium	UMLS:CN237641	Combined hamartoma of the retina and RPE	UMLS		live		live	
+MONDO:0018608	pure autonomic failure	UMLS:C0393911	Pure autonomic failure	UMLS:C2931939	Idiopathic orthostatic hypotension	UMLS		live		live	
+MONDO:0018608	pure autonomic failure	UMLS:C0393911	Pure autonomic failure	UMLS:CN205091	Pure idiopatic dysautonomia	UMLS		live		live	
+MONDO:0018608	pure autonomic failure	UMLS:C2931939	Idiopathic orthostatic hypotension	UMLS:CN205091	Pure idiopatic dysautonomia	UMLS		live		live	
+MONDO:0018612	congenital hypothyroidism	SCTID:190268003	congenital hypothyroidism (disorder)	SCTID:217710005	congenital iodine deficiency syndrome (disorder)	SCTID		live		live	
+MONDO:0018615	hemicrania continua	UMLS:C2349425	Hemicrania continua	UMLS:CN237652	Hemicrania continua	UMLS		live		live	
+MONDO:0018626	paratyphoid fever	UMLS:C0030528	Paratyphoid fever	UMLS:C0343375	Paratyphoid A fever	UMLS		live		live	
+MONDO:0018626	paratyphoid fever	UMLS:C0030528	Paratyphoid fever	UMLS:C0343376	Paratyphoid B fever	UMLS		live		live	
+MONDO:0018626	paratyphoid fever	UMLS:C0030528	Paratyphoid fever	UMLS:C0343377	Paratyphoid C fever	UMLS		live		live	
+MONDO:0018626	paratyphoid fever	UMLS:C0343375	Paratyphoid A fever	UMLS:C0343376	Paratyphoid B fever	UMLS		live		live	
+MONDO:0018626	paratyphoid fever	UMLS:C0343375	Paratyphoid A fever	UMLS:C0343377	Paratyphoid C fever	UMLS		live		live	
+MONDO:0018626	paratyphoid fever	UMLS:C0343376	Paratyphoid B fever	UMLS:C0343377	Paratyphoid C fever	UMLS		live		live	
+MONDO:0018641	paroxysmal nocturnal hemoglobinuria	UMLS:C0019050	Paroxysmal Hemoglobinuria	UMLS:C0024790	Paroxysmal nocturnal hemoglobinuria	UMLS		live		live	
+MONDO:0018648	Keratocystic odontogenic tumor	UMLS:C1708604	Keratocystic Odontogenic Tumor	UMLS:CN237705	Odontogenic keratocystoma	UMLS		live		live	
+MONDO:0018661	Zika virus disease	UMLS:C0276289	Zika Virus Infection	UMLS:CN237724	Zika virus infection	UMLS		live		live	
+MONDO:0018695	avian influenza	UMLS:C0016627	Influenza in Bird	UMLS:CN237762	Avian influenza	UMLS		live		live	
+MONDO:0018698	hereditary neuroendocrine tumor of small intestine	UMLS:CN237770	Hereditary neuroendocrine tumor of small bowel	UMLS:CN847586	Hereditary neuroendocrine tumor of small intestine	UMLS		live		live	
+MONDO:0018712	composite hemangioendothelioma	UMLS:C1304513	Composite hemangioendothelioma	UMLS:CN242120	Composite hemangioendothelioma	UMLS		live		live	
+MONDO:0018713	retiform hemangioendothelioma	UMLS:C1304512	Retiform hemangioendothelioma	UMLS:CN242097	Retiform hemangioendothelioma	UMLS		live		live	
+MONDO:0018737	catastrophic antiphospholipid syndrome	UMLS:C3662487	Catastrophic antiphospholipid syndrome	UMLS:CN242096	Catastrophic APS	UMLS		live		live	
+MONDO:0018744	oligodendroglial tumor	UMLS:C1335110	Oligodendroglial Neoplasm	UMLS:CN205116	Oligodendroglial tumor	UMLS		live		live	
+MONDO:0018768	familial cold autoinflammatory syndrome	UMLS:C0343068	Familial cold urticaria	UMLS:CN230757	Familial cold autoinflammatory syndrome	UMLS		live		live	
+MONDO:0018781	KID syndrome	UMLS:C0265336	Senter syndrome	UMLS:CN205136	Keratitis-ichthyosis-deafness/Hystrix-like ichthyosis-deafness syndrome	UMLS		live		live	
+MONDO:0018829	familial schizencephaly	UMLS:C2931870	Familial schizencephaly	UMLS:CN776926	Familial schizencephaly	UMLS		live		live	
+MONDO:0018838	lissencephaly (disease)	GARD:0007300	Pachygyria	GARD:0012291	Lissencephaly	GARD		live		live	
+MONDO:0018850	proliferating trichilemmal cyst	UMLS:C0345992	Pilar tumor	UMLS:C2959585	Proliferating trichilemmal tumor	UMLS		live		live	
+MONDO:0018854	acquired purpura fulminans	UMLS:C4510896	Acquired purpura fulminans	UMLS:CN205163	Acquired purpura fulminans	UMLS		live		live	
+MONDO:0018861	Zellweger-like syndrome without peroxisomal anomalies	UMLS:C4305104	Zellweger-like syndrome without peroxisomal anomaly	UMLS:CN205183	Ahn-Lerman-Sagie syndrome	UMLS		live		live	
+MONDO:0018874	acute myeloid leukemia	GARD:0000537	Acute non lymphoblastic leukemia	GARD:0012757	Acute myeloid leukemia	GARD		live		live	
+MONDO:0018881	myelodysplastic syndrome	UMLS:C0033027	Preleukemias	UMLS:C3463824	Myelodysplastic syndrome	UMLS		live		live	
+MONDO:0018885	orbital leiomyoma	UMLS:C4305000	Orbital leiomyoma	UMLS:CN205236	Orbital leiomyoma	UMLS		live		live	
+MONDO:0018901	left ventricular noncompaction	UMLS:C1960469	Spongy myocardium	UMLS:C4021133	Left Ventricular Non-Compaction Syndrome	UMLS		live		live	
+MONDO:0018922	cold agglutinin disease	UMLS:C1264008	Chronic cold agglutinin disease	UMLS:CN205305	Cold agglutinin syndrome	UMLS		live		live	
+MONDO:0018937	mucopolysaccharidosis type 3	UMLS:C0026706	Mucopolysaccharidosis IIIs	UMLS:CN205330	MPS3	UMLS		live		live	
+MONDO:0018940	congenital myasthenic syndrome	GARD:0000098	Myasthenia gravis congenital	GARD:0011902	Congenital myasthenic syndrome	GARD		live		live	
+MONDO:0018950	3-methylcrotonyl-CoA carboxylase deficiency	UMLS:C0268600	MCCD	UMLS:CN239165	3-MCC Deficiency	UMLS		live		live	
+MONDO:0018957	pudendal neuralgia	UMLS:C1997249	Pudendal neuralgia	UMLS:C3178970	Pudendal Nerve Entrapment Syndrome	UMLS		live		live	
+MONDO:0018957	pudendal neuralgia	UMLS:C1997249	Pudendal neuralgia	UMLS:CN226268	Pudendalgia	UMLS		live		live	
+MONDO:0018957	pudendal neuralgia	UMLS:C3178970	Pudendal Nerve Entrapment Syndrome	UMLS:CN226268	Pudendalgia	UMLS		live		live	
+MONDO:0018960	congenital primary megaureter	GARD:0000219	Congenital giant megaureter	GARD:0001492	Congenital megalo-ureter	GARD		live		live	
+MONDO:0018983	tolosa-Hunt syndrome	UMLS:C0040381	Tolosa-Hunt syndrome	UMLS:C0392060	Painful ophthalmoplegia	UMLS		live		live	
+MONDO:0018983	tolosa-Hunt syndrome	UMLS:C0040381	Tolosa-Hunt syndrome	UMLS:CN205421	Painful ophthalmoplegia	UMLS		live		live	
+MONDO:0018983	tolosa-Hunt syndrome	UMLS:C0392060	Painful ophthalmoplegia	UMLS:CN205421	Painful ophthalmoplegia	UMLS		live		live	
+MONDO:0018984	Oroya fever	SCTID:240453002	oroya fever (disorder)	SCTID:262461007	infection caused by bartonella bacilliformis (disorder)	SCTID		live		live	
+MONDO:0018984	Oroya fever	UMLS:C0029307	Oroya fever	UMLS:CN205422	Carrion disease	UMLS		live		live	
+MONDO:0018988	iridocorneal endothelial syndrome	UMLS:C1096100		UMLS:CN205427	ICE syndrome	UMLS		not_present		live	
+MONDO:0019003	multiple endocrine neoplasia type 2	UMLS:C4048306	Multiple Endocrine Neoplasia Type 2	UMLS:CN073359	MEN2	UMLS		live		live	
+MONDO:0019004	kidney Wilms tumor	DOID:2154	nephroblastoma	DOID:5176	renal Wilms' tumor	DOID		live		live	
+MONDO:0019005	nephronophthisis (disease)	UMLS:C0687120	Nephronophthisis	UMLS:C2939174	Medullary cystic disease	UMLS		live		live	
+MONDO:0019006	familial idiopathic steroid-resistant nephrotic syndrome	UMLS:C1868672	Familial idiopathic nephrotic syndrome	UMLS:C4273714	Familial idiopathic steroid-resistant nephrotic syndrome	UMLS		live		live	
+MONDO:0019006	familial idiopathic steroid-resistant nephrotic syndrome	UMLS:C1868672	Familial idiopathic nephrotic syndrome	UMLS:CN536255		UMLS		live		not_present	
+MONDO:0019006	familial idiopathic steroid-resistant nephrotic syndrome	UMLS:C4273714	Familial idiopathic steroid-resistant nephrotic syndrome	UMLS:CN536255		UMLS		live		not_present	
+MONDO:0019012	Carpenter syndrome	UMLS:C1275078	Acrocephalopolysyndactyly type 2	UMLS:CN229565	Carpenter syndrome	UMLS		live		live	
+MONDO:0019018	Tako-tsubo cardiomyopathy	UMLS:C1739395	Takotsubo cardiomyopathy	UMLS:CN205479	Tako-Tsubo syndrome	UMLS		live		live	
+MONDO:0019037	progressive supranuclear palsy	UMLS:C0038868	Progressive supranuclear palsy	UMLS:CN205522	PSP syndrome	UMLS		live		live	
+MONDO:0019046	leukodystrophy	DOID:0050987	hypomyelinating leukoencephalopathy	DOID:0060786	hypomyelinating leukodystrophy	DOID		live		live	
+MONDO:0019046	leukodystrophy	DOID:0050987	hypomyelinating leukoencephalopathy	DOID:10579	leukodystrophy	DOID		live		live	
+MONDO:0019046	leukodystrophy	DOID:0060786	hypomyelinating leukodystrophy	DOID:10579	leukodystrophy	DOID		live		live	
+MONDO:0019046	leukodystrophy	UMLS:C0023520	Leukodystrophy	UMLS:CN228461	Hypomyelinating leukodystrophy	UMLS		live		live	
+MONDO:0019050	inherited hemoglobinopathy	UMLS:C0019045	Hemoglobinopathy	UMLS:C1960031	Hereditary hemoglobinopathy	UMLS		live		live	
+MONDO:0019072	intrahepatic cholestasis	DOID:0070227	intrahepatic cholestasis of pregnancy	DOID:1852	intrahepatic cholestasis	DOID		live		live	
+MONDO:0019079	proximal spinal muscular atrophy	UMLS:C4024957	Proximal spinal muscular atrophy	UMLS:CN205570	SMA	UMLS		live		live	
+MONDO:0019092	infantile apnea	UMLS:C0745261	Infantile apnea	UMLS:CN205590	Apnea of infancy	UMLS		live		live	
+MONDO:0019107	Rh deficiency syndrome	UMLS:C0272052	Rh deficiency syndrome	UMLS:C1849387	Rh-null syndrome	UMLS		live		live	
+MONDO:0019118	inherited retinal dystrophy	COHD:377270		COHD:380395		COHD		not_present		not_present	
+MONDO:0019118	inherited retinal dystrophy	DOID:8500	hereditary retinal dystrophy	DOID:8501	fundus dystrophy	DOID		live		live	
+MONDO:0019118	inherited retinal dystrophy	NCIT:C35194	Hereditary Retinal Dystrophy	NCIT:C35625	Retinal Dystrophy	NCIT		live		live	
+MONDO:0019118	inherited retinal dystrophy	SCTID:314407005	retinal dystrophy (disorder)	SCTID:41799005	hereditary retinal dystrophy (disorder)	SCTID		live		live	
+MONDO:0019118	inherited retinal dystrophy	UMLS:C0154860	Hereditary retinal dystrophy	UMLS:C0854723	Retinal dystrophy	UMLS		live		live	
+MONDO:0019122	idiopathic acute eosinophilic pneumonia	GARD:0000107	Pneumonia, eosinophilic	GARD:0000519	Idiopathic acute eosinophilic pneumonia	GARD		live		live	
+MONDO:0019122	idiopathic acute eosinophilic pneumonia	UMLS:C0242459	Simple pulmonary eosinophilia	UMLS:C4518469	Idiopathic acute eosinophilic pneumonia	UMLS		live		live	
+MONDO:0019122	idiopathic acute eosinophilic pneumonia	UMLS:C0242459	Simple pulmonary eosinophilia	UMLS:CN227574	Loffler syndrome	UMLS		live		live	
+MONDO:0019122	idiopathic acute eosinophilic pneumonia	UMLS:C4518469	Idiopathic acute eosinophilic pneumonia	UMLS:CN227574	Loffler syndrome	UMLS		live		live	
+MONDO:0019123	continuous spikes and waves during sleep	UMLS:C3806403	Continuous spike and waves during slow sleep	UMLS:CN181337	CSWS	UMLS		live		live	
+MONDO:0019123	continuous spikes and waves during sleep	UMLS:C3806403	Continuous spike and waves during slow sleep	UMLS:CN205644	Epileptic encephalopathy with continuous spike-and-wave during slow sleep	UMLS		live		live	
+MONDO:0019123	continuous spikes and waves during sleep	UMLS:CN181337	CSWS	UMLS:CN205644	Epileptic encephalopathy with continuous spike-and-wave during slow sleep	UMLS		live		live	
+MONDO:0019136	Zygomycosis	MESH:D009091	Mucormycosis	MESH:D020096	Zygomycosis	MESH		live		live	
+MONDO:0019136	Zygomycosis	SCTID:59277005	zygomycosis (disorder)	SCTID:76627001	mucormycosis (disorder)	SCTID		live		live	
+MONDO:0019145	hereditary thrombophilia due to congenital protein C deficiency	MESH:C535424	Congenital thrombotic disease, due to Protein C deficiency	MESH:D020151	Protein C Deficiency	MESH		live		live	
+MONDO:0019146	mendelian susceptibility to mycobacterial diseases	UMLS:C3266863	Mendelian susceptibility to mycobacterial infections	UMLS:CN181681	MSMD	UMLS		live		live	
+MONDO:0019148	Wolman disease	UMLS:C0043208	Wolman disease	UMLS:CN438428	Wolman disease	UMLS		live		live	
+MONDO:0019151	oligocone trichromacy	UMLS:C4302876	Oligocone trichromacy	UMLS:CN205696	Oligocone syndrome	UMLS		live		live	
+MONDO:0019158	tropical endomyocardial fibrosis	UMLS:C2882252	Tropical endomyocardial fibrosis	UMLS:CN205710	TEMF	UMLS		live		live	
+MONDO:0019160	primary progressive freezing gait	UMLS:C4275078	Primary progressive freezing gait	UMLS:CN205712	PPFG	UMLS		live		live	
+MONDO:0019164	6q terminal deletion syndrome	UMLS:C4304514	6q terminal deletion syndrome	UMLS:CN205719	6q terminal deletion syndrome	UMLS		live		live	
+MONDO:0019168	pyomyositis	UMLS:C0041188	Tropical pyomyositis	UMLS:C1704275	Pyomyositis	UMLS		live		live	
+MONDO:0019187	Axenfeld-Rieger syndrome	UMLS:C3495488	Axenfeld-Rieger syndrome	UMLS:CN776842	Rieger syndrome	UMLS		live		live	
+MONDO:0019192	AKT2-related familial partial lipodystrophy	UMLS:CN205772	AKT2-related FPLD	UMLS:CN536246	AKT2-related familial partial lipodystrophy	UMLS		live		live	
+MONDO:0019194	localized lipodystrophy	UMLS:C4329999	Focal Lipodystrophy	UMLS:CN227583	Localized lipodystrophy	UMLS		live		live	
+MONDO:0019200	retinitis pigmentosa	UMLS:C0035334	Retinitis pigmentosa	UMLS:C4072872	obsolete Rod-cone dystrophy	UMLS		live		live	
+MONDO:0019207	DEND syndrome	UMLS:C1853564	Developmental delay-epilepsy-neonatal diabetes syndrome	UMLS:C4303593	K ATP Associated Developmental Delay, Epilepsy and Neonatal Diabetes	UMLS		live		live	
+MONDO:0019218	inborn disorder of bile acid synthesis	UMLS:CN231736	Disorder of bile acid synthesis	UMLS:CN544763	Inborn Errors of Bile Acid Synthesis	UMLS		live		live	
+MONDO:0019220	inborn disorder of cobalamin metabolism and transport	UMLS:CN043592	Disorders of Intracellular Cobalamin Metabolism	UMLS:CN227587	Disorder of cobalamin metabolism and transport	UMLS		live		live	
+MONDO:0019234	peroxisome biogenesis disorder	GARD:0009473	Peroxisomal biogenesis disorders	GARD:0011890	Peroxisome biogenesis disorder-Zellweger syndrome spectrum	GARD		live		live	
+MONDO:0019234	peroxisome biogenesis disorder	MESH:C531857	Zellweger leukodystrophy	MESH:C536664	Peroxisome biogenesis disorders	MESH		live		live	
+MONDO:0019260	adult neuronal ceroid lipofuscinosis	UMLS:C0022797	Adult neuronal ceroid lipofuscinosis	UMLS:CN205864	Kufs disease	UMLS		live		live	
+MONDO:0019308	junctional epidermolysis bullosa inversa	UMLS:C2673609	JEB-I	UMLS:C2673610	JEB-I	UMLS		live		live	
+MONDO:0019309	late-onset junctional epidermolysis bullosa	UMLS:C4304724	Late-onset junctional epidermolysis bullosa	UMLS:CN205949	JEB-lo	UMLS		live		live	
+MONDO:0019313	hereditary lymphedema	SCTID:254199006	hereditary lymphedema (disorder)	SCTID:399889006	hereditary lymphedema type i (disorder)	SCTID		live		live	
+MONDO:0019321	atypical Werner syndrome	UMLS:C4275075	Atypical Werner syndrome	UMLS:CN205977	Atypical progeroid syndrome	UMLS		live		live	
+MONDO:0019322	pemphigus vegetans	UMLS:C0263316	Pemphigus vegetans	UMLS:CN205981	Pemphigus vegetans	UMLS		live		live	
+MONDO:0019341	tuberous sclerosis complex	GARD:0000946	Bourneville syndrome	GARD:0007830	Tuberous sclerosis	GARD		live		live	
+MONDO:0019346	sialidosis type 1	UMLS:C0023806	Lipomucopolysaccharidosis	UMLS:CN206021	Normomorphic sialidosis	UMLS		live		live	
+MONDO:0019349	Sotos syndrome	UMLS:C0175695	Sotos syndrome	UMLS:CN239475	Sotos Syndrome	UMLS		live		live	
+MONDO:0019350	hereditary spherocytosis	UMLS:C0037889	Hereditary spherocytosis	UMLS:CN206031		UMLS		live		not_present	
+MONDO:0019353	Stargardt disease	UMLS:C0271093	Stargardt's disease	UMLS:C1855465	STARGARDT DISEASE	UMLS		live		live	
+MONDO:0019355	adult-onset Still disease	SCTID:239920006	adult onset still's disease (disorder)	SCTID:68190001	wissler-fanconi syndrome (disorder)	SCTID		live		live	
+MONDO:0019355	adult-onset Still disease	UMLS:C0085253	Adult onset Still's disease	UMLS:CN206037	AOSD	UMLS		live		live	
+MONDO:0019366	free sialic acid storage disease	UMLS:C2931872	Free sialic acid storage disease	UMLS:CN206051	Free sialic acid storage disease	UMLS		live		live	
+MONDO:0019370	vulvovaginal gingival syndrome	UMLS:C3873472	Vulvovaginal gingival syndrome	UMLS:CN206058	Vulvovaginal gingival syndrome	UMLS		live		live	
+MONDO:0019371	narcolepsy without cataplexy	UMLS:C1456240	Narcolepsy without cataplexy	UMLS:CN206062	Narcolepsy without cataplexy	UMLS		live		live	
+MONDO:0019374	CAMOS syndrome	UMLS:C1847114	Cerebellar ataxia-intellectual disability-optic atrophy-skin abnormalities syndrome	UMLS:C4511633	CAMOS syndrome	UMLS		live		live	
+MONDO:0019378	la Crosse encephalitis	UMLS:C0014053	California encephalitis	UMLS:C0276379	La Crosse encephalitis	UMLS		live		live	
+MONDO:0019388	pelvis syndrome	UMLS:C4510867	PELVIS syndrome	UMLS:CN206083	Perineal hemangioma-external genitalia malformations-lipomyelomeningocele-vesicorenal abnormalities-imperforate anus syndrome	UMLS		live		live	
+MONDO:0019395	Hinman syndrome	UMLS:C1997362	Non-Neurogenic Neurogenic Bladder	UMLS:CN206094	Occult neuropathic bladder	UMLS		live		live	
+MONDO:0019396	collagen type III glomerulopathy	UMLS:C3872695	Collagenofibrotic glomerulopathy	UMLS:CN206095	Collagenofibrotic glomerulopathy	UMLS		live		live	
+MONDO:0019399	Isaac syndrome	UMLS:C0751919	Acquired Neuromyotonia	UMLS:CN206101	Quantal squander syndrome	UMLS		live		live	
+MONDO:0019413	ischio-vertebral syndrome	UMLS:C4274732	Ischio-vertebral syndrome	UMLS:CN206143	Ischio-vertebral dysplasia	UMLS		live		live	
+MONDO:0019428	fried syndrome	UMLS:C4305134	Fried syndrome	UMLS:CN206186	Fried syndrome	UMLS		live		live	
+MONDO:0019433	oligoarticular juvenile idiopathic arthritis	UMLS:C2931171	Oligoarticular JIA	UMLS:C3898105	Oligoarticular Juvenile Idiopathic Arthritis	UMLS		live		live	
+MONDO:0019439	AA amyloidosis	UMLS:C0221014	Reactive systemic amyloidosis	UMLS:C3536715	AA amyloidosis	UMLS		live		live	
+MONDO:0019448	benign adult familial myoclonic epilepsy	UMLS:C4273988	Benign adult familial myoclonic epilepsy	UMLS:CN206220	Benign adult familial myoclonus epilepsy	UMLS		live		live	
+MONDO:0019451	chronic neutrophilic leukemia	UMLS:C0023481	Chronic neutrophilic leukemia	UMLS:C0474856	Neutrophilic leukemia	UMLS		live		live	
+MONDO:0019458	acute basophilic leukemia	UMLS:C0023437	Acute basophilic leukemia	UMLS:C0221292	Basophilic leukemia	UMLS		live		live	
+MONDO:0019467	CD4+/CD56+ hematodermic neoplasm	UMLS:C1301363	Blastic plasmacytoid dendritic cell neoplasm	UMLS:CN206246	Monomorphic NK-cell lymphoma	UMLS		live		live	
+MONDO:0019468	T-cell prolymphocytic leukemia	NCIT:C4752	T-Cell Prolymphocytic Leukemia	NCIT:C70649	T-Cell Chronic Lymphocytic Leukemia	NCIT		live		live	
+MONDO:0019468	T-cell prolymphocytic leukemia	SCTID:277545003	t-cell chronic lymphocytic leukemia (disorder)	SCTID:277567002	t-cell prolymphocytic leukemia (disorder)	SCTID		live		live	
+MONDO:0019468	T-cell prolymphocytic leukemia	UMLS:C0023494	Chronic T-Cell Leukemia	UMLS:C2363142	T-cell prolymphocytic leukemia	UMLS		live		live	
+MONDO:0019469	T-cell large granular lymphocyte leukemia	UMLS:C1522378	Large granular lymphocytic leukemia	UMLS:C1955861	T-Cell Large Granular Lymphocyte Leukemia	UMLS		live		live	
+MONDO:0019490	progressive familial heart block	SCTID:698249005	progressive familial heart block (disorder)	SCTID:93130009		SCTID		live		not_present	
+MONDO:0019493	primary adult heart tumor	UMLS:C4275152	Adult heart tumor	UMLS:CN206280	Adult heart tumor	UMLS		live		live	
+MONDO:0019496	neuroendocrine neoplasm	UMLS:C0003650	Apudoma	UMLS:C0206754	Neuroendocrine tumor	UMLS		live		live	
+MONDO:0019496	neuroendocrine neoplasm	UMLS:C0003650	Apudoma	UMLS:CN206284	APUDoma	UMLS		live		live	
+MONDO:0019496	neuroendocrine neoplasm	UMLS:C0206754	Neuroendocrine tumor	UMLS:CN206284	APUDoma	UMLS		live		live	
+MONDO:0019499	Turner syndrome	GARD:0002458	Genital dwarfism	GARD:0002459	Genital dwarfism, Turner type	GARD		live		live	
+MONDO:0019499	Turner syndrome	GARD:0002458	Genital dwarfism	GARD:0002540	Gonadal dysgenesis Turner type	GARD		live		live	
+MONDO:0019499	Turner syndrome	GARD:0002458	Genital dwarfism	GARD:0007831	Turner syndrome	GARD		live		live	
+MONDO:0019499	Turner syndrome	GARD:0002459	Genital dwarfism, Turner type	GARD:0002540	Gonadal dysgenesis Turner type	GARD		live		live	
+MONDO:0019499	Turner syndrome	GARD:0002459	Genital dwarfism, Turner type	GARD:0007831	Turner syndrome	GARD		live		live	
+MONDO:0019499	Turner syndrome	GARD:0002540	Gonadal dysgenesis Turner type	GARD:0007831	Turner syndrome	GARD		live		live	
+MONDO:0019524	infantile Bartter syndrome with sensorineural deafness	UMLS:C3838860	Bartter syndrome type 4	UMLS:CN206343	Bartter syndrome type IV	UMLS		live		live	
+MONDO:0019538	Gaisbock syndrome	UMLS:C0541719	Stress polycythemia	UMLS:C2242785	Gaisbock's syndrome	UMLS		live		live	
+MONDO:0019538	Gaisbock syndrome	UMLS:C0541719	Stress polycythemia	UMLS:CN206365	Stress polycythemia	UMLS		live		live	
+MONDO:0019538	Gaisbock syndrome	UMLS:C2242785	Gaisbock's syndrome	UMLS:CN206365	Stress polycythemia	UMLS		live		live	
+MONDO:0019557	chilblain lupus	UMLS:C0024145	Chilblain lupus	UMLS:CN239336	Chilblain Lupus	UMLS		live		live	
+MONDO:0019588	autosomal recessive nonsyndromic deafness	UMLS:C1846647	Deafness, autosomal recessive	UMLS:CN206424	Autosomal recessive non-syndromic neurosensory deafness type DFNB	UMLS		live		live	
+MONDO:0019604	acquired monoclonal Ig light chain-associated Fanconi syndrome	UMLS:C4510369	Acquired monoclonal immunoglobulin light chain-associated Fanconi syndrome	UMLS:CN206457	Acquired monoclonal immunoglobulin light chain-associated Fanconi syndrome	UMLS		live		live	
+MONDO:0019606	simple cryoglobulinemia	UMLS:C4510006	Simple cryoglobulinemia	UMLS:CN206459	Cryoglobulinemia type 1	UMLS		live		live	
+MONDO:0019617	pituitary deficiency due to empty sella turcica syndrome	UMLS:C4275064	Pituitary deficiency due to empty sella turcica syndrome	UMLS:CN206468	Hypopituitarism due to empty sella turcica syndrome	UMLS		live		live	
+MONDO:0019621	chronic pneumonitis of infancy	UMLS:C3872848	Chronic pneumonitis of infancy	UMLS:CN206472	CPI	UMLS		live		live	
+MONDO:0019623	hereditary angioedema	UMLS:C0019243	Hereditary angioedema	UMLS:CN239191	Hereditary Angioedema	UMLS		live		live	
+MONDO:0019635	idiopathic achalasia	UMLS:C0859976	Idiopathic achalasia of esophagus	UMLS:C1860213	Idiopathic achalasia of esophagus	UMLS		live		live	
+MONDO:0019640	posterior urethral valve	UMLS:C0238506		UMLS:CN227669	PUV	UMLS		not_present		live	
+MONDO:0019643	transient pseudohypoaldosteronism	UMLS:C4273962	Transient pseudohypoaldosteronism	UMLS:CN776908	TPHA	UMLS		live		live	
+MONDO:0019668	adenoma of pancreas	UMLS:C1142432	Pancreatic adenoma	UMLS:C4076724	Adenoma of pancreas	UMLS		live		live	
+MONDO:0019680	genochondromatosis type 2	UMLS:C4511481	Genochondromatosis type 2	UMLS:CN206604	Genochondromatosis type 2	UMLS		live		live	
+MONDO:0019681	juvenile sialidosis type 2	UMLS:C0268229	Dysmorphic sialidosis, juvenile form	UMLS:CN206605	Juvenile sialidosis type 2	UMLS		live		live	
+MONDO:0019716	overgrowth syndrome	UMLS:C2986703	Overgrowth Syndrome	UMLS:CN206621	Overgrowth syndrome	UMLS		live		live	
+MONDO:0019728	heavy chain deposition disease	UMLS:C1333947	Heavy Chain Deposition Disease	UMLS:CN206635	HCDD	UMLS		live		live	
+MONDO:0019735	polymyalgia rheumatica	UMLS:C0032533	Polymyalgia rheumatica	UMLS:C1527406	Rhizomelic pseudopolyarthritis	UMLS		live		live	
+MONDO:0019740	acquired thrombotic thrombocytopenic purpura	UMLS:C2584777	Autoimmune thrombotic thrombocytopenic purpura	UMLS:C2584778	Acquired thrombotic thrombocytopenic purpura	UMLS		live		live	
+MONDO:0019751	autoinflammatory syndrome	UMLS:C3267073	Autoinflammatory syndrome	UMLS:C3890737	Autoinflammatory Syndrome	UMLS		live		live	
+MONDO:0019753	localized Castleman disease	UMLS:C3898582	Localized Angiofollicular Lymphoid Hyperplasia	UMLS:CN206685	Localized Castleman disease	UMLS		live		live	
+MONDO:0019755	developmental defect during embryogenesis	UMLS:C1302790	Congenital malformation syndrome	UMLS:CN206687	Malformation syndrome	UMLS		live		live	
+MONDO:0019759	epispadias (disease)	UMLS:C0014588		UMLS:CN227686	Epispadias	UMLS		not_present		live	
+MONDO:0019784	12q14 microdeletion syndrome	UMLS:C4305140	12q14 microdeletion syndrome	UMLS:CN206727	Osteopoikilosis-short stature-intellectual disability syndrome	UMLS		live		live	
+MONDO:0019828	pituitary stalk interruption syndrome	UMLS:C4053775	Pituitary stalk interruption syndrome	UMLS:CN206776	PSIS	UMLS		live		live	
+MONDO:0019873	4p16.3 microduplication syndrome	UMLS:C4512053	4p16.3 microduplication syndrome	UMLS:CN206808	Trisomy 4pter	UMLS		live		live	
+MONDO:0019957	PPoma	UMLS:C0346407	Pancreatic polypeptidoma	UMLS:C1882278	Pancreatic Polypeptide Tumor	UMLS		live		live	
+MONDO:0019957	PPoma	UMLS:C0346407	Pancreatic polypeptidoma	UMLS:CN206879	Pancreatic polypeptidoma	UMLS		live		live	
+MONDO:0019957	PPoma	UMLS:C1882278	Pancreatic Polypeptide Tumor	UMLS:CN206879	Pancreatic polypeptidoma	UMLS		live		live	
+MONDO:0019960	VIPoma	GARD:0003787	WDHA syndrome	GARD:0005493	VIPoma	GARD		live		live	
+MONDO:0019975	pellagra	UMLS:C0030783	Pellagra	UMLS:C4317126	Niacin deficiency	UMLS		live		live	
+MONDO:0019978	Robinow syndrome	UMLS:C0265205	Robinow syndrome	UMLS:CN776872	Robinow-Silverman-Smith syndrome	UMLS		live		live	
+MONDO:0019995	peripheral resistance to thyroid hormones	UMLS:C4273673	Peripheral resistance to thyroid hormone	UMLS:CN206931	Peripheral resistance to thyroid hormones	UMLS		live		live	
+MONDO:0020076	myeloproliferative neoplasm	EFO:0002428	chronic myeloproliferative disorder	EFO:0004251	myeloproliferative disorder	EFO		live		live	
+MONDO:0020214	posterior corneal dystrophy	UMLS:C2063478	Posterior corneal dystrophy	UMLS:CN227822	Posterior corneal dystrophy	UMLS		live		live	
+MONDO:0020321	acute undifferentiated leukemia	UMLS:C0280141	Acute Undifferentiated Leukemia	UMLS:C0856823		UMLS		live		not_present	
+MONDO:0020321	acute undifferentiated leukemia	UMLS:C0280141	Acute Undifferentiated Leukemia	UMLS:C1282947	Acute myeloid leukemia, minimal differentiation, FAB M0	UMLS		live		live	
+MONDO:0020321	acute undifferentiated leukemia	UMLS:C0856823		UMLS:C1282947	Acute myeloid leukemia, minimal differentiation, FAB M0	UMLS		not_present		live	
+MONDO:0020349	acute motor axonal neuropathy	UMLS:C3890941	Acute motor axonal neuropathy	UMLS:CN207196	Acute pure motor Guillain-Barré syndrome	UMLS		live		live	
+MONDO:0020371	essential iris atrophy	UMLS:C0271111	Essential iris atrophy	UMLS:CN207238	Essential iris atrophy	UMLS		live		live	
+MONDO:0020381	patterned macular dystrophy	UMLS:C4511237	Butterfly-shaped pigmentary macular dystrophy	UMLS:CN207254	Butterfly-shaped pigmentary macular dystrophy	UMLS		live		live	
+MONDO:0020467	mosaic monosomy X	UMLS:C4040907	Mosaic Turner syndrome	UMLS:CN776903	Mosaic monosomy X	UMLS		live		live	
+MONDO:0020469	48,XYYY syndrome	UMLS:C4518082	48,XYYY syndrome	UMLS:CN207331	48,XYYY syndrome	UMLS		live		live	
+MONDO:0020470	49,XYYYY syndrome	UMLS:C4518342	49,XYYYY syndrome	UMLS:CN207332	49,XYYYY syndrome	UMLS		live		live	
+MONDO:0020478	Leber plus disease	UMLS:C4304725	Leber plus disease	UMLS:CN207347	LHON plus disease	UMLS		live		live	
+MONDO:0020485	King-Denborough syndrome	GARD:0008433	King Denborough syndrome	GARD:0008561	Kousseff Nichols syndrome	GARD		live		live	
+MONDO:0020485	King-Denborough syndrome	MESH:C536883	King Denborough syndrome	MESH:C537504	Kousseff Nichols syndrome	MESH		live		live	
+MONDO:0020491	subcortical band heterotopia	GARD:0001904	Subcortical band heterotopia	GARD:0002250	Familial band heterotopia	GARD		live		live	
+MONDO:0020491	subcortical band heterotopia	UMLS:C1848201	Subcortical laminar heterotopia	UMLS:C4284594	BAND HETEROTOPIA	UMLS		live		live	
+MONDO:0020501	Crimean-Congo hemorrhagic fever	UMLS:C0019099	Crimean hemorrhagic fever	UMLS:C1304456	Congo hemorrhagic fever	UMLS		live		live	
+MONDO:0020502	yellow fever	UMLS:C0043395	Yellow fever	UMLS:C0043397	Jungle yellow fever	UMLS		live		live	
+MONDO:0020502	yellow fever	UMLS:C0043395	Yellow fever	UMLS:C0043398	Urban yellow fever	UMLS		live		live	
+MONDO:0020502	yellow fever	UMLS:C0043397	Jungle yellow fever	UMLS:C0043398	Urban yellow fever	UMLS		live		live	
+MONDO:0020505	ravine syndrome	UMLS:C4275006	RAVINE syndrome	UMLS:CN207401	Reunion island-anorexia-vomiting which is irrepressible-neurological signs syndrome	UMLS		live		live	
+MONDO:0020513	spermatocytic seminoma	DOID:5834	spermatocytoma	DOID:7891	testicular spermatocytic seminoma	DOID		live		live	
+MONDO:0020516	thymic neuroendocrine carcinoma	UMLS:C2210965	Neuroendocrine carcinoma of thymus	UMLS:CN207412	Thymic neuroendocrine carcinoma	UMLS		live		live	
+MONDO:0020520	adult pulmonary Langerhans cell histiocytosis	UMLS:C1455705	Pulmonary histiocytosis X	UMLS:C3161104	Adult pulmonary Langerhans cell histiocytosis	UMLS		live		live	
+MONDO:0020522	Ehlers-Danlos syndrome type 7B	UMLS:C1851801	EDS VIIB	UMLS:CN706304	EDSARTH2	UMLS		live		live	
+MONDO:0020528	ACTH-dependent Cushing syndrome	SCTID:190502001	pituitary-dependent cushing's disease (disorder)	SCTID:237734007	adrenocorticotropic hormone-dependent cushing syndrome (disorder)	SCTID		live		live	
+MONDO:0020533	streptobacillary rat-bite fever	UMLS:C0152063	Streptobacillary fever	UMLS:CN207435	Streptobacillary rat-bite fever	UMLS		live		live	
+MONDO:0020540	ovarian gynandroblastoma	UMLS:C0018413	Gynandroblastoma	UMLS:C0346178	Ovarian Gynandroblastoma	UMLS		live		live	
+MONDO:0020541	maligant granulosa cell tumor of ovary	UMLS:C0346175	Malignant Ovarian Granulosa Cell Tumor	UMLS:CN207442	Granulosa cell malignant tumor	UMLS		live		live	
+MONDO:0020542	malignant Sertoli-Leydig cell tumor of ovary	UMLS:C0342515	Virilizing ovarian tumor	UMLS:CN207443	Ovarian malignant Sertoli-Leydig cell tumor	UMLS		live		live	
+MONDO:0020558	autosomal dominant Charcot-Marie-tooth disease type 2K	UMLS:C1842984	Autosomal dominant Charcot-Marie-Tooth disease type 2K	UMLS:CN207468	CMT2K	UMLS		live		live	
+MONDO:0020560	atypical teratoid rhabdoid tumor	UMLS:C1266184	Atypical teratoid/rhabdoid tumor	UMLS:CN207484	ATRT	UMLS		live		live	
+MONDO:0021055	classic familial adenomatous polyposis	UMLS:C0032580	Adenomatous polyposis coli	UMLS:CN240755	Familial adenomatous polyposis	UMLS		live		live	
+MONDO:0021097	intraductal breast papilloma	SCTID:254848002	duct papilloma of breast (disorder)	SCTID:99571000119102	papilloma of breast (disorder)	SCTID		live		live	
+MONDO:0021104	alcoholic fatty liver disease	UMLS:C0015696	Alcoholic fatty liver	UMLS:C2718067	Alcoholic Steatohepatitis	UMLS		live		live	
+MONDO:0021187	hyperlipidemia (disease)	UMLS:C0020473	Hyperlipidemia	UMLS:CN236649	Hyperlipidemias	UMLS		live		live	
+MONDO:0021288	carcinoma in situ of hypopharynx	UMLS:C0347100	Carcinoma in situ of hypopharynx	UMLS:C4331310		UMLS		live		not_present	
+MONDO:0021297	carcinoma in situ of nasopharynx	UMLS:C0347096	Carcinoma in situ of nasopharynx	UMLS:C4331312		UMLS		live		not_present	
+MONDO:0021315	malignant tumor of nasopharynx	UMLS:C0153392	Malignant neoplasm of nasopharynx	UMLS:C0238301	Cancer of nasopharynx	UMLS		live		live	
+MONDO:0021545	myomatous neoplasm	MESH:D009379	Neoplasms, Muscle Tissue	MESH:D019042	Muscle Neoplasms	MESH		live		live	
+MONDO:0021644	esophageal varices without bleeding	ICD10:I85.00		ICD10:I85.9		ICD10		not_present		not_present	
+MONDO:0021645	esophageal varices with bleeding	ICD10:I85.0		ICD10:I85.01		ICD10		not_present		not_present	
+MONDO:0021944	auditory neuropathy	UMLS:C1852271	AUDITORY NEUROPATHY	UMLS:C2732267	Auditory neuropathy spectrum disorder	UMLS		live		live	
+MONDO:0023073	eosinophilic cryptitis	GARD:0006346	Eosinophilic cryptitis	GARD:0006347	Eosinophilic cystitis	GARD		live		live	
+MONDO:0023122	familial prostate cancer	UMLS:C2931456	Familial prostate cancer	UMLS:CN036094	Hereditary prostate cancer	UMLS		live		live	
+MONDO:0023204	Fukuda Miyanomae Nakata syndrome	GARD:0002411	Fukuda Miyanomae Nakata syndrome	GARD:0006475	Fukuyama type muscular dystrophy	GARD		live		live	
+MONDO:0024240	eccrine carcinoma	UMLS:C1266066	Eccrine adenocarcinoma	UMLS:C1302864	Eccrine carcinoma of skin	UMLS		live		live	
+MONDO:0024240	eccrine carcinoma	UMLS:C1266066	Eccrine adenocarcinoma	UMLS:C1707878	Eccrine Carcinoma	UMLS		live		live	
+MONDO:0024240	eccrine carcinoma	UMLS:C1302864	Eccrine carcinoma of skin	UMLS:C1707878	Eccrine Carcinoma	UMLS		live		live	
+MONDO:0024246	syringofibroadenoma	UMLS:C0473578	Acrosyringeal nevus	UMLS:C1266060	Syringofibroadenoma	UMLS		live		live	
+MONDO:0024298	vitamin deficiency disorder	UMLS:C0376286	Avitaminosis	UMLS:C1510471	Vitamin deficiency	UMLS		live		live	
+MONDO:0024330	infectious otitis media	UMLS:C0271429	Acute otitis media	UMLS:C2827407	Infectious Otitis Media	UMLS		live		live	
+MONDO:0024456	anterior segment dysgenesis 3	GARD:0002482	Glaucoma iridogoniodysgenesia	GARD:0002978	Iridogoniodysgenesis type 1	GARD		live		live	
+MONDO:0024472	boutonneuse fever	Orphanet:101334	African tick typhus	Orphanet:83313	Boutonneuse fever	Orphanet		live		live	
+MONDO:0024532	otofaciocervical syndrome 1	UMLS:C3714941	OTOFACIOCERVICAL SYNDROME 1	UMLS:CN034490		UMLS		live		not_present	
+MONDO:0024570	hyperparathyroidism 4	UMLS:C4479229	HYPERPARATHYROIDISM 4	UMLS:CN240514		UMLS		live		not_present	
+MONDO:0024623	otorhinolaryngologic disease	UMLS:C0029896	Otorhinolaryngologic Disease	UMLS:C0395797	Ear, nose and throat disorder	UMLS		live		live	
+MONDO:0024892	soft tissue amyloid neoplasm	UMLS:C0333572	Amyloid tumor	UMLS:C1706802	Soft Tissue Amyloid Neoplasm	UMLS		live		live	
+MONDO:0027772	lung colloid adenocarcinoma	DOID:0080303	mucinous lung adenocarcinoma	DOID:0080304	lung mucinous cystadenocarcinoma	DOID		live		live	
+MONDO:0033044	Meckel syndrome 13	DOID:0080253	Meckel syndrome 13	DOID:0080276	Joubert syndrome 29	DOID		live		live	
+MONDO:0042971	congenital herpes virus infection	GARD:0002669	Herpes virus antenatal infection	GARD:0002670	Herpetic embryopathy	GARD		live		live	
+MONDO:0043370	secondary adrenal insufficiency	UMLS:C0271738	Hypocortisolism secondary to another disorder	UMLS:C0948387	Secondary Adrenal Insufficiency	UMLS		live		live	
+MONDO:0043373	sudden sensorineural hearing loss	SCTID:715239002	sudden sensorineural hearing loss (disorder)	SCTID:79471008	sudden hearing loss (disorder)	SCTID		live		live	
+MONDO:0044343	cervical disc degenerative disorder	UMLS:C0158262	Degeneration of cervical intervertebral disc	UMLS:C0410606	Cervical Disc Degenerative Disorder	UMLS		live		live	
+MONDO:0044777	premature ovarian failure 14	UMLS:CN753759	GDF9 related ovarian dysfunction	UMLS:CN757793	GDF9-related primary ovarian insufficiency	UMLS		live		live	
+MONDO:0044792	large congenital melanocytic nevus	UMLS:C1318558	Congenital melanocytic nevus	UMLS:C1842036	LCMN	UMLS		live		live	

--- a/src/ontology/void.ttl
+++ b/src/ontology/void.ttl
@@ -46,7 +46,7 @@
 <imports>
     a lib:Ontology ;
     a lib:Virtual ;
-    owl:imports <imports/uberon_import.owl>, <imports/ro_import.owl>, <imports/cl_import.owl>, <imports/go_import.owl>, <imports/pato_import.owl> .
+    owl:imports <imports/uberon_import.owl>, <imports/ro_import.owl>, <imports/cl_import.owl>, <imports/go_import.owl>, <imports/pato_import.owl> , <imports/hp_import.owl> .
     
 
 <all>

--- a/src/patterns/acquired.csv
+++ b/src/patterns/acquired.csv
@@ -1,36 +1,57 @@
 iri,iri label,disease,disease label
-MONDO:0019624,acquired angioedema,MONDO:0010481,angioedema
-MONDO:0019846,acquired central diabetes insipidus,MONDO:0015790,central diabetes insipidus
-MONDO:0015130,acquired chronic primary adrenal insufficiency,MONDO:0015129,chronic primary adrenal insufficiency
-MONDO:0016446,acquired cutis laxa,MONDO:0016175,cutis laxa
-MONDO:0016434,acquired dermis elastic tissue disorder,MONDO:0019292,dermis elastic tissue disorder
-MONDO:0018747,acquired epidermolysis bullosa,MONDO:0006541,epidermolysis bullosa
-MONDO:0021134,acquired factor X deficiency,MONDO:0002247,factor X deficiency
-MONDO:0021133,acquired factor XIII deficiency,MONDO:0002241,factor XIII deficiency
-MONDO:0003206,acquired hemangioma,MONDO:0006500,hemangioma
-MONDO:0019139,acquired hemophilia,MONDO:0018660,hemophilia
-MONDO:0018683,acquired ichthyosis,MONDO:0019269,ichthyosis (disease)
-MONDO:0006522,acquired keratosis,MONDO:0006566,keratosis
-MONDO:0020089,acquired lipodystrophy,MONDO:0006573,lipodystrophy (disease)
-MONDO:0006504,acquired metabolic disease,MONDO:0005066,metabolic disease
-MONDO:0020129,acquired motor neuron disease,MONDO:0020128,motor neuron disease
-MONDO:0020125,acquired neuromuscular junction disease,MONDO:0020124,neuromuscular junction disease
-MONDO:0015822,acquired neutropenia,MONDO:0001475,neutropenia
-MONDO:0001296,acquired night blindness,MONDO:0004588,night blindness
-MONDO:0015923,acquired peripheral neuropathy,MONDO:0005244,peripheral neuropathy
-MONDO:0019832,acquired pituitary hormone deficiency,MONDO:0005152,hypopituitarism
-MONDO:0002438,acquired polycythemia,MONDO:0005571,polycythemia
-MONDO:0017815,acquired porencephaly,MONDO:0017410,porencephaly
-MONDO:0016990,acquired prothrombin deficiency,MONDO:0013361,prothrombin deficiency
-MONDO:0016441,acquired pseudoxanthoma elasticum,MONDO:0009925,pseudoxanthoma elasticum
-MONDO:0018854,acquired purpura fulminans,MONDO:0000809,purpura fulminans
-MONDO:0021142,acquired rippling muscle disease,MONDO:0011634,rippling muscle disease
-MONDO:0018839,acquired schizencephaly,MONDO:0010011,schizencephaly
-MONDO:0016541,acquired secondary polycythemia,MONDO:0020115,secondary polycythemia
-MONDO:0016105,acquired skeletal muscle disease,MONDO:0020120,skeletal muscle disease
-MONDO:0001198,acquired thrombocytopenia,MONDO:0002049,thrombocytopenia
-MONDO:0019740,acquired thrombotic thrombocytopenic purpura,MONDO:0018896,thrombotic thrombocytopenic purpura
-MONDO:0020460,acquired von willebrand syndrome,MONDO:0019565,von willebrand disease
-MONDO:0012579,autoimmune pulmonary alveolar proteinosis,MONDO:0001437,pulmonary alveolar proteinosis
-MONDO:0018740,drug-induced methemoglobinemia,MONDO:0001117,methemoglobinemia
-MONDO:0015542,secondary hemophagocytic lymphohistiocytosis,MONDO:0015540,hemophagocytic syndrome
+http://purl.obolibrary.org/obo/MONDO_0018686,acquired Creutzfeldt-Jakob disease,http://purl.obolibrary.org/obo/MONDO_0005357,Creutzfeldt Jacob disease
+http://purl.obolibrary.org/obo/MONDO_0045023,acquired adrenogenital syndrome,http://purl.obolibrary.org/obo/MONDO_0015898,adrenogenital syndrome
+http://purl.obolibrary.org/obo/MONDO_0019624,acquired angioedema,http://purl.obolibrary.org/obo/MONDO_0010481,angioedema
+http://purl.obolibrary.org/obo/MONDO_0015610,acquired aplastic anemia,http://purl.obolibrary.org/obo/MONDO_0015909,aplastic anemia
+http://purl.obolibrary.org/obo/MONDO_0016593,acquired ataxia,http://purl.obolibrary.org/obo/MONDO_0000437,cerebellar ataxia
+http://purl.obolibrary.org/obo/MONDO_0019846,acquired central diabetes insipidus,http://purl.obolibrary.org/obo/MONDO_0015790,central diabetes insipidus
+http://purl.obolibrary.org/obo/MONDO_0015130,acquired chronic primary adrenal insufficiency,http://purl.obolibrary.org/obo/MONDO_0015129,chronic primary adrenal insufficiency
+http://purl.obolibrary.org/obo/MONDO_0020599,acquired coagulation factor deficiency,http://purl.obolibrary.org/obo/MONDO_0002242,coagulation protein disease
+http://purl.obolibrary.org/obo/MONDO_0001828,acquired color blindness,http://purl.obolibrary.org/obo/MONDO_0001703,color vision disorder
+http://purl.obolibrary.org/obo/MONDO_0016446,acquired cutis laxa,http://purl.obolibrary.org/obo/MONDO_0016175,cutis laxa
+http://purl.obolibrary.org/obo/MONDO_0016434,acquired dermis elastic tissue disorder,http://purl.obolibrary.org/obo/MONDO_0019292,dermis elastic tissue disorder
+http://purl.obolibrary.org/obo/MONDO_0018747,acquired epidermolysis bullosa,http://purl.obolibrary.org/obo/MONDO_0006541,epidermolysis bullosa
+http://purl.obolibrary.org/obo/MONDO_0021134,acquired factor X deficiency,http://purl.obolibrary.org/obo/MONDO_0002247,factor X deficiency
+http://purl.obolibrary.org/obo/MONDO_0021133,acquired factor XIII deficiency,http://purl.obolibrary.org/obo/MONDO_0002241,factor XIII deficiency
+http://purl.obolibrary.org/obo/MONDO_0019193,acquired generalized lipodystrophy,http://purl.obolibrary.org/obo/MONDO_0027766,generalized lipodystrophy
+http://purl.obolibrary.org/obo/MONDO_0003206,acquired hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma
+http://purl.obolibrary.org/obo/MONDO_0044349,acquired hemoglobinopathy,http://purl.obolibrary.org/obo/MONDO_0044348,hemoglobinopathy
+http://purl.obolibrary.org/obo/MONDO_0019139,acquired hemophilia,http://purl.obolibrary.org/obo/MONDO_0018660,hemophilia
+http://purl.obolibrary.org/obo/MONDO_0024305,acquired hyperprolactinemia,http://purl.obolibrary.org/obo/MONDO_0005804,hyperprolactinemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0001878,acquired hypertrophic pyloric stenosis,http://purl.obolibrary.org/obo/MONDO_0001560,hypertrophic pyloric stenosis
+http://purl.obolibrary.org/obo/MONDO_0018683,acquired ichthyosis,http://purl.obolibrary.org/obo/MONDO_0019269,ichthyosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0044817,acquired idiopathic torsion dystonia,http://purl.obolibrary.org/obo/MONDO_0044811,idiopathic torsion dystonia
+http://purl.obolibrary.org/obo/MONDO_0006522,acquired keratosis,http://purl.obolibrary.org/obo/MONDO_0006566,keratosis
+http://purl.obolibrary.org/obo/MONDO_0024306,acquired lactic acidosis,http://purl.obolibrary.org/obo/MONDO_0006040,lactic acidosis
+http://purl.obolibrary.org/obo/MONDO_0020089,acquired lipodystrophy,http://purl.obolibrary.org/obo/MONDO_0006573,lipodystrophy (disease)
+http://purl.obolibrary.org/obo/MONDO_0006504,acquired metabolic disease,http://purl.obolibrary.org/obo/MONDO_0005066,metabolic disease
+http://purl.obolibrary.org/obo/MONDO_0024301,acquired mineral metabolism disease,http://purl.obolibrary.org/obo/MONDO_0000226,mineral metabolism disease
+http://purl.obolibrary.org/obo/MONDO_0020129,acquired motor neuron disease,http://purl.obolibrary.org/obo/MONDO_0020128,motor neuron disease
+http://purl.obolibrary.org/obo/MONDO_0020125,acquired neuromuscular junction disease,http://purl.obolibrary.org/obo/MONDO_0020124,neuromuscular junction disease
+http://purl.obolibrary.org/obo/MONDO_0015822,acquired neutropenia,http://purl.obolibrary.org/obo/MONDO_0001475,neutropenia
+http://purl.obolibrary.org/obo/MONDO_0001296,acquired night blindness,http://purl.obolibrary.org/obo/MONDO_0004588,night blindness
+http://purl.obolibrary.org/obo/MONDO_0012104,acquired partial lipodystrophy,http://purl.obolibrary.org/obo/MONDO_0027767,partial lipodystrophy
+http://purl.obolibrary.org/obo/MONDO_0015923,acquired peripheral neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy
+http://purl.obolibrary.org/obo/MONDO_0019832,acquired pituitary hormone deficiency,http://purl.obolibrary.org/obo/MONDO_0005152,hypopituitarism
+http://purl.obolibrary.org/obo/MONDO_0002438,acquired polycythemia,http://purl.obolibrary.org/obo/MONDO_0005571,polycythemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0017815,acquired porencephaly,http://purl.obolibrary.org/obo/MONDO_0017410,porencephaly
+http://purl.obolibrary.org/obo/MONDO_0019851,acquired primary ovarian failure,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure
+http://purl.obolibrary.org/obo/MONDO_0016990,acquired prothrombin deficiency,http://purl.obolibrary.org/obo/MONDO_0024307,prothrombin deficiency
+http://purl.obolibrary.org/obo/MONDO_0016441,acquired pseudoxanthoma elasticum,http://purl.obolibrary.org/obo/MONDO_0024308,pseudoxanthoma elasticum (inherited or acquired)
+http://purl.obolibrary.org/obo/MONDO_0018854,acquired purpura fulminans,http://purl.obolibrary.org/obo/MONDO_0000809,purpura fulminans
+http://purl.obolibrary.org/obo/MONDO_0021142,acquired rippling muscle disease,http://purl.obolibrary.org/obo/MONDO_0011634,rippling muscle disease
+http://purl.obolibrary.org/obo/MONDO_0018839,acquired schizencephaly,http://purl.obolibrary.org/obo/MONDO_0010011,schizencephaly
+http://purl.obolibrary.org/obo/MONDO_0016541,acquired secondary polycythemia,http://purl.obolibrary.org/obo/MONDO_0020115,secondary polycythemia
+http://purl.obolibrary.org/obo/MONDO_0016172,acquired sensory ganglionopathy,http://purl.obolibrary.org/obo/MONDO_0021260,sensory ganglionopathy
+http://purl.obolibrary.org/obo/MONDO_0016105,acquired skeletal muscle disease,http://purl.obolibrary.org/obo/MONDO_0020120,skeletal muscle disease
+http://purl.obolibrary.org/obo/MONDO_0001198,acquired thrombocytopenia,http://purl.obolibrary.org/obo/MONDO_0002049,thrombocytopenia
+http://purl.obolibrary.org/obo/MONDO_0019740,acquired thrombotic thrombocytopenic purpura,http://purl.obolibrary.org/obo/MONDO_0018896,thrombotic thrombocytopenic purpura
+http://purl.obolibrary.org/obo/MONDO_0044870,acquired torsion dystonia,http://purl.obolibrary.org/obo/MONDO_0044843,torsion dystonia
+http://purl.obolibrary.org/obo/MONDO_0020460,acquired von willebrand syndrome,http://purl.obolibrary.org/obo/MONDO_0024574,von Willebrand disease (hereditary or acquired)
+http://purl.obolibrary.org/obo/MONDO_0021180,acquired xanthinuria,http://purl.obolibrary.org/obo/MONDO_0000721,xanthinuria
+http://purl.obolibrary.org/obo/MONDO_0018740,drug-induced methemoglobinemia,http://purl.obolibrary.org/obo/MONDO_0001117,methemoglobinemia
+http://purl.obolibrary.org/obo/MONDO_0016330,non-familial hypertrophic cardiomyopathy,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0016625,rare acquired deficiency anemia,http://purl.obolibrary.org/obo/MONDO_0001639,deficiency anemia
+http://purl.obolibrary.org/obo/MONDO_0016634,rare thrombotic disorder due to an acquired coagulation factors defect,http://purl.obolibrary.org/obo/MONDO_0016632,rare thrombotic disorder due to a coagulation factors defect
+http://purl.obolibrary.org/obo/MONDO_0015542,secondary hemophagocytic lymphohistiocytosis,http://purl.obolibrary.org/obo/MONDO_0015540,hemophagocytic syndrome
+http://purl.obolibrary.org/obo/MONDO_0008295,sporadic porphyria cutanea tarda,http://purl.obolibrary.org/obo/MONDO_0015104,porphyria cutanea tarda

--- a/src/patterns/acute.csv
+++ b/src/patterns/acute.csv
@@ -1,39 +1,51 @@
 iri,iri label,disease,disease label
-MONDO:0001090,acute anterolateral myocardial infarction,MONDO:0006652,anterolateral myocardial infarction
-MONDO:0001081,acute cervicitis,MONDO:0002345,cervicitis (disease)
-MONDO:0001930,acute cholangitis,MONDO:0004789,cholangitis
-MONDO:0001817,acute closed-angle glaucoma,MONDO:0001744,angle-closure glaucoma
-MONDO:0001214,acute conjunctivitis,MONDO:0003799,conjunctivitis (disease)
-MONDO:0004598,acute cor pulmonale,MONDO:0004596,cor pulmonale
-MONDO:0001650,acute cystitis (disease),MONDO:0006032,cystitis
-MONDO:0004812,acute dacryoadenitis,MONDO:0004804,dacryoadenitis
-MONDO:0001610,acute dacryocystitis,MONDO:0004926,dacryocystitis
-MONDO:0000257,acute diarrhea,MONDO:0001673,diarrhea
-MONDO:0001871,acute diffuse glomerulonephritis,MONDO:0003137,diffuse glomerulonephritis
-MONDO:0004265,acute endometritis,MONDO:0000918,endometritis
-MONDO:0017202,acute endophthalmitis,MONDO:0016047,endophthalmitis
-MONDO:0004810,acute ethmoiditis,MONDO:0005756,ethmoid sinusitis
-MONDO:0001912,acute frontal sinusitis,MONDO:0001121,frontal sinusitis
-MONDO:0020546,acute graft versus host disease,MONDO:0013730,graft versus host disease
-MONDO:0005174,acute hypotension,MONDO:0005468,hypotension (disease)
-MONDO:0002492,acute kidney failure,MONDO:0001106,kidney failure
-MONDO:0004777,acute laryngitis,MONDO:0002647,laryngitis
-MONDO:0004967,acute lymphoblastic leukemia (disease),MONDO:0001018,lymphoblastic leukemia
-MONDO:0002186,acute maxillary sinusitis,MONDO:0005842,maxillary sinusitis
-MONDO:0007896,acute monocytic leukemia,MONDO:0004600,monocytic leukemia
-MONDO:0018874,acute myeloid leukemia,MONDO:0004643,myeloid leukemia
-MONDO:0004781,acute myocardial infarction,MONDO:0005068,myocardial infarction (disease)
-MONDO:0002815,acute myocarditis,MONDO:0004496,myocarditis
-MONDO:0006515,acute pancreatitis,MONDO:0004982,pancreatitis
-MONDO:0001028,acute pericementitis,MONDO:0005076,periodontitis
-MONDO:0002240,acute perichondritis of pinna,MONDO:0002246,perichondritis of auricle
-MONDO:0002520,acute porphyria,MONDO:0019142,porphyria
-MONDO:0001644,acute proliferative glomerulonephritis,MONDO:0003134,proliferative glomerulonephritis
-MONDO:0003529,acute pyelonephritis,MONDO:0006939,pyelonephritis
-MONDO:0001208,acute respiratory failure,MONDO:0021113,respiratory failure
-MONDO:0001173,acute salpingitis,MONDO:0003619,salpingitis
-MONDO:0001171,acute salpingo-oophoritis,MONDO:0001172,salpingo-oophoritis
-MONDO:0001624,acute sphenoidal sinusitis,MONDO:0005964,sphenoid sinusitis
-MONDO:0001949,acute thyroiditis,MONDO:0004126,thyroiditis (disease)
-MONDO:0002738,acute transudative otitis media,MONDO:0001212,non-suppurative otitis media
-MONDO:0001031,purulent acute otitis media,MONDO:0005975,suppurative otitis media
+http://purl.obolibrary.org/obo/MONDO_0001090,acute anterolateral myocardial infarction,http://purl.obolibrary.org/obo/MONDO_0006652,anterolateral myocardial infarction
+http://purl.obolibrary.org/obo/MONDO_0001081,acute cervicitis,http://purl.obolibrary.org/obo/MONDO_0002345,cervicitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0001930,acute cholangitis,http://purl.obolibrary.org/obo/MONDO_0004789,cholangitis
+http://purl.obolibrary.org/obo/MONDO_0001817,acute closed-angle glaucoma,http://purl.obolibrary.org/obo/MONDO_0001744,angle-closure glaucoma
+http://purl.obolibrary.org/obo/MONDO_0001214,acute conjunctivitis,http://purl.obolibrary.org/obo/MONDO_0003799,conjunctivitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0004598,acute cor pulmonale,http://purl.obolibrary.org/obo/MONDO_0004596,cor pulmonale
+http://purl.obolibrary.org/obo/MONDO_0001650,acute cystitis (disease),http://purl.obolibrary.org/obo/MONDO_0006032,cystitis
+http://purl.obolibrary.org/obo/MONDO_0004812,acute dacryoadenitis,http://purl.obolibrary.org/obo/MONDO_0004804,dacryoadenitis
+http://purl.obolibrary.org/obo/MONDO_0001610,acute dacryocystitis,http://purl.obolibrary.org/obo/MONDO_0004926,dacryocystitis
+http://purl.obolibrary.org/obo/MONDO_0000257,acute diarrhea,http://purl.obolibrary.org/obo/MONDO_0001673,diarrheal disease
+http://purl.obolibrary.org/obo/MONDO_0001871,acute diffuse glomerulonephritis,http://purl.obolibrary.org/obo/MONDO_0003137,diffuse glomerulonephritis
+http://purl.obolibrary.org/obo/MONDO_0004265,acute endometritis,http://purl.obolibrary.org/obo/MONDO_0000918,endometritis
+http://purl.obolibrary.org/obo/MONDO_0017202,acute endophthalmitis,http://purl.obolibrary.org/obo/MONDO_0016047,endophthalmitis
+http://purl.obolibrary.org/obo/MONDO_0041366,acute epiglottitis,http://purl.obolibrary.org/obo/MONDO_0005753,epiglottitis
+http://purl.obolibrary.org/obo/MONDO_0004810,acute ethmoiditis,http://purl.obolibrary.org/obo/MONDO_0005756,ethmoid sinusitis
+http://purl.obolibrary.org/obo/MONDO_0001064,acute eustachian salpingitis,http://purl.obolibrary.org/obo/MONDO_0002172,otosalpingitis
+http://purl.obolibrary.org/obo/MONDO_0001912,acute frontal sinusitis,http://purl.obolibrary.org/obo/MONDO_0001121,frontal sinusitis
+http://purl.obolibrary.org/obo/MONDO_0001080,acute gonococcal cervicitis,http://purl.obolibrary.org/obo/MONDO_0021157,gonococcal cervicitis
+http://purl.obolibrary.org/obo/MONDO_0001777,acute gonococcal cystitis,http://purl.obolibrary.org/obo/MONDO_0021160,gonococcal cystitis
+http://purl.obolibrary.org/obo/MONDO_0001125,acute gonococcal epididymo-orchitis,http://purl.obolibrary.org/obo/MONDO_0021158,gonococcal epididymo-orchitis
+http://purl.obolibrary.org/obo/MONDO_0001838,acute gonococcal prostatitis,http://purl.obolibrary.org/obo/MONDO_0021161,gonococcal prostatitis
+http://purl.obolibrary.org/obo/MONDO_0001837,acute gonococcal salpingitis,http://purl.obolibrary.org/obo/MONDO_0021159,gonococcal salpingitis
+http://purl.obolibrary.org/obo/MONDO_0020546,acute graft versus host disease,http://purl.obolibrary.org/obo/MONDO_0013730,graft versus host disease
+http://purl.obolibrary.org/obo/MONDO_0005174,acute hypotension,http://purl.obolibrary.org/obo/MONDO_0005468,hypotension (disease)
+http://purl.obolibrary.org/obo/MONDO_0044213,acute idiopathic urticaria,http://purl.obolibrary.org/obo/MONDO_0044211,idiopathic urticaria
+http://purl.obolibrary.org/obo/MONDO_0002492,acute kidney failure,http://purl.obolibrary.org/obo/MONDO_0001106,kidney failure
+http://purl.obolibrary.org/obo/MONDO_0004777,acute laryngitis,http://purl.obolibrary.org/obo/MONDO_0002647,laryngitis
+http://purl.obolibrary.org/obo/MONDO_0004967,acute lymphoblastic leukemia (disease),http://purl.obolibrary.org/obo/MONDO_0001018,lymphoblastic leukemia
+http://purl.obolibrary.org/obo/MONDO_0002186,acute maxillary sinusitis,http://purl.obolibrary.org/obo/MONDO_0005842,maxillary sinusitis
+http://purl.obolibrary.org/obo/MONDO_0007896,acute monocytic leukemia,http://purl.obolibrary.org/obo/MONDO_0004600,monocytic leukemia
+http://purl.obolibrary.org/obo/MONDO_0018874,acute myeloid leukemia,http://purl.obolibrary.org/obo/MONDO_0004643,myeloid leukemia
+http://purl.obolibrary.org/obo/MONDO_0004781,acute myocardial infarction,http://purl.obolibrary.org/obo/MONDO_0005068,myocardial infarction (disease)
+http://purl.obolibrary.org/obo/MONDO_0002815,acute myocarditis,http://purl.obolibrary.org/obo/MONDO_0004496,myocarditis
+http://purl.obolibrary.org/obo/MONDO_0001051,acute otitis externa,http://purl.obolibrary.org/obo/MONDO_0004795,otitis externa
+http://purl.obolibrary.org/obo/MONDO_0006515,acute pancreatitis,http://purl.obolibrary.org/obo/MONDO_0004982,pancreatitis
+http://purl.obolibrary.org/obo/MONDO_0041295,acute papillary necrosis,http://purl.obolibrary.org/obo/MONDO_0006821,kidney papillary necrosis
+http://purl.obolibrary.org/obo/MONDO_0001028,acute pericementitis,http://purl.obolibrary.org/obo/MONDO_0005076,periodontitis
+http://purl.obolibrary.org/obo/MONDO_0002240,acute perichondritis of pinna,http://purl.obolibrary.org/obo/MONDO_0002246,perichondritis of auricle
+http://purl.obolibrary.org/obo/MONDO_0001644,acute proliferative glomerulonephritis,http://purl.obolibrary.org/obo/MONDO_0003134,proliferative glomerulonephritis
+http://purl.obolibrary.org/obo/MONDO_0003529,acute pyelonephritis,http://purl.obolibrary.org/obo/MONDO_0006939,pyelonephritis
+http://purl.obolibrary.org/obo/MONDO_0001208,acute respiratory failure,http://purl.obolibrary.org/obo/MONDO_0021113,respiratory failure
+http://purl.obolibrary.org/obo/MONDO_0001895,acute retrobulbar neuritis,http://purl.obolibrary.org/obo/MONDO_0024335,retrobulbar neuritis
+http://purl.obolibrary.org/obo/MONDO_0001173,acute salpingitis,http://purl.obolibrary.org/obo/MONDO_0003619,salpingitis
+http://purl.obolibrary.org/obo/MONDO_0001171,acute salpingo-oophoritis,http://purl.obolibrary.org/obo/MONDO_0001172,salpingo-oophoritis
+http://purl.obolibrary.org/obo/MONDO_0001624,acute sphenoidal sinusitis,http://purl.obolibrary.org/obo/MONDO_0005964,sphenoid sinusitis
+http://purl.obolibrary.org/obo/MONDO_0000990,acute subendocardial myocardial infarction,http://purl.obolibrary.org/obo/MONDO_0003674,subendocardial myocardial infarction
+http://purl.obolibrary.org/obo/MONDO_0001949,acute thyroiditis,http://purl.obolibrary.org/obo/MONDO_0004126,thyroiditis (disease)
+http://purl.obolibrary.org/obo/MONDO_0002738,acute transudative otitis media,http://purl.obolibrary.org/obo/MONDO_0001212,non-suppurative otitis media
+http://purl.obolibrary.org/obo/MONDO_0001031,purulent acute otitis media,http://purl.obolibrary.org/obo/MONDO_0005975,suppurative otitis media
+http://purl.obolibrary.org/obo/MONDO_0000222,seminal vesicle acute gonorrhea,http://purl.obolibrary.org/obo/MONDO_0001027,gonococcal seminal vesiculitis

--- a/src/patterns/adenocarcinoma.csv
+++ b/src/patterns/adenocarcinoma.csv
@@ -1,0 +1,57 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0003853,Bartholin's gland adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0003410,Wolffian duct adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0003074,mesonephric duct
+http://purl.obolibrary.org/obo/MONDO_0016275,adenocarcinoma of cervix uteri,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0018351,adenocarcinoma of penis,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0004173,adenocarcinoma of skene gland origin,http://purl.obolibrary.org/obo/UBERON_0010145,paraurethral gland
+http://purl.obolibrary.org/obo/MONDO_0002670,ampulla of vater adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0004913,hepatopancreatic ampulla
+http://purl.obolibrary.org/obo/MONDO_0002735,anal canal adenocarcinoma (disease),http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0002652,anus adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0003214,apocrine adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0008974,apocrine gland
+http://purl.obolibrary.org/obo/MONDO_0006087,appendix adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0003193,bile duct adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0002751,bladder adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0004331,bladder urachal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002068,urachus
+http://purl.obolibrary.org/obo/MONDO_0004988,breast adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0005590,breast ductal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001765,mammary duct
+http://purl.obolibrary.org/obo/MONDO_0006028,cecum adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0002271,colon adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0005008,colorectal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0006186,duodenal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0000554,endocervical adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000458,endocervix
+http://purl.obolibrary.org/obo/MONDO_0005461,endometrium adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0001017,epididymal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001301,epididymis
+http://purl.obolibrary.org/obo/MONDO_0005028,esophageal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0002665,extrahepatic bile duct adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002746,fallopian tube adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0006215,gallbladder adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0005036,gastric adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003835,gastric cardia adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001162,cardia of stomach
+http://purl.obolibrary.org/obo/MONDO_0003219,gastroesophageal junction adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0007650,esophagogastric junction
+http://purl.obolibrary.org/obo/MONDO_0000541,jejunal adenocarcinoma (disease),http://purl.obolibrary.org/obo/UBERON_0002115,jejunum
+http://purl.obolibrary.org/obo/MONDO_0002475,lacrimal gland adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0005061,lung adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003189,middle ear adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0006304,minor salivary gland adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001830,minor salivary gland
+http://purl.obolibrary.org/obo/MONDO_0003211,nasal cavity adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0002752,ovarian adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006047,pancreatic adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0005184,pancreatic ductal adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0007329,pancreatic duct
+http://purl.obolibrary.org/obo/MONDO_0004465,periampullary adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0012273,periampullary region of duodenum
+http://purl.obolibrary.org/obo/MONDO_0017582,pituitary adenocarcinoma (disease),http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0005082,prostate adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002169,rectum adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0005086,renal cell carcinoma (disease),http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0003205,renal pelvis adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001224,renal pelvis
+http://purl.obolibrary.org/obo/MONDO_0003191,rete ovarii adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0010185,rete ovarii
+http://purl.obolibrary.org/obo/MONDO_0001992,rete testis adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0003959,rete testis
+http://purl.obolibrary.org/obo/MONDO_0006962,sebaceous adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0001993,seminal vesicle adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000998,seminal vesicle
+http://purl.obolibrary.org/obo/MONDO_0003198,small intestine adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0003209,thymus gland adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0024622,thyroid gland adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0002822,trabecular adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000440,trabecula
+http://purl.obolibrary.org/obo/MONDO_0003216,ureter adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0003200,urethra adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0002741,uterine ligament adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0036262,uterine ligament
+http://purl.obolibrary.org/obo/MONDO_0024336,vulvar adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/adenoma.csv
+++ b/src/patterns/adenoma.csv
@@ -1,0 +1,32 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0003419,Bartholin gland adenoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0002364,Wolffian duct adenoma,http://purl.obolibrary.org/obo/UBERON_0003074,mesonephric duct
+http://purl.obolibrary.org/obo/MONDO_0021301,adenoma of nipple,http://purl.obolibrary.org/obo/UBERON_0002030,nipple
+http://purl.obolibrary.org/obo/MONDO_0021303,adenoma of small intestine,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0003924,adrenal cortex adenoma,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0006088,appendix adenoma,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0006108,bile duct adenoma,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0002058,breast adenoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0000527,colon adenoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0005484,colorectal adenoma,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0006180,digestive system adenoma,http://purl.obolibrary.org/obo/UBERON_0001555,digestive tract
+http://purl.obolibrary.org/obo/MONDO_0003445,extrahepatic bile duct adenoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0005032,follicular thyroid adenoma,http://purl.obolibrary.org/obo/UBERON_0005305,thyroid follicle
+http://purl.obolibrary.org/obo/MONDO_0006216,gallbladder adenoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0006221,gastric adenoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003444,intrahepatic bile duct adenoma,http://purl.obolibrary.org/obo/UBERON_0003704,intrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0003422,lung adenoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003423,middle ear adenoma,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0002197,minor vestibular glands adenoma,http://purl.obolibrary.org/obo/UBERON_0000461,minor vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0006890,parathyroid gland adenoma,http://purl.obolibrary.org/obo/UBERON_0001132,parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0000488,periampullary adenoma,http://purl.obolibrary.org/obo/UBERON_0012273,periampullary region of duodenum
+http://purl.obolibrary.org/obo/MONDO_0006373,pituitary gland adenoma,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0002450,prostatic adenoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0006391,pyloric gland adenoma,http://purl.obolibrary.org/obo/UBERON_0008861,pyloric gastric gland
+http://purl.obolibrary.org/obo/MONDO_0000530,rectum adenoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0004005,rete ovarii adenoma,http://purl.obolibrary.org/obo/UBERON_0010185,rete ovarii
+http://purl.obolibrary.org/obo/MONDO_0003893,rete testis adenoma,http://purl.obolibrary.org/obo/UBERON_0003959,rete testis
+http://purl.obolibrary.org/obo/MONDO_0002375,sebaceous adenoma,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0021110,sweat gland adenoma,http://purl.obolibrary.org/obo/UBERON_0001820,sweat gland
+http://purl.obolibrary.org/obo/MONDO_0002454,thyroid adenoma (disease),http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0003434,vaginal adenoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina

--- a/src/patterns/adult.csv
+++ b/src/patterns/adult.csv
@@ -1,0 +1,55 @@
+iri,iri label,disease,disease label
+http://purl.obolibrary.org/obo/MONDO_0000814,B-cell adult acute lymphocytic leukemia,http://purl.obolibrary.org/obo/MONDO_0000872,B-cell childhood acute lymphoblastic leukemia
+http://purl.obolibrary.org/obo/MONDO_0017723,"Sandhoff disease, adult form",http://purl.obolibrary.org/obo/MONDO_0010006,Sandhoff disease
+http://purl.obolibrary.org/obo/MONDO_0016091,adult Krabbe disease,http://purl.obolibrary.org/obo/MONDO_0009499,Krabbe disease
+http://purl.obolibrary.org/obo/MONDO_0019471,adult T-cell leukemia/lymphoma,http://purl.obolibrary.org/obo/MONDO_0005525,T-cell leukemia
+http://purl.obolibrary.org/obo/MONDO_0000875,adult acute monocytic leukemia,http://purl.obolibrary.org/obo/MONDO_0007896,acute monocytic leukemia
+http://purl.obolibrary.org/obo/MONDO_0003690,adult anaplastic ependymoma,http://purl.obolibrary.org/obo/MONDO_0016700,anaplastic ependymoma
+http://purl.obolibrary.org/obo/MONDO_0004012,adult botryoid rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0002578,botryoid rhabdomyosarcoma
+http://purl.obolibrary.org/obo/MONDO_0024797,adult brain stem neoplasm,http://purl.obolibrary.org/obo/MONDO_0021228,brainstem neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003153,adult brainstem glioma,http://purl.obolibrary.org/obo/MONDO_0002911,brain stem glioma
+http://purl.obolibrary.org/obo/MONDO_0003952,adult central nervous system choriocarcinoma,http://purl.obolibrary.org/obo/MONDO_0016740,choriocarcinoma of the central nervous system
+http://purl.obolibrary.org/obo/MONDO_0004155,adult central nervous system embryonal carcinoma,http://purl.obolibrary.org/obo/MONDO_0018843,embryonal carcinoma of the central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003405,adult central nervous system germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0003000,central nervous system germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0004383,adult central nervous system germinoma,http://purl.obolibrary.org/obo/MONDO_0002999,central nervous system germinoma
+http://purl.obolibrary.org/obo/MONDO_0003732,adult central nervous system mature teratoma,http://purl.obolibrary.org/obo/MONDO_0003733,central nervous system mature teratoma
+http://purl.obolibrary.org/obo/MONDO_0004406,adult central nervous system mixed germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0016742,mixed germ cell tumor of central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002795,adult central nervous system primitive neuroectodermal neoplasm,http://purl.obolibrary.org/obo/MONDO_0000640,central nervous system primitive neuroectodermal neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003731,adult central nervous system teratoma,http://purl.obolibrary.org/obo/MONDO_0002718,central nervous system teratoma
+http://purl.obolibrary.org/obo/MONDO_0003260,adult cerebellar neoplasm,http://purl.obolibrary.org/obo/MONDO_0002913,cerebellar neoplasm
+http://purl.obolibrary.org/obo/MONDO_0002683,adult choroid plexus neoplasm,http://purl.obolibrary.org/obo/MONDO_0016717,choroid plexus neoplasm
+http://purl.obolibrary.org/obo/MONDO_0004099,adult cystic teratoma,http://purl.obolibrary.org/obo/MONDO_0002379,cystic teratoma
+http://purl.obolibrary.org/obo/MONDO_0001907,adult dermatomyositis,http://purl.obolibrary.org/obo/MONDO_0016367,dermatomyositis
+http://purl.obolibrary.org/obo/MONDO_0004310,"adult embryonal tumor with multilayered rosettes, c19mc-altered",http://purl.obolibrary.org/obo/MONDO_0016715,ependymoblastoma
+http://purl.obolibrary.org/obo/MONDO_0004521,adult epithelioid sarcoma,http://purl.obolibrary.org/obo/MONDO_0017387,epithelioid sarcoma
+http://purl.obolibrary.org/obo/MONDO_0004391,adult extraosseous chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0003044,extraosseous chondrosarcoma
+http://purl.obolibrary.org/obo/MONDO_0004374,adult extraskeletal osteosarcoma,http://purl.obolibrary.org/obo/MONDO_0002621,extraosseous osteosarcoma
+http://purl.obolibrary.org/obo/MONDO_0002676,adult fibrosarcoma,http://purl.obolibrary.org/obo/MONDO_0005164,fibrosarcoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0044878,adult germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0005040,germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0016216,adult hepatocellular carcinoma,http://purl.obolibrary.org/obo/MONDO_0007256,hepatocellular carcinoma
+http://purl.obolibrary.org/obo/MONDO_0007798,adult hypophosphatasia,http://purl.obolibrary.org/obo/MONDO_0018570,hypophosphatasia
+http://purl.obolibrary.org/obo/MONDO_0015806,adult intestinal botulism,http://purl.obolibrary.org/obo/MONDO_0015805,intestinal botulism
+http://purl.obolibrary.org/obo/MONDO_0024675,adult kidney Wilms tumor,http://purl.obolibrary.org/obo/MONDO_0019004,kidney Wilms tumor
+http://purl.obolibrary.org/obo/MONDO_0003585,adult liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma
+http://purl.obolibrary.org/obo/MONDO_0003660,adult lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma
+http://purl.obolibrary.org/obo/MONDO_0003856,adult malignant hemangiopericytoma,http://purl.obolibrary.org/obo/MONDO_0009330,"hemangiopericytoma, malignant"
+http://purl.obolibrary.org/obo/MONDO_0003692,adult malignant mesenchymoma,http://purl.obolibrary.org/obo/MONDO_0003633,malignant mesenchymoma
+http://purl.obolibrary.org/obo/MONDO_0004545,adult malignant schwannoma,http://purl.obolibrary.org/obo/MONDO_0004345,childhood malignant schwannoma
+http://purl.obolibrary.org/obo/MONDO_0002794,adult medulloblastoma,http://purl.obolibrary.org/obo/MONDO_0007959,medulloblastoma
+http://purl.obolibrary.org/obo/MONDO_0003042,adult mesenchymal chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0006853,mesenchymal chondrosarcoma
+http://purl.obolibrary.org/obo/MONDO_0003899,adult myxoid chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0003681,myxoid chondrosarcoma
+http://purl.obolibrary.org/obo/MONDO_0019260,adult neuronal ceroid lipofuscinosis,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis
+http://purl.obolibrary.org/obo/MONDO_0002543,adult oligodendroglioma,http://purl.obolibrary.org/obo/MONDO_0016695,oligodendroglioma
+http://purl.obolibrary.org/obo/MONDO_0004373,adult papillary meningioma,http://purl.obolibrary.org/obo/MONDO_0021088,papillary meningioma
+http://purl.obolibrary.org/obo/MONDO_0003248,adult pineal parenchymal tumor,http://purl.obolibrary.org/obo/MONDO_0024890,pineal parenchymal cell neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003957,adult pineoblastoma,http://purl.obolibrary.org/obo/MONDO_0016722,pineoblastoma
+http://purl.obolibrary.org/obo/MONDO_0004513,adult pleomorphic rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0017386,pleomorphic rhabdomyosarcoma
+http://purl.obolibrary.org/obo/MONDO_0020338,adult pure red cell aplasia,http://purl.obolibrary.org/obo/MONDO_0001705,pure red-cell aplasia
+http://purl.obolibrary.org/obo/MONDO_0004361,adult spinal cord ependymoma,http://purl.obolibrary.org/obo/MONDO_0003473,spinal cord ependymoma
+http://purl.obolibrary.org/obo/MONDO_0010056,adult spinal muscular atrophy,http://purl.obolibrary.org/obo/MONDO_0001516,spinal muscular atrophy
+http://purl.obolibrary.org/obo/MONDO_0003516,adult teratoma,http://purl.obolibrary.org/obo/MONDO_0002601,teratoma
+http://purl.obolibrary.org/obo/MONDO_0004013,adult vagina botryoid embryonal rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0003994,botryoid-type embryonal rhabdomyosarcoma of the vagina
+http://purl.obolibrary.org/obo/MONDO_0004385,adult xanthogranuloma,http://purl.obolibrary.org/obo/MONDO_0024617,xanthogranuloma
+http://purl.obolibrary.org/obo/MONDO_0003404,adult yolk sac tumor,http://purl.obolibrary.org/obo/MONDO_0005744,yolk sac tumor
+http://purl.obolibrary.org/obo/MONDO_0016115,bulbospinal muscular atrophy of adulthood,http://purl.obolibrary.org/obo/MONDO_0016113,bulbospinal muscular atrophy
+http://purl.obolibrary.org/obo/MONDO_0020541,maligant granulosa cell tumor of ovary,http://purl.obolibrary.org/obo/MONDO_0023283,ovarian granulosa cell tumor

--- a/src/patterns/allergic_form_of_disease.csv
+++ b/src/patterns/allergic_form_of_disease.csv
@@ -1,9 +1,11 @@
 iri,iri label,disease,disease label
-MONDO:0004784,allergic asthma,MONDO:0004979,asthma
-MONDO:0006525,allergic contact dermatitis,MONDO:0005480,contact dermatitis
-MONDO:0005271,allergic disease,MONDO:0005046,immune system disease
-MONDO:0000771,allergic respiratory disease,MONDO:0005087,respiratory system disease
-MONDO:0011786,allergic rhinitis,MONDO:0003014,rhinitis
-MONDO:0006526,allergic urticaria,MONDO:0005492,urticaria
-MONDO:0005642,atopic conjunctivitis,MONDO:0003799,conjunctivitis (disease)
-MONDO:0004980,atopic eczema,MONDO:0002406,dermatitis
+http://purl.obolibrary.org/obo/MONDO_0004784,allergic asthma,http://purl.obolibrary.org/obo/MONDO_0004979,asthma
+http://purl.obolibrary.org/obo/MONDO_0006525,allergic contact dermatitis,http://purl.obolibrary.org/obo/MONDO_0005480,contact dermatitis
+http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0021202,allergic otitis media,http://purl.obolibrary.org/obo/MONDO_0005441,otitis media (disease)
+http://purl.obolibrary.org/obo/MONDO_0000771,allergic respiratory disease,http://purl.obolibrary.org/obo/MONDO_0005087,respiratory system disease
+http://purl.obolibrary.org/obo/MONDO_0011786,allergic rhinitis,http://purl.obolibrary.org/obo/MONDO_0003014,rhinitis
+http://purl.obolibrary.org/obo/MONDO_0006526,allergic urticaria,http://purl.obolibrary.org/obo/MONDO_0005492,urticaria (disease)
+http://purl.obolibrary.org/obo/MONDO_0005642,atopic conjunctivitis,http://purl.obolibrary.org/obo/MONDO_0003799,conjunctivitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0004980,atopic eczema,http://purl.obolibrary.org/obo/MONDO_0002406,dermatitis
+http://purl.obolibrary.org/obo/MONDO_0004553,extrinsic allergic alveolitis,http://purl.obolibrary.org/obo/MONDO_0043905,pneumonitis

--- a/src/patterns/allergy.csv
+++ b/src/patterns/allergy.csv
@@ -1,22 +1,35 @@
 iri,iri label,substance,substance label
-MONDO:0000789,Atlantic cod allergy,NCBITaxon:8049,Gadus morhua
-MONDO:0000790,Atlantic salmon allergy,NCBITaxon:8030,Salmo salar
-MONDO:0000773,Timothy grass allergy,NCBITaxon:15957,Phleum pratense
-MONDO:0000779,apple allergy,NCBITaxon:3750,Malus domestica
-MONDO:0000780,apricot allergy,NCBITaxon:36596,Prunus armeniaca
-MONDO:0000794,beta-lactam allergy,CHEBI:35627,beta-lactam
-MONDO:0000800,brown shrimp allergy,FOODON:03000003
-MONDO:0000791,carp allergy,NCBITaxon:7962,Cyprinus carpio
-MONDO:0005741,egg allergy,FOODON:03420194
-MONDO:0000606,gluten allergy,FOODON:03420177
-MONDO:0000801,green mud crab allergy,FOODON:03000004
-MONDO:0000806,horned turban snail allergy,NCBITaxon:63673,Turbo cornutus
-MONDO:0000802,indian prawn allergy,FOODON:03000005
-MONDO:0000785,peach allergy,NCBITaxon:3760,Prunus persica
-MONDO:0000795,penicillin allergy,CHEBI:17334,penicillin
-MONDO:0000786,plum allergy,NCBITaxon:3758,Prunus domestica
-MONDO:0000772,pollen allergy,FOODON:03420279
-MONDO:0000793,rainbow trout allergy,NCBITaxon:8022,Oncorhynchus mykiss
-MONDO:0000803,tiger prawn allergy,NCBITaxon:6687,Penaeus monodon
-MONDO:0000787,tomato allergy,NCBITaxon:4081,Solanum lycopersicum
-MONDO:0000804,white shrimp allergy,NCBITaxon:122378,Litopenaeus schmitti
+http://purl.obolibrary.org/obo/MONDO_0000789,Atlantic cod allergy,http://purl.obolibrary.org/obo/NCBITaxon_8049,Gadus morhua
+http://purl.obolibrary.org/obo/MONDO_0000790,Atlantic salmon allergy,http://purl.obolibrary.org/obo/NCBITaxon_8030,Salmo salar
+http://purl.obolibrary.org/obo/MONDO_0000802,Indian prawn allergy,http://purl.obolibrary.org/obo/FOODON_03000005,Indian prawn
+http://purl.obolibrary.org/obo/MONDO_0000773,Timothy grass allergy,http://purl.obolibrary.org/obo/NCBITaxon_15957,Phleum pratense
+http://purl.obolibrary.org/obo/MONDO_0000779,apple allergy,http://purl.obolibrary.org/obo/NCBITaxon_3750,Malus domestica
+http://purl.obolibrary.org/obo/MONDO_0000780,apricot allergy,http://purl.obolibrary.org/obo/NCBITaxon_36596,Prunus armeniaca
+http://purl.obolibrary.org/obo/MONDO_0025518,aspirin allergy,http://purl.obolibrary.org/obo/CHEBI_15365,acetylsalicylic acid
+http://purl.obolibrary.org/obo/MONDO_0000794,beta-lactam allergy,http://purl.obolibrary.org/obo/CHEBI_35627,beta-lactam
+http://purl.obolibrary.org/obo/MONDO_0000800,brown shrimp allergy,http://purl.obolibrary.org/obo/FOODON_03000003,brown shrimp
+http://purl.obolibrary.org/obo/MONDO_0000791,carp allergy,http://purl.obolibrary.org/obo/NCBITaxon_7962,Cyprinus carpio
+http://purl.obolibrary.org/obo/MONDO_0000796,cow milk allergy (disease),http://purl.obolibrary.org/obo/FOODON_00001771,cow milk based food product
+http://purl.obolibrary.org/obo/MONDO_0000799,crustacean allergy,http://purl.obolibrary.org/obo/FOODON_00001792,crustacean food product
+http://purl.obolibrary.org/obo/MONDO_0000775,drug allergy,http://purl.obolibrary.org/obo/ECTO_0000509,exposure to drug
+http://purl.obolibrary.org/obo/MONDO_0005741,egg allergy,http://purl.obolibrary.org/obo/FOODON_03420194,egg
+http://purl.obolibrary.org/obo/MONDO_0000788,fish allergy,http://purl.obolibrary.org/obo/FOODON_00001248,fish food product
+http://purl.obolibrary.org/obo/MONDO_0002497,food allergy,http://purl.obolibrary.org/obo/FOODON_00002403,food material
+http://purl.obolibrary.org/obo/MONDO_0000606,gluten allergy,http://purl.obolibrary.org/obo/FOODON_03420177,gluten
+http://purl.obolibrary.org/obo/MONDO_0000797,goat milk allergy,http://purl.obolibrary.org/obo/FOODON_00001911,goat dairy food product
+http://purl.obolibrary.org/obo/MONDO_0000801,green mud crab allergy,http://purl.obolibrary.org/obo/FOODON_03000004,green mud crab
+http://purl.obolibrary.org/obo/MONDO_0000806,horned turban snail allergy,http://purl.obolibrary.org/obo/NCBITaxon_63673,Turbo cornutus
+http://purl.obolibrary.org/obo/MONDO_0000776,metal allergy,http://purl.obolibrary.org/obo/CHEBI_88184,metal allergen
+http://purl.obolibrary.org/obo/MONDO_0000798,mollusc allergy,http://purl.obolibrary.org/obo/FOODON_00002044,mollusc food product
+http://purl.obolibrary.org/obo/MONDO_0006872,nut allergic reaction,http://purl.obolibrary.org/obo/FOODON_03400685,022  tree nuts (tn) (ccpr)
+http://purl.obolibrary.org/obo/MONDO_0000785,peach allergy,http://purl.obolibrary.org/obo/NCBITaxon_3760,Prunus persica
+http://purl.obolibrary.org/obo/MONDO_0000795,penicillin allergy,http://purl.obolibrary.org/obo/CHEBI_17334,penicillin
+http://purl.obolibrary.org/obo/MONDO_0000786,plum allergy,http://purl.obolibrary.org/obo/NCBITaxon_3758,Prunus domestica
+http://purl.obolibrary.org/obo/MONDO_0000772,pollen allergy,http://purl.obolibrary.org/obo/FOODON_03420279,pollen
+http://purl.obolibrary.org/obo/MONDO_0000793,rainbow trout allergy,http://purl.obolibrary.org/obo/NCBITaxon_8022,Oncorhynchus mykiss
+http://purl.obolibrary.org/obo/MONDO_0025517,shrimp allergy,http://purl.obolibrary.org/obo/FOODON_00002239,shrimp food product
+http://purl.obolibrary.org/obo/MONDO_0000805,snail allergy,http://purl.obolibrary.org/obo/FOODON_00002244,snail food product
+http://purl.obolibrary.org/obo/MONDO_0000803,tiger prawn allergy,http://purl.obolibrary.org/obo/NCBITaxon_6687,Penaeus monodon
+http://purl.obolibrary.org/obo/MONDO_0000787,tomato allergy,http://purl.obolibrary.org/obo/NCBITaxon_4081,Solanum lycopersicum
+http://purl.obolibrary.org/obo/MONDO_0007021,wheat allergic disease,http://purl.obolibrary.org/obo/FOODON_00001141,wheat based food product
+http://purl.obolibrary.org/obo/MONDO_0000804,white shrimp allergy,http://purl.obolibrary.org/obo/NCBITaxon_122378,Litopenaeus schmitti

--- a/src/patterns/autoimmune.csv
+++ b/src/patterns/autoimmune.csv
@@ -1,0 +1,26 @@
+iri,iri label,disease,disease label
+http://purl.obolibrary.org/obo/MONDO_0030702,autoimmune atherosclerosis,http://purl.obolibrary.org/obo/MONDO_0005311,atherosclerosis
+http://purl.obolibrary.org/obo/MONDO_0030701,autoimmune cardiomyopathy,http://purl.obolibrary.org/obo/MONDO_0004994,cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000587,"autoimmune disease of ear, nose and throat",http://purl.obolibrary.org/obo/MONDO_0024623,otorhinolaryngologic disease
+http://purl.obolibrary.org/obo/MONDO_0031014,autoimmune gastritis,http://purl.obolibrary.org/obo/MONDO_0004966,gastritis (disease)
+http://purl.obolibrary.org/obo/MONDO_0030700,autoimmune glomerulonephritis,http://purl.obolibrary.org/obo/MONDO_0002462,glomerulonephritis (disease)
+http://purl.obolibrary.org/obo/MONDO_0020108,autoimmune hemolytic anemia,http://purl.obolibrary.org/obo/MONDO_0003664,hemolytic anemia
+http://purl.obolibrary.org/obo/MONDO_0016264,autoimmune hepatitis,http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis
+http://purl.obolibrary.org/obo/MONDO_0018242,autoimmune hypoparathyroidism (disease),http://purl.obolibrary.org/obo/MONDO_0001220,hypoparathyroidism
+http://purl.obolibrary.org/obo/MONDO_0022518,autoimmune inner ear disease,http://purl.obolibrary.org/obo/MONDO_0002467,inner ear disease
+http://purl.obolibrary.org/obo/MONDO_0017979,autoimmune lymphoproliferative syndrome,http://purl.obolibrary.org/obo/MONDO_0016537,lymphoproliferative syndrome
+http://purl.obolibrary.org/obo/MONDO_0022519,autoimmune myocarditis,http://purl.obolibrary.org/obo/MONDO_0004496,myocarditis
+http://purl.obolibrary.org/obo/MONDO_0000774,autoimmune neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy
+http://purl.obolibrary.org/obo/MONDO_0021950,autoimmune oophoritis,http://purl.obolibrary.org/obo/MONDO_0006877,oophoritis
+http://purl.obolibrary.org/obo/MONDO_0031013,autoimmune optic neuritis,http://purl.obolibrary.org/obo/MONDO_0005885,optic neuritis
+http://purl.obolibrary.org/obo/MONDO_0015175,autoimmune pancreatitis,http://purl.obolibrary.org/obo/MONDO_0004982,pancreatitis
+http://purl.obolibrary.org/obo/MONDO_0017278,autoimmune polyendocrinopathy,http://purl.obolibrary.org/obo/MONDO_0015126,polyendocrinopathy
+http://purl.obolibrary.org/obo/MONDO_0044338,autoimmune primary ovarian failure,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure
+http://purl.obolibrary.org/obo/MONDO_0012579,autoimmune pulmonary alveolar proteinosis,http://purl.obolibrary.org/obo/MONDO_0001437,pulmonary alveolar proteinosis
+http://purl.obolibrary.org/obo/MONDO_0019098,autoimmune thrombocytopenia,http://purl.obolibrary.org/obo/MONDO_0002049,thrombocytopenia
+http://purl.obolibrary.org/obo/MONDO_0025513,autoimmune urticaria,http://purl.obolibrary.org/obo/MONDO_0005492,urticaria (disease)
+http://purl.obolibrary.org/obo/MONDO_0031012,autoimmune uveitis,http://purl.obolibrary.org/obo/MONDO_0020283,uveitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0030703,autoimmune vasculitis,http://purl.obolibrary.org/obo/MONDO_0018882,vasculitis
+http://purl.obolibrary.org/obo/MONDO_0008383,rheumatoid arthritis,http://purl.obolibrary.org/obo/MONDO_0005578,arthritis
+http://purl.obolibrary.org/obo/MONDO_0015939,systemic autoimmune disease,http://purl.obolibrary.org/obo/MONDO_0015938,systemic disease

--- a/src/patterns/autoimmune_inflammation.csv
+++ b/src/patterns/autoimmune_inflammation.csv
@@ -1,2 +1,2 @@
 iri,iri label,location,location label
-MONDO:0005623,autoimmune thyroid disease,UBERON:0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0005623,autoimmune thyroid disease,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland

--- a/src/patterns/autosomal_dominant.csv
+++ b/src/patterns/autosomal_dominant.csv
@@ -1,46 +1,53 @@
 iri,iri label,disease,disease label
-MONDO:0007086,autosomal dominant Alport syndrome,MONDO:0018965,Alport syndrome
-MONDO:0007524,"autosomal dominant Ehlers-Danlos syndrome, vascular type",MONDO:0017314,"Ehlers-Danlos syndrome, vascular type"
-MONDO:0020336,autosomal dominant Emery-Dreifuss muscular dystrophy,MONDO:0016830,Emery-Dreifuss muscular dystrophy
-MONDO:0007478,autosomal dominant Kenny-Caffey syndrome,MONDO:0016516,Kenny-Caffey syndrome
-MONDO:0007779,autosomal dominant Opitz G/BBB syndrome,MONDO:0017138,Opitz G/BBB syndrome
-MONDO:0007232,autosomal dominant brachyolmia,MONDO:0015262,brachyolmia
-MONDO:0008048,autosomal dominant centronuclear myopathy,MONDO:0018947,centronuclear myopathy
-MONDO:0020380,autosomal dominant cerebellar ataxia,MONDO:0000437,cerebellar ataxia
-MONDO:0007321,autosomal dominant chondrodysplasia punctata,MONDO:0019701,chondrodysplasia punctata
-MONDO:0015445,autosomal dominant coarctation of aorta,MONDO:0007345,aorta coarctation
-MONDO:0015087,autosomal dominant complex spastic paraplegia,MONDO:0015150,complex hereditary spastic paraplegia
-MONDO:0019571,autosomal dominant cutis laxa,MONDO:0016175,cutis laxa
-MONDO:0007420,autosomal dominant deafness-onychodystrophy syndrome,MONDO:0017922,deafness-onychodystrophy syndrome
-MONDO:0000426,autosomal dominant disease,MONDO:0000001,disease
-MONDO:0020095,autosomal dominant disease associated with focal palmoplantar keratoderma as a major feature,MONDO:0017674,disease with focal palmoplantar keratoderma as a major feature
-MONDO:0020094,autosomal dominant disease with diffuse palmoplantar keratoderma as a major feature,MONDO:0017669,disease with diffuse palmoplantar keratoderma as a major feature
-MONDO:0015362,autosomal dominant distal hereditary motor neuropathy,MONDO:0018894,distal hereditary motor neuropathy
-MONDO:0016108,autosomal dominant distal myopathy,MONDO:0018949,distal myopathy
-MONDO:0008368,autosomal dominant distal renal tubular acidosis,MONDO:0015827,distal renal tubular acidosis (disease)
-MONDO:0015365,autosomal dominant hereditary sensory and autonomic neuropathy,MONDO:0015364,hereditary sensory and autonomic neuropathy
-MONDO:0015884,autosomal dominant hypohidrotic ectodermal dysplasia,MONDO:0016535,hypohidrotic ectodermal dysplasia
-MONDO:0008660,autosomal dominant hypophosphatemic rickets,MONDO:0000044,hypophosphatemic rickets
-MONDO:0019548,autosomal dominant intermediate Charcot-Marie-tooth disease,MONDO:0018778,intermediate Charcot-Marie-tooth disease
-MONDO:0020093,autosomal dominant isolated diffuse palmoplantar keratoderma,MONDO:0017667,isolated diffuse palmoplantar keratoderma
-MONDO:0007848,autosomal dominant keratitis,MONDO:0003085,keratitis
-MONDO:0007850,autosomal dominant keratitis-ichthyosis-deafness syndrome,MONDO:0018781,KID syndrome
-MONDO:0015151,autosomal dominant limb-girdle muscular dystrophy,MONDO:0016971,limb-girdle muscular dystrophy
-MONDO:0007988,autosomal dominant microcephaly,MONDO:0001149,microcephaly (disease)
-MONDO:0008338,autosomal dominant multiple pterygium syndrome,MONDO:0017415,multiple pterygium syndrome
-MONDO:0008046,autosomal dominant myoglobinuria,MONDO:0000866,myoglobinuria
-MONDO:0015802,autosomal dominant non-syndromic intellectual disability,MONDO:0000509,non-syndromic intellectual disability
-MONDO:0019587,autosomal dominant nonsyndromic deafness,MONDO:0019497,nonsyndromic deafness
-MONDO:0008123,autosomal dominant omodysplasia,MONDO:0017136,omodysplasia
-MONDO:0020250,autosomal dominant optic atrophy,MONDO:0003608,optic atrophy
-MONDO:0007334,autosomal dominant popliteal pterygium syndrome,MONDO:0017435,popliteal pterygium syndrome
-MONDO:0008003,autosomal dominant progressive external ophthalmoplegia,MONDO:0005181,progressive external ophthalmoplegia
-MONDO:0017829,autosomal dominant proximal renal tubular acidosis,MONDO:0008369,proximal renal tubular acidosis
-MONDO:0016224,autosomal dominant proximal spinal muscular atrophy,MONDO:0019079,proximal spinal muscular atrophy
-MONDO:0015088,autosomal dominant pure spastic paraplegia,MONDO:0015149,pure hereditary spastic paraplegia
-MONDO:0016202,autosomal dominant rhegmatogenous retinal detachment,MONDO:0005464,rhegmatogenous retinal detachment
-MONDO:0016599,autosomal dominant secondary polycythemia,MONDO:0020115,secondary polycythemia
-MONDO:0008742,autosomal dominant severe congenital neutropenia,MONDO:0018542,severe congenital neutropenia
-MONDO:0008422,autosomal dominant sideroblastic anemia,MONDO:0015194,sideroblastic anemia
-MONDO:0017846,autosomal dominant spastic ataxia,MONDO:0017845,spastic ataxia
-MONDO:0015826,autosomal dominant spondylocostal dysostosis,MONDO:0000359,spondylocostal dysostosis
+http://purl.obolibrary.org/obo/MONDO_0007086,autosomal dominant Alport syndrome,http://purl.obolibrary.org/obo/MONDO_0018965,Alport syndrome
+http://purl.obolibrary.org/obo/MONDO_0007524,"autosomal dominant Ehlers-Danlos syndrome, vascular type",http://purl.obolibrary.org/obo/MONDO_0017314,"Ehlers-Danlos syndrome, vascular type"
+http://purl.obolibrary.org/obo/MONDO_0020336,autosomal dominant Emery-Dreifuss muscular dystrophy,http://purl.obolibrary.org/obo/MONDO_0016830,Emery-Dreifuss muscular dystrophy
+http://purl.obolibrary.org/obo/MONDO_0007478,autosomal dominant Kenny-Caffey syndrome,http://purl.obolibrary.org/obo/MONDO_0016516,Kenny-Caffey syndrome
+http://purl.obolibrary.org/obo/MONDO_0007779,autosomal dominant Opitz G/BBB syndrome,http://purl.obolibrary.org/obo/MONDO_0017138,Opitz G/BBB syndrome
+http://purl.obolibrary.org/obo/MONDO_0008389,autosomal dominant Robinow syndrome,http://purl.obolibrary.org/obo/MONDO_0019978,Robinow syndrome
+http://purl.obolibrary.org/obo/MONDO_0007232,autosomal dominant brachyolmia,http://purl.obolibrary.org/obo/MONDO_0015262,brachyolmia
+http://purl.obolibrary.org/obo/MONDO_0008048,autosomal dominant centronuclear myopathy,http://purl.obolibrary.org/obo/MONDO_0018947,centronuclear myopathy
+http://purl.obolibrary.org/obo/MONDO_0020380,autosomal dominant cerebellar ataxia,http://purl.obolibrary.org/obo/MONDO_0000437,cerebellar ataxia
+http://purl.obolibrary.org/obo/MONDO_0007321,autosomal dominant chondrodysplasia punctata,http://purl.obolibrary.org/obo/MONDO_0019701,chondrodysplasia punctata
+http://purl.obolibrary.org/obo/MONDO_0015445,autosomal dominant coarctation of aorta,http://purl.obolibrary.org/obo/MONDO_0007345,aorta coarctation
+http://purl.obolibrary.org/obo/MONDO_0015087,autosomal dominant complex spastic paraplegia,http://purl.obolibrary.org/obo/MONDO_0015150,complex hereditary spastic paraplegia
+http://purl.obolibrary.org/obo/MONDO_0019571,autosomal dominant cutis laxa,http://purl.obolibrary.org/obo/MONDO_0016175,cutis laxa
+http://purl.obolibrary.org/obo/MONDO_0007420,autosomal dominant deafness-onychodystrophy syndrome,http://purl.obolibrary.org/obo/MONDO_0017922,deafness-onychodystrophy syndrome
+http://purl.obolibrary.org/obo/MONDO_0000426,autosomal dominant disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0020095,autosomal dominant disease associated with focal palmoplantar keratoderma as a major feature,http://purl.obolibrary.org/obo/MONDO_0017674,disease with focal palmoplantar keratoderma as a major feature
+http://purl.obolibrary.org/obo/MONDO_0020094,autosomal dominant disease with diffuse palmoplantar keratoderma as a major feature,http://purl.obolibrary.org/obo/MONDO_0017669,disease with diffuse palmoplantar keratoderma as a major feature
+http://purl.obolibrary.org/obo/MONDO_0015362,autosomal dominant distal hereditary motor neuropathy,http://purl.obolibrary.org/obo/MONDO_0018894,distal hereditary motor neuropathy
+http://purl.obolibrary.org/obo/MONDO_0016108,autosomal dominant distal myopathy,http://purl.obolibrary.org/obo/MONDO_0018949,distal myopathy
+http://purl.obolibrary.org/obo/MONDO_0008368,autosomal dominant distal renal tubular acidosis,http://purl.obolibrary.org/obo/MONDO_0015827,distal renal tubular acidosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0015365,autosomal dominant hereditary sensory and autonomic neuropathy,http://purl.obolibrary.org/obo/MONDO_0015364,hereditary sensory and autonomic neuropathy
+http://purl.obolibrary.org/obo/MONDO_0007818,autosomal dominant hyper-IgE syndrome,http://purl.obolibrary.org/obo/MONDO_0018037,hyper-IgE syndrome
+http://purl.obolibrary.org/obo/MONDO_0015884,autosomal dominant hypohidrotic ectodermal dysplasia,http://purl.obolibrary.org/obo/MONDO_0016535,hypohidrotic ectodermal dysplasia
+http://purl.obolibrary.org/obo/MONDO_0008660,autosomal dominant hypophosphatemic rickets,http://purl.obolibrary.org/obo/MONDO_0000044,hereditary hypophosphatemic rickets
+http://purl.obolibrary.org/obo/MONDO_0007810,autosomal dominant ichthyosis vulgaris,http://purl.obolibrary.org/obo/MONDO_0024304,ichthyosis vulgaris
+http://purl.obolibrary.org/obo/MONDO_0019548,autosomal dominant intermediate Charcot-Marie-tooth disease,http://purl.obolibrary.org/obo/MONDO_0018778,intermediate Charcot-Marie-tooth disease
+http://purl.obolibrary.org/obo/MONDO_0020093,autosomal dominant isolated diffuse palmoplantar keratoderma,http://purl.obolibrary.org/obo/MONDO_0017667,isolated diffuse palmoplantar keratoderma
+http://purl.obolibrary.org/obo/MONDO_0007848,autosomal dominant keratitis,http://purl.obolibrary.org/obo/MONDO_0003085,keratitis
+http://purl.obolibrary.org/obo/MONDO_0007850,autosomal dominant keratitis-ichthyosis-deafness syndrome,http://purl.obolibrary.org/obo/MONDO_0018781,KID syndrome
+http://purl.obolibrary.org/obo/MONDO_0015151,autosomal dominant limb-girdle muscular dystrophy,http://purl.obolibrary.org/obo/MONDO_0016971,limb-girdle muscular dystrophy
+http://purl.obolibrary.org/obo/MONDO_0008338,autosomal dominant multiple pterygium syndrome,http://purl.obolibrary.org/obo/MONDO_0017415,multiple pterygium syndrome
+http://purl.obolibrary.org/obo/MONDO_0008046,autosomal dominant myoglobinuria,http://purl.obolibrary.org/obo/MONDO_0000866,myoglobinuria
+http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0000509,non-syndromic intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://purl.obolibrary.org/obo/MONDO_0019497,nonsyndromic genetic deafness
+http://purl.obolibrary.org/obo/MONDO_0040654,autosomal dominant oculocutaneous albinism,http://purl.obolibrary.org/obo/MONDO_0018910,oculocutaneous albinism
+http://purl.obolibrary.org/obo/MONDO_0008123,autosomal dominant omodysplasia,http://purl.obolibrary.org/obo/MONDO_0017136,omodysplasia
+http://purl.obolibrary.org/obo/MONDO_0020250,autosomal dominant optic atrophy,http://purl.obolibrary.org/obo/MONDO_0003608,optic atrophy
+http://purl.obolibrary.org/obo/MONDO_0007334,autosomal dominant popliteal pterygium syndrome,http://purl.obolibrary.org/obo/MONDO_0017435,popliteal pterygium syndrome
+http://purl.obolibrary.org/obo/MONDO_0008003,autosomal dominant progressive external ophthalmoplegia,http://purl.obolibrary.org/obo/MONDO_0005181,progressive external ophthalmoplegia
+http://purl.obolibrary.org/obo/MONDO_0017829,autosomal dominant proximal renal tubular acidosis,http://purl.obolibrary.org/obo/MONDO_0008369,proximal renal tubular acidosis
+http://purl.obolibrary.org/obo/MONDO_0016224,autosomal dominant proximal spinal muscular atrophy,http://purl.obolibrary.org/obo/MONDO_0019079,proximal spinal muscular atrophy
+http://purl.obolibrary.org/obo/MONDO_0015088,autosomal dominant pure spastic paraplegia,http://purl.obolibrary.org/obo/MONDO_0015149,pure hereditary spastic paraplegia
+http://purl.obolibrary.org/obo/MONDO_0016202,autosomal dominant rhegmatogenous retinal detachment,http://purl.obolibrary.org/obo/MONDO_0005464,rhegmatogenous retinal detachment
+http://purl.obolibrary.org/obo/MONDO_0016599,autosomal dominant secondary polycythemia,http://purl.obolibrary.org/obo/MONDO_0020115,secondary polycythemia
+http://purl.obolibrary.org/obo/MONDO_0008742,autosomal dominant severe congenital neutropenia,http://purl.obolibrary.org/obo/MONDO_0018542,severe congenital neutropenia
+http://purl.obolibrary.org/obo/MONDO_0008422,autosomal dominant sideroblastic anemia,http://purl.obolibrary.org/obo/MONDO_0015194,sideroblastic anemia
+http://purl.obolibrary.org/obo/MONDO_0017846,autosomal dominant spastic ataxia,http://purl.obolibrary.org/obo/MONDO_0017845,spastic ataxia
+http://purl.obolibrary.org/obo/MONDO_0015826,autosomal dominant spondylocostal dysostosis,http://purl.obolibrary.org/obo/MONDO_0000359,spondylocostal dysostosis
+http://purl.obolibrary.org/obo/MONDO_0007447,autosomal dominant vibratory urticaria,http://purl.obolibrary.org/obo/MONDO_0006618,vibratory urticaria
+http://purl.obolibrary.org/obo/MONDO_0008382,"retinoschisis, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0004579,retinoschisis
+http://purl.obolibrary.org/obo/MONDO_0008474,"spondyloepiphyseal dysplasia tarda, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0019667,spondyloepiphyseal dysplasia tarda
+http://purl.obolibrary.org/obo/MONDO_0012868,"thrombophilia due to protein S deficiency, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0019144,hereditary thrombophilia due to congenital protein S deficiency

--- a/src/patterns/autosomal_recessive.csv
+++ b/src/patterns/autosomal_recessive.csv
@@ -1,43 +1,47 @@
 iri,iri label,disease,disease label
-MONDO:0008719,"acrorenal syndrome, autosomal recessive",MONDO:0007059,acrorenal syndrome
-MONDO:0008762,autosomal recessive Alport syndrome,MONDO:0018965,Alport syndrome
-MONDO:0002014,"autosomal recessive Ehlers-Danlos syndrome, vascular type",MONDO:0017314,"Ehlers-Danlos syndrome, vascular type"
-MONDO:0008406,autosomal recessive Emery-Dreifuss muscular dystrophy,MONDO:0016830,Emery-Dreifuss muscular dystrophy
-MONDO:0009486,autosomal recessive Kenny-Caffey syndrome,MONDO:0016516,Kenny-Caffey syndrome
-MONDO:0009999,autosomal recessive Robinow syndrome,MONDO:0019978,Robinow syndrome
-MONDO:0016647,autosomal recessive Stickler syndrome,MONDO:0019354,Stickler syndrome
-MONDO:0019601,autosomal recessive axonal hereditary motor and sensory neuropathy,MONDO:0018775,axonal hereditary motor and sensory neuropathy
-MONDO:0018662,autosomal recessive brachyolmia,MONDO:0015262,brachyolmia
-MONDO:0015705,autosomal recessive centronuclear myopathy,MONDO:0018947,centronuclear myopathy
-MONDO:0015244,autosomal recessive cerebellar ataxia,MONDO:0000437,cerebellar ataxia
-MONDO:0015089,autosomal recessive complex spastic paraplegia,MONDO:0015150,complex hereditary spastic paraplegia
-MONDO:0006025,autosomal recessive disease,MONDO:0000001,disease
-MONDO:0020097,autosomal recessive disease with focal palmoplantar keratoderma as a major feature,MONDO:0017674,disease with focal palmoplantar keratoderma as a major feature
-MONDO:0015363,autosomal recessive distal hereditary motor neuropathy,MONDO:0018894,distal hereditary motor neuropathy
-MONDO:0016109,autosomal recessive distal myopathy,MONDO:0018949,distal myopathy
-MONDO:0018440,autosomal recessive distal renal tubular acidosis,MONDO:0015827,distal renal tubular acidosis (disease)
-MONDO:0011551,autosomal recessive dopa-responsive dystonia,MONDO:0016812,Dopa-responsive dystonia
-MONDO:0009572,autosomal recessive familial Mediterranean fever,MONDO:0018088,familial Mediterranean fever
-MONDO:0015366,autosomal recessive hereditary sensory and autonomic neuropathy,MONDO:0015364,hereditary sensory and autonomic neuropathy
-MONDO:0009356,autosomal recessive humeroradial synostosis,MONDO:0007737,humeroradial synostosis (disease)
-MONDO:0016619,autosomal recessive hypohidrotic ectodermal dysplasia,MONDO:0016535,hypohidrotic ectodermal dysplasia
-MONDO:0017324,autosomal recessive hypophosphatemic rickets,MONDO:0000044,hypophosphatemic rickets
-MONDO:0017058,autosomal recessive intermediate Charcot-Marie-tooth disease,MONDO:0018778,intermediate Charcot-Marie-tooth disease
-MONDO:0020096,autosomal recessive isolated diffuse palmoplantar keratoderma,MONDO:0017667,isolated diffuse palmoplantar keratoderma
-MONDO:0015152,autosomal recessive limb-girdle muscular dystrophy,MONDO:0016971,limb-girdle muscular dystrophy
-MONDO:0009926,autosomal recessive multiple pterygium syndrome,MONDO:0017415,multiple pterygium syndrome
-MONDO:0019502,autosomal recessive non-syndromic intellectual disability,MONDO:0000509,non-syndromic intellectual disability
-MONDO:0019588,autosomal recessive nonsyndromic deafness,MONDO:0019497,nonsyndromic deafness
-MONDO:0009779,autosomal recessive omodysplasia,MONDO:0017136,omodysplasia
-MONDO:0016810,autosomal recessive progressive external ophthalmoplegia,MONDO:0005181,progressive external ophthalmoplegia
-MONDO:0011422,autosomal recessive proximal renal tubular acidosis,MONDO:0008369,proximal renal tubular acidosis
-MONDO:0015090,autosomal recessive pure spastic paraplegia,MONDO:0015149,pure hereditary spastic paraplegia
-MONDO:0016828,autosomal recessive sideroblastic anemia,MONDO:0015194,sideroblastic anemia
-MONDO:0017847,autosomal recessive spastic ataxia,MONDO:0017845,spastic ataxia
-MONDO:0010180,autosomal recessive spondylocostal dysostosis,MONDO:0000359,spondylocostal dysostosis
-MONDO:0008866,"bifid nose, autosomal recessive",MONDO:0000110,bifid nose
-MONDO:0009035,"craniometaphyseal dysplasia, autosomal recessive",MONDO:0015465,craniometaphyseal dysplasia
-MONDO:0009715,"myotonia congenita, autosomal recessive",MONDO:0009710,myotonia congenita
-MONDO:0009768,"oculodentodigital dysplasia, autosomal recessive",MONDO:0008111,oculodentodigital dysplasia
-MONDO:0009097,"persistent hyperplastic primary vitreous, autosomal recessive",MONDO:0019631,persistent hyperplastic primary vitreous
-MONDO:0010072,"spondyloepiphyseal dysplasia tarda, autosomal recessive",MONDO:0019667,spondyloepiphyseal dysplasia tarda
+http://purl.obolibrary.org/obo/MONDO_0008719,"acrorenal syndrome, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0007059,acrorenal syndrome
+http://purl.obolibrary.org/obo/MONDO_0008762,autosomal recessive Alport syndrome,http://purl.obolibrary.org/obo/MONDO_0018965,Alport syndrome
+http://purl.obolibrary.org/obo/MONDO_0002014,"autosomal recessive Ehlers-Danlos syndrome, vascular type",http://purl.obolibrary.org/obo/MONDO_0017314,"Ehlers-Danlos syndrome, vascular type"
+http://purl.obolibrary.org/obo/MONDO_0008406,autosomal recessive Emery-Dreifuss muscular dystrophy,http://purl.obolibrary.org/obo/MONDO_0016830,Emery-Dreifuss muscular dystrophy
+http://purl.obolibrary.org/obo/MONDO_0009486,autosomal recessive Kenny-Caffey syndrome,http://purl.obolibrary.org/obo/MONDO_0016516,Kenny-Caffey syndrome
+http://purl.obolibrary.org/obo/MONDO_0009999,autosomal recessive Robinow syndrome,http://purl.obolibrary.org/obo/MONDO_0019978,Robinow syndrome
+http://purl.obolibrary.org/obo/MONDO_0016647,autosomal recessive Stickler syndrome,http://purl.obolibrary.org/obo/MONDO_0019354,Stickler syndrome
+http://purl.obolibrary.org/obo/MONDO_0019601,autosomal recessive axonal hereditary motor and sensory neuropathy,http://purl.obolibrary.org/obo/MONDO_0018775,axonal hereditary motor and sensory neuropathy
+http://purl.obolibrary.org/obo/MONDO_0018662,autosomal recessive brachyolmia,http://purl.obolibrary.org/obo/MONDO_0015262,brachyolmia
+http://purl.obolibrary.org/obo/MONDO_0015705,autosomal recessive centronuclear myopathy,http://purl.obolibrary.org/obo/MONDO_0018947,centronuclear myopathy
+http://purl.obolibrary.org/obo/MONDO_0015244,autosomal recessive cerebellar ataxia,http://purl.obolibrary.org/obo/MONDO_0000437,cerebellar ataxia
+http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://purl.obolibrary.org/obo/MONDO_0015150,complex hereditary spastic paraplegia
+http://purl.obolibrary.org/obo/MONDO_0017265,autosomal recessive congenital ichthyosis,http://purl.obolibrary.org/obo/MONDO_0015947,inherited ichthyosis
+http://purl.obolibrary.org/obo/MONDO_0006025,autosomal recessive disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0020097,autosomal recessive disease with focal palmoplantar keratoderma as a major feature,http://purl.obolibrary.org/obo/MONDO_0017674,disease with focal palmoplantar keratoderma as a major feature
+http://purl.obolibrary.org/obo/MONDO_0015363,autosomal recessive distal hereditary motor neuropathy,http://purl.obolibrary.org/obo/MONDO_0018894,distal hereditary motor neuropathy
+http://purl.obolibrary.org/obo/MONDO_0016109,autosomal recessive distal myopathy,http://purl.obolibrary.org/obo/MONDO_0018949,distal myopathy
+http://purl.obolibrary.org/obo/MONDO_0018440,autosomal recessive distal renal tubular acidosis,http://purl.obolibrary.org/obo/MONDO_0015827,distal renal tubular acidosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0011551,autosomal recessive dopa-responsive dystonia,http://purl.obolibrary.org/obo/MONDO_0016812,dopa-responsive dystonia
+http://purl.obolibrary.org/obo/MONDO_0009572,autosomal recessive familial Mediterranean fever,http://purl.obolibrary.org/obo/MONDO_0018088,familial Mediterranean fever
+http://purl.obolibrary.org/obo/MONDO_0015366,autosomal recessive hereditary sensory and autonomic neuropathy,http://purl.obolibrary.org/obo/MONDO_0015364,hereditary sensory and autonomic neuropathy
+http://purl.obolibrary.org/obo/MONDO_0009356,autosomal recessive humeroradial synostosis,http://purl.obolibrary.org/obo/MONDO_0007737,humeroradial synostosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0016619,autosomal recessive hypohidrotic ectodermal dysplasia,http://purl.obolibrary.org/obo/MONDO_0016535,hypohidrotic ectodermal dysplasia
+http://purl.obolibrary.org/obo/MONDO_0017324,autosomal recessive hypophosphatemic rickets,http://purl.obolibrary.org/obo/MONDO_0000044,hereditary hypophosphatemic rickets
+http://purl.obolibrary.org/obo/MONDO_0007749,autosomal recessive infantile hypercalcemia,http://purl.obolibrary.org/obo/MONDO_0000212,"hypercalcemia, infantile"
+http://purl.obolibrary.org/obo/MONDO_0017058,autosomal recessive intermediate Charcot-Marie-tooth disease,http://purl.obolibrary.org/obo/MONDO_0018778,intermediate Charcot-Marie-tooth disease
+http://purl.obolibrary.org/obo/MONDO_0020096,autosomal recessive isolated diffuse palmoplantar keratoderma,http://purl.obolibrary.org/obo/MONDO_0017667,isolated diffuse palmoplantar keratoderma
+http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://purl.obolibrary.org/obo/MONDO_0016971,limb-girdle muscular dystrophy
+http://purl.obolibrary.org/obo/MONDO_0009926,autosomal recessive multiple pterygium syndrome,http://purl.obolibrary.org/obo/MONDO_0017415,multiple pterygium syndrome
+http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0000509,non-syndromic intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://purl.obolibrary.org/obo/MONDO_0019497,nonsyndromic genetic deafness
+http://purl.obolibrary.org/obo/MONDO_0040653,autosomal recessive ocular albinism,http://purl.obolibrary.org/obo/MONDO_0017304,ocular albinism (disease)
+http://purl.obolibrary.org/obo/MONDO_0009779,autosomal recessive omodysplasia,http://purl.obolibrary.org/obo/MONDO_0017136,omodysplasia
+http://purl.obolibrary.org/obo/MONDO_0016810,autosomal recessive progressive external ophthalmoplegia,http://purl.obolibrary.org/obo/MONDO_0005181,progressive external ophthalmoplegia
+http://purl.obolibrary.org/obo/MONDO_0011422,autosomal recessive proximal renal tubular acidosis,http://purl.obolibrary.org/obo/MONDO_0008369,proximal renal tubular acidosis
+http://purl.obolibrary.org/obo/MONDO_0015090,autosomal recessive pure spastic paraplegia,http://purl.obolibrary.org/obo/MONDO_0015149,pure hereditary spastic paraplegia
+http://purl.obolibrary.org/obo/MONDO_0016828,autosomal recessive sideroblastic anemia,http://purl.obolibrary.org/obo/MONDO_0015194,sideroblastic anemia
+http://purl.obolibrary.org/obo/MONDO_0017847,autosomal recessive spastic ataxia,http://purl.obolibrary.org/obo/MONDO_0017845,spastic ataxia
+http://purl.obolibrary.org/obo/MONDO_0010180,autosomal recessive spondylocostal dysostosis,http://purl.obolibrary.org/obo/MONDO_0000359,spondylocostal dysostosis
+http://purl.obolibrary.org/obo/MONDO_0008866,"bifid nose, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0000110,bifid nose
+http://purl.obolibrary.org/obo/MONDO_0009035,"craniometaphyseal dysplasia, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0015465,craniometaphyseal dysplasia
+http://purl.obolibrary.org/obo/MONDO_0011679,"craniosynostosis syndrome, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis
+http://purl.obolibrary.org/obo/MONDO_0009715,"myotonia congenita, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0009710,myotonia congenita
+http://purl.obolibrary.org/obo/MONDO_0009768,"oculodentodigital dysplasia, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0008111,oculodentodigital dysplasia
+http://purl.obolibrary.org/obo/MONDO_0009097,"persistent hyperplastic primary vitreous, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0019631,persistent hyperplastic primary vitreous
+http://purl.obolibrary.org/obo/MONDO_0010072,"spondyloepiphyseal dysplasia tarda, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0019667,spondyloepiphyseal dysplasia tarda

--- a/src/patterns/basis_in_disruption_of_process.csv
+++ b/src/patterns/basis_in_disruption_of_process.csv
@@ -1,4 +1,56 @@
 iri,iri label,process,process label
-MONDO:0017740,disorder of protein N-glycosylation,GO:0006487,protein N-linked glycosylation
-MONDO:0017741,disorder of protein O-glycosylation,GO:0006493,protein O-linked glycosylation
-MONDO:0002145,sex differentiation disease,GO:0007548,sex differentiation
+http://purl.obolibrary.org/obo/MONDO_0012996,AGAT deficiency,http://purl.obolibrary.org/obo/GO_0015068,glycine amidinotransferase activity
+http://purl.obolibrary.org/obo/MONDO_0021190,DNA repair disease,http://purl.obolibrary.org/obo/GO_0006281,DNA repair
+http://purl.obolibrary.org/obo/MONDO_0018274,GM3 synthase deficiency,http://purl.obolibrary.org/obo/GO_0047291,"lactosylceramide alpha-2,3-sialyltransferase activity"
+http://purl.obolibrary.org/obo/MONDO_0021060,RASopathy,http://purl.obolibrary.org/obo/GO_0007265,Ras protein signal transduction
+http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease,http://purl.obolibrary.org/obo/GO_0016068,type I hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0017779,alpha-N-acetylgalactosaminidase deficiency,http://purl.obolibrary.org/obo/GO_0008456,alpha-N-acetylgalactosaminidase activity
+http://purl.obolibrary.org/obo/MONDO_0037871,amino acid metabolism disease,http://purl.obolibrary.org/obo/GO_0006520,cellular amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0024422,auditory perceptual disorders,http://purl.obolibrary.org/obo/GO_0007605,sensory perception of sound
+http://purl.obolibrary.org/obo/MONDO_0022606,branchial arch disease,http://purl.obolibrary.org/obo/GO_0060037,pharyngeal system development
+http://purl.obolibrary.org/obo/MONDO_0037792,carbohydrate metabolism disease,http://purl.obolibrary.org/obo/GO_0005975,carbohydrate metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045015,carbohydrate transport disease,http://purl.obolibrary.org/obo/GO_0008643,carbohydrate transport
+http://purl.obolibrary.org/obo/MONDO_0021016,channelopathy,http://purl.obolibrary.org/obo/GO_0005216,ion channel activity
+http://purl.obolibrary.org/obo/MONDO_0045017,cholesterol biosynthetic process disease,http://purl.obolibrary.org/obo/GO_0006695,cholesterol biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0045016,cholesterol catabolic process disease,http://purl.obolibrary.org/obo/GO_0006707,cholesterol catabolic process
+http://purl.obolibrary.org/obo/MONDO_0045008,cholesterol metabolism disease,http://purl.obolibrary.org/obo/GO_0008203,cholesterol metabolic process
+http://purl.obolibrary.org/obo/MONDO_0003832,complement deficiency,http://purl.obolibrary.org/obo/GO_0006956,complement activation
+http://purl.obolibrary.org/obo/MONDO_0024239,congenital anomaly of cardiovascular system,http://purl.obolibrary.org/obo/GO_0072358,cardiovascular system development
+http://purl.obolibrary.org/obo/MONDO_0019512,congenital heart malformation,http://purl.obolibrary.org/obo/GO_0007507,heart development
+http://purl.obolibrary.org/obo/MONDO_0045018,creatine biosynthetic process disease,http://purl.obolibrary.org/obo/GO_0006601,creatine biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0022918,cytokine deficiency,http://purl.obolibrary.org/obo/GO_0005125,cytokine activity
+http://purl.obolibrary.org/obo/MONDO_0022919,cytokine receptor deficiency,http://purl.obolibrary.org/obo/GO_0004896,cytokine receptor activity
+http://purl.obolibrary.org/obo/MONDO_0022953,delta-1-pyrroline-5-carboxylate dehydrogenase deficiency,http://purl.obolibrary.org/obo/GO_0003842,1-pyrroline-5-carboxylate dehydrogenase activity
+http://purl.obolibrary.org/obo/MONDO_0019755,developmental defect during embryogenesis,http://purl.obolibrary.org/obo/GO_0048598,embryonic morphogenesis
+http://purl.obolibrary.org/obo/MONDO_0009862,dihydropteridine reductase deficiency,http://purl.obolibrary.org/obo/GO_0004155,"6,7-dihydropteridine reductase activity"
+http://purl.obolibrary.org/obo/MONDO_0011610,dimethylglycine dehydrogenase deficiency,http://purl.obolibrary.org/obo/GO_0047865,dimethylglycine dehydrogenase activity
+http://purl.obolibrary.org/obo/MONDO_0024321,disorder of GPI anchor biosynthesis,http://purl.obolibrary.org/obo/GO_0006506,GPI anchor biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0042970,disorder of glutamate decarboxylase,http://purl.obolibrary.org/obo/GO_0004351,glutamate decarboxylase activity
+http://purl.obolibrary.org/obo/MONDO_0024322,disorder of glycosylation,http://purl.obolibrary.org/obo/GO_0070085,glycosylation
+http://purl.obolibrary.org/obo/MONDO_0044209,disorder of lectin complement activation pathway,http://purl.obolibrary.org/obo/GO_0001867,"complement activation, lectin pathway"
+http://purl.obolibrary.org/obo/MONDO_0045022,disorder of organic acid metabolism,http://purl.obolibrary.org/obo/GO_0006082,organic acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017740,disorder of protein N-glycosylation,http://purl.obolibrary.org/obo/GO_0006487,protein N-linked glycosylation
+http://purl.obolibrary.org/obo/MONDO_0017741,disorder of protein O-glycosylation,http://purl.obolibrary.org/obo/GO_0006493,protein O-linked glycosylation
+http://purl.obolibrary.org/obo/MONDO_0037807,glycerol metabolism disease,http://purl.obolibrary.org/obo/GO_0006071,glycerol metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045020,glycine metabolism disease,http://purl.obolibrary.org/obo/GO_0006544,glycine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045010,glycoprotein metabolism disease,http://purl.obolibrary.org/obo/GO_0009100,glycoprotein metabolic process
+http://purl.obolibrary.org/obo/MONDO_0012999,guanidinoacetate methyltransferase deficiency,http://purl.obolibrary.org/obo/GO_0030731,guanidinoacetate N-methyltransferase activity
+http://purl.obolibrary.org/obo/MONDO_0004738,histidine metabolism disease,http://purl.obolibrary.org/obo/GO_0006547,histidine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0021189,intestinal motility disease,http://purl.obolibrary.org/obo/GO_0120054,intestinal motility
+http://purl.obolibrary.org/obo/MONDO_0100004,mast cell activation syndrome,http://purl.obolibrary.org/obo/GO_0045576,mast cell activation
+http://purl.obolibrary.org/obo/MONDO_0005084,mental disorder,http://purl.obolibrary.org/obo/MF_0000020,mental process
+http://purl.obolibrary.org/obo/MONDO_0005066,metabolic disease,http://purl.obolibrary.org/obo/GO_0008152,metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017059,neural tube closure defect,http://purl.obolibrary.org/obo/GO_0001843,neural tube closure
+http://purl.obolibrary.org/obo/MONDO_0021635,neurocristopathy,http://purl.obolibrary.org/obo/GO_0014032,neural crest cell development
+http://purl.obolibrary.org/obo/MONDO_0037821,porphyrin metabolism disease,http://purl.obolibrary.org/obo/GO_0006778,porphyrin-containing compound metabolic process
+http://purl.obolibrary.org/obo/MONDO_0037829,purine metabolism disease,http://purl.obolibrary.org/obo/GO_0006144,purine nucleobase metabolic process
+http://purl.obolibrary.org/obo/MONDO_0037937,pyrimidine metabolism disease,http://purl.obolibrary.org/obo/GO_0006206,pyrimidine nucleobase metabolic process
+http://purl.obolibrary.org/obo/MONDO_0006510,renal tubular transport disease,http://purl.obolibrary.org/obo/GO_0070293,renal absorption
+http://purl.obolibrary.org/obo/MONDO_0008891,riboflavin transporter deficiency,http://purl.obolibrary.org/obo/GO_0032217,riboflavin transmembrane transporter activity
+http://purl.obolibrary.org/obo/MONDO_0002145,sex differentiation disease,http://purl.obolibrary.org/obo/GO_0007548,sex differentiation
+http://purl.obolibrary.org/obo/MONDO_0045012,steroid metabolism disease,http://purl.obolibrary.org/obo/GO_0008202,steroid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045014,tetrahydrobiopterin metabolic process disease,http://purl.obolibrary.org/obo/GO_0046146,tetrahydrobiopterin metabolic process
+http://purl.obolibrary.org/obo/MONDO_0025512,type II hypersensitivity reaction disease,http://purl.obolibrary.org/obo/GO_0002445,type II hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0007004,type III hypersensitivity disease,http://purl.obolibrary.org/obo/GO_0001802,type III hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0002459,type IV hypersensitivity disease,http://purl.obolibrary.org/obo/GO_0001806,type IV hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0037870,valine metabolism disease,http://purl.obolibrary.org/obo/GO_0006573,valine metabolic process

--- a/src/patterns/benign.csv
+++ b/src/patterns/benign.csv
@@ -1,17 +1,30 @@
 iri,iri label,neoplasm,neoplasm label
-MONDO:0006103,benign adrenal gland pheochromocytoma,MONDO:0004974,adrenal gland pheochromocytoma
-MONDO:0002065,benign breast adenomyoepithelioma,MONDO:0002066,breast adenomyoepithelioma
-MONDO:0015871,benign breast phyllodes tumor,MONDO:0021047,breast phyllodes tumor
-MONDO:0006104,benign carotid body paraganglioma,MONDO:0021053,carotid body paraganglioma
-MONDO:0003161,benign ependymoma,MONDO:0016698,ependymoma
-MONDO:0000638,benign glioma,MONDO:0021042,glioma
-MONDO:0003250,benign granular cell tumor,MONDO:0006235,granular cell tumor
-MONDO:0021048,benign mastocytoma,MONDO:0003079,mastocytoma
-MONDO:0003054,benign meningioma,MONDO:0016642,meningioma (disease)
-MONDO:0002382,benign mesenchymoma,MONDO:0006854,mesenchymoma
-MONDO:0002373,benign mesothelioma,MONDO:0005065,mesothelioma
-MONDO:0006675,benign monoclonal gammopathy,MONDO:0004960,monoclonal gammopathy
-MONDO:0005165,benign neoplasm,MONDO:0005070,neoplasm (disease)
-MONDO:0003342,benign perivascular tumor,MONDO:0002604,pericytic neoplasm
-MONDO:0003308,benign pleural mesothelioma,MONDO:0006379,pleural mesothelioma (disease)
-MONDO:0003333,benign struma ovarii,MONDO:0006980,struma ovarii
+http://purl.obolibrary.org/obo/MONDO_0036990,benign Leydig cell tumor,http://purl.obolibrary.org/obo/MONDO_0006266,Leydig cell tumor
+http://purl.obolibrary.org/obo/MONDO_0006103,benign adrenal gland pheochromocytoma,http://purl.obolibrary.org/obo/MONDO_0004974,adrenal gland pheochromocytoma
+http://purl.obolibrary.org/obo/MONDO_0036781,benign axillary neoplasm,http://purl.obolibrary.org/obo/MONDO_0036779,axillary neoplasm
+http://purl.obolibrary.org/obo/MONDO_0002065,benign breast adenomyoepithelioma,http://purl.obolibrary.org/obo/MONDO_0002066,breast adenomyoepithelioma
+http://purl.obolibrary.org/obo/MONDO_0015871,benign breast phyllodes tumor,http://purl.obolibrary.org/obo/MONDO_0021047,breast phyllodes tumor
+http://purl.obolibrary.org/obo/MONDO_0006104,benign carotid body paraganglioma,http://purl.obolibrary.org/obo/MONDO_0021053,carotid body paraganglioma
+http://purl.obolibrary.org/obo/MONDO_0024470,benign chondrogenic neoplasm,http://purl.obolibrary.org/obo/MONDO_0024469,chondrogenic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0000654,benign connective and soft tissue neoplasm,http://purl.obolibrary.org/obo/MONDO_0044334,connective and soft tissue neoplasm
+http://purl.obolibrary.org/obo/MONDO_0024247,benign eccrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0002090,eccrine sweat gland neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003161,benign ependymoma,http://purl.obolibrary.org/obo/MONDO_0016698,ependymoma
+http://purl.obolibrary.org/obo/MONDO_0036976,benign epithelial neoplasm,http://purl.obolibrary.org/obo/MONDO_0005626,epithelial neoplasm
+http://purl.obolibrary.org/obo/MONDO_0024666,benign epithelial skin neoplasm,http://purl.obolibrary.org/obo/MONDO_0021634,epithelial skin neoplasm
+http://purl.obolibrary.org/obo/MONDO_0000638,benign glioma,http://purl.obolibrary.org/obo/MONDO_0021042,glioma
+http://purl.obolibrary.org/obo/MONDO_0003250,benign granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor
+http://purl.obolibrary.org/obo/MONDO_0021048,benign mastocytoma,http://purl.obolibrary.org/obo/MONDO_0003079,mastocytoma
+http://purl.obolibrary.org/obo/MONDO_0002382,benign mesenchymoma,http://purl.obolibrary.org/obo/MONDO_0006854,mesenchymoma
+http://purl.obolibrary.org/obo/MONDO_0024889,benign mesonephroma,http://purl.obolibrary.org/obo/MONDO_0024888,mesonephric neoplasm
+http://purl.obolibrary.org/obo/MONDO_0002373,benign mesothelioma,http://purl.obolibrary.org/obo/MONDO_0005065,mesothelioma
+http://purl.obolibrary.org/obo/MONDO_0005165,benign neoplasm,http://purl.obolibrary.org/obo/MONDO_0005070,neoplasm (disease)
+http://purl.obolibrary.org/obo/MONDO_0045052,benign osteogenic neoplasm,http://purl.obolibrary.org/obo/MONDO_0045053,osteogenic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0036915,benign ovarian mucinous tumor,http://purl.obolibrary.org/obo/MONDO_0003756,ovarian mucinous neoplasm
+http://purl.obolibrary.org/obo/MONDO_0024387,benign ovarian sex cord-stromal tumor,http://purl.obolibrary.org/obo/MONDO_0021657,ovarian sex cord-stromal tumor
+http://purl.obolibrary.org/obo/MONDO_0020581,benign pecoma,http://purl.obolibrary.org/obo/MONDO_0006359,neoplasm with perivascular epithelioid cell differentiation
+http://purl.obolibrary.org/obo/MONDO_0003342,benign perivascular tumor,http://purl.obolibrary.org/obo/MONDO_0002604,pericytic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0037002,benign phyllodes tumor,http://purl.obolibrary.org/obo/MONDO_0005078,phyllodes tumor
+http://purl.obolibrary.org/obo/MONDO_0002451,benign prostate phyllodes tumor,http://purl.obolibrary.org/obo/MONDO_0021102,prostate phyllodes tumor
+http://purl.obolibrary.org/obo/MONDO_0044335,benign soft tissue neoplasm,http://purl.obolibrary.org/obo/MONDO_0006424,soft tissue neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003333,benign struma ovarii,http://purl.obolibrary.org/obo/MONDO_0006980,struma ovarii
+http://purl.obolibrary.org/obo/MONDO_0024715,benign synovial neoplasm,http://purl.obolibrary.org/obo/MONDO_0002528,synovium neoplasm

--- a/src/patterns/cancer.csv
+++ b/src/patterns/cancer.csv
@@ -1,202 +1,226 @@
 iri,iri label,location,location label
-MONDO:0020541,Maligant granulosa cell tumor of ovary,CL:0000501,granulosa cell
-MONDO:0000954,Meckel diverticulum cancer,UBERON:0003705,Meckel's diverticulum
-MONDO:0004685,Waldeyer's ring cancer,UBERON:0001735,tonsillar ring
-MONDO:0002817,adrenal gland cancer,UBERON:0002369,adrenal gland
-MONDO:0003606,adrenal medulla cancer,UBERON:0001236,adrenal medulla
-MONDO:0000919,ampulla of vater cancer,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0000405,anal canal cancer,UBERON:0000159,anal canal
-MONDO:0001879,anus cancer,UBERON:0001245,anus
-MONDO:0003215,apocrine sweat gland cancer,UBERON:0000382,apocrine sweat gland
-MONDO:0001235,appendix cancer,UBERON:0001154,vermiform appendix
-MONDO:0004637,aryepiglottic fold cancer,UBERON:0014385,aryepiglottic fold
-MONDO:0002238,ascending colon cancer,UBERON:0001156,ascending colon
-MONDO:0004532,auditory system cancer,UBERON:0016490,auditory system
-MONDO:0003059,bile duct cancer,UBERON:0002394,bile duct
-MONDO:0003060,biliary tract cancer,UBERON:0001173,biliary tree
-MONDO:0001380,bladder dome cancer,UBERON:0006082,fundus of urinary bladder
-MONDO:0001372,bladder neck cancer,UBERON:0001258,neck of urinary bladder
-MONDO:0001375,bladder trigone cancer,UBERON:0001257,trigone of urinary bladder
-MONDO:0002129,bone cancer,UBERON:0004765,skeletal element
-MONDO:0021138,bone marrow cancer,UBERON:0002371,bone marrow
-MONDO:0001657,brain cancer,UBERON:0000955,brain
-MONDO:0002912,brain stem cancer,UBERON:0002298,brainstem
-MONDO:0007254,breast cancer,UBERON:0000310,breast
-MONDO:0001108,broad ligament malignant neoplasm,UBERON:0012332,broad ligament of uterus
-MONDO:0001672,bronchus cancer,UBERON:0002185,bronchus
-MONDO:0001063,cardia cancer,UBERON:0001162,cardia of stomach
-MONDO:0000639,cartilage cancer,UBERON:0002418,cartilage tissue
-MONDO:0002033,cecum cancer,UBERON:0001153,caecum
-MONDO:0002714,central nervous system cancer,UBERON:0001017,central nervous system
-MONDO:0002682,cerebral ventricle cancer,UBERON:0004086,brain ventricle
-MONDO:0002731,cerebrum cancer,UBERON:0001893,telencephalon
-MONDO:0002974,cervical cancer,UBERON:0000002,uterine cervix
-MONDO:0004645,cheek mucosa cancer,UBERON:0006956,buccal mucosa
-MONDO:0006700,choroid cancer,UBERON:0001776,optic choroid
-MONDO:0002681,choroid plexus cancer,UBERON:0001886,choroid plexus
-MONDO:0002969,ciliary body cancer,UBERON:0001775,ciliary body
-MONDO:0002290,clitoris cancer,UBERON:0002411,clitoris
-MONDO:0005575,colorectal cancer,UBERON:0012652,colorectum
-MONDO:0003454,conjunctival cancer,UBERON:0001811,conjunctiva
-MONDO:0002176,connective tissue cancer,UBERON:0002384,connective tissue
-MONDO:0003802,cornea cancer,UBERON:0000964,cornea
-MONDO:0002433,cranial nerve malignant neoplasm,UBERON:0001785,cranial nerve
-MONDO:0001462,descending colon cancer,UBERON:0001158,descending colon
-MONDO:0002786,diencephalic cancer,UBERON:0001894,diencephalon
-MONDO:0002516,digestive system cancer,UBERON:0001007,digestive system
-MONDO:0000920,duodenum cancer,UBERON:0002114,duodenum
-MONDO:0005506,eccrine sweat gland cancer,UBERON:0000423,eccrine sweat gland
-MONDO:0003687,endocardium cancer,UBERON:0002165,endocardium
-MONDO:0011962,endometrial cancer,UBERON:0001295,endometrium
-MONDO:0003104,epicardium cancer,UBERON:0002348,epicardium
-MONDO:0001016,epididymis cancer,UBERON:0001301,epididymis
-MONDO:0004473,epiglottis cancer,UBERON:0000388,epiglottis
-MONDO:0007576,esophageal cancer,UBERON:0001043,esophagus
-MONDO:0001763,ethmoid sinus cancer,UBERON:0002453,ethmoid sinus
-MONDO:0003574,external ear cancer,UBERON:0001691,external ear
-MONDO:0002158,fallopian tube cancer,UBERON:0003889,fallopian tube
-MONDO:0001416,female reproductive organ cancer,UBERON:0003134,female reproductive organ
-MONDO:0004203,female urethral cancer,UBERON:0001334,female urethra
-MONDO:0003505,femoral cancer,UBERON:0000981,femur
-MONDO:0001756,frontal sinus cancer,UBERON:0001760,frontal sinus
-MONDO:0005411,gallbladder cancer,UBERON:0002110,gall bladder
-MONDO:0001056,gastric cancer,UBERON:0000945,stomach
-MONDO:0001058,gastric fundus cancer,UBERON:0001160,fundus of stomach
-MONDO:0005507,gingival cancer,UBERON:0001828,gingiva
-MONDO:0001388,glans penis cancer,UBERON:0001299,glans penis
-MONDO:0002351,glottis cancer,UBERON:0002486,glottis
-MONDO:0004719,hard palate cancer,UBERON:0003216,hard palate
-MONDO:0005627,head and neck malignant neoplasia,UBERON:0007811,craniocervical region
-MONDO:0001340,heart cancer,UBERON:0000948,heart
-MONDO:0002357,hepatic flexure cancer,UBERON:0022277,hepatic flexure of colon
-MONDO:0000955,ileum cancer,UBERON:0002116,ileum
-MONDO:0000621,immune system cancer,UBERON:0002405,immune system
-MONDO:0003278,inner ear cancer,UBERON:0001846,internal ear
-MONDO:0000653,integumentary system cancer,UBERON:0002416,integumental system
-MONDO:0005814,intestinal cancer,UBERON:0000160,intestine
-MONDO:0002658,iris cancer,UBERON:0001769,iris
-MONDO:0004792,isthmus cancer,UBERON:0003052,midbrain-hindbrain boundary
-MONDO:0002131,jaw cancer,UBERON:0001708,jaw skeleton
-MONDO:0006815,jejunal cancer,UBERON:0002115,jejunum
-MONDO:0002367,kidney cancer,UBERON:0002113,kidney
-MONDO:0001526,labia minora cancer,UBERON:0004014,labium minora
-MONDO:0001403,labium majus cancer,UBERON:0004085,labium majora
-MONDO:0002464,lacrimal gland cancer,UBERON:0001817,lacrimal gland
-MONDO:0003576,large intestine cancer,UBERON:0000059,large intestine
-MONDO:0001691,laryngeal cartilage cancer,UBERON:0001739,laryngeal cartilage
-MONDO:0002352,larynx cancer,UBERON:0001737,larynx
-MONDO:0006834,lip cancer,UBERON:0001833,lip
-MONDO:0002691,liver cancer,UBERON:0002107,liver
-MONDO:0004713,lower gum cancer,UBERON:0011602,gingiva of lower jaw
-MONDO:0004673,lower lip cancer,UBERON:0001835,lower lip
-MONDO:0008903,lung cancer,UBERON:0002048,lung
-MONDO:0004332,lung hilum cancer,UBERON:0004886,lung hilus
-MONDO:0001082,lymph node cancer,UBERON:0000029,lymph node
-MONDO:0000612,lymphatic system cancer,UBERON:0006558,lymphatic part of lymphoid system
-MONDO:0002811,main bronchus cancer,UBERON:0002182,main bronchus
-MONDO:0005836,male reproductive organ cancer,UBERON:0003135,male reproductive organ
-MONDO:0004197,male urethral cancer,UBERON:0001333,male urethra
-MONDO:0021063,malignant colon neoplasm,UBERON:0001155,colon
-MONDO:0003363,malignant dermis tumor,UBERON:0002067,dermis
-MONDO:0003277,malignant ear neoplasm,UBERON:0001690,ear
-MONDO:0021069,malignant endocrine neoplasm,UBERON:0002368,endocrine gland
-MONDO:0002116,malignant exocrine pancreas neoplasm,UBERON:0000017,exocrine pancreas
-MONDO:0006290,malignant germ cell tumor,CL:0000586,germ cell
-MONDO:0003340,malignant glomus tumor,UBERON:0004739,pronephric glomerulus
-MONDO:0006291,malignant jugulotympanic paraganglioma,UBERON:0034972,jugular body
-MONDO:0003762,malignant leptomeningeal tumor,UBERON:0000391,leptomeninx
-MONDO:0000377,malignant leydig cell tumor,CL:0000178,Leydig cell
-MONDO:0002432,malignant neoplasm of acoustic nerve,UBERON:0001648,vestibulocochlear nerve
-MONDO:0002434,malignant oculomotor nerve tumor,UBERON:0001643,oculomotor nerve
-MONDO:0009831,malignant pancreatic neoplasm,UBERON:0001264,pancreas
-MONDO:0006294,malignant pleural neoplasm,UBERON:0000977,pleura
-MONDO:0006519,malignant rectal neoplasm,UBERON:0001052,rectum
-MONDO:0006295,malignant urinary system neoplasm,UBERON:0001008,renal system
-MONDO:0005837,mandibular cancer,UBERON:0001684,mandible
-MONDO:0001748,maxillary sinus cancer,UBERON:0001764,maxillary sinus
-MONDO:0005843,mediastinal cancer,UBERON:0003728,mediastinum
-MONDO:0003275,middle ear cancer,UBERON:0001756,middle ear
-MONDO:0005864,muscle cancer,UBERON:0005090,muscle structure
-MONDO:0000637,musculoskeletal system cancer,UBERON:0002204,musculoskeletal system
-MONDO:0004749,myocardium cancer,UBERON:0002349,myocardium
-MONDO:0001128,nasal cavity cancer,UBERON:0001707,nasal cavity
-MONDO:0005872,nervous system cancer,UBERON:0001016,nervous system
-MONDO:0002597,notochordal cancer,UBERON:0002328,notochord
-MONDO:0002236,ocular cancer,UBERON:0000970,eye
-MONDO:0005515,oral cavity cancer,UBERON:0000167,oral cavity
-MONDO:0002889,orbital cancer,UBERON:0001697,orbit of skull
-MONDO:0004608,oropharynx cancer,UBERON:0001729,oropharynx
-MONDO:0008170,ovarian cancer,UBERON:0000992,ovary
-MONDO:0001350,parametrium malignant neoplasm,UBERON:0010391,parametrium
-MONDO:0000380,paranasal sinus cancer,UBERON:0001825,paranasal sinus
-MONDO:0001869,paraurethral gland cancer,UBERON:0010145,paraurethral gland
-MONDO:0001952,parietal lobe neoplasm,UBERON:0001872,parietal lobe
-MONDO:0004700,parotid gland cancer,UBERON:0001831,parotid gland
-MONDO:0001325,penile cancer,UBERON:0000989,penis
-MONDO:0001322,pericardium cancer,UBERON:0002407,pericardium
-MONDO:0021089,peripheral nervous system cancer,UBERON:0000010,peripheral nervous system
-MONDO:0002087,peritoneum cancer,UBERON:0002358,peritoneum
-MONDO:0005517,pharynx cancer,UBERON:0006562,pharynx
-MONDO:0003249,pineal gland cancer,UBERON:0001905,pineal body
-MONDO:0002178,placenta cancer,UBERON:0001987,placenta
-MONDO:0002972,posterior mediastinum cancer,UBERON:0008822,posterior mediastinum
-MONDO:0001653,prepuce cancer,UBERON:0011374,prepuce
-MONDO:0008315,prostate cancer,UBERON:0002367,prostate gland
-MONDO:0001062,pyloric antrum cancer,UBERON:0001165,pyloric antrum
-MONDO:0001061,pylorus cancer,UBERON:0001166,pylorus
-MONDO:0002425,rectosigmoid junction cancer,UBERON:0036214,rectosigmoid junction
-MONDO:0005519,renal pelvis carcinoma,UBERON:0001224,renal pelvis
-MONDO:0002149,reproductive organ cancer,UBERON:0003133,reproductive organ
-MONDO:0000376,respiratory system cancer,UBERON:0001004,respiratory system
-MONDO:0003072,retinal cancer,UBERON:0000966,retina
-MONDO:0004338,retinal cell cancer,CL:0009004,retinal cell
-MONDO:0001352,round ligament malignant neoplasm,UBERON:0006589,round ligament of uterus
-MONDO:0004669,salivary gland cancer,UBERON:0001044,saliva-secreting gland
-MONDO:0021112,scrotum cancer,UBERON:0001300,scrotum
-MONDO:0000649,sensory system cancer,UBERON:0001032,sensory system
-MONDO:0001464,sigmoid colon cancer,UBERON:0001159,sigmoid colon
-MONDO:0002847,skeletal muscle cancer,UBERON:0014895,somatic muscle
-MONDO:0002898,skin cancer,UBERON:0000014,zone of skin
-MONDO:0002132,skull cancer,UBERON:0003129,skull
-MONDO:0000956,small intestine cancer,UBERON:0002108,small intestine
-MONDO:0004611,soft palate cancer,UBERON:0001733,soft palate
-MONDO:0001654,spermatic cord cancer,UBERON:0005352,spermatic cord
-MONDO:0001994,sphenoidal sinus cancer,UBERON:0001724,sphenoidal sinus
-MONDO:0003544,spinal cord cancer,UBERON:0002240,spinal cord
-MONDO:0004151,spinal meninges cancer,UBERON:0003292,meninx of spinal cord
-MONDO:0005966,spleen cancer,UBERON:0002106,spleen
-MONDO:0001463,splenic flexure cancer,UBERON:0022276,splenic flexure of colon
-MONDO:0003273,sternum cancer,UBERON:0000975,sternum
-MONDO:0001293,subglottis cancer,UBERON:0036068,subglottis
-MONDO:0004667,sublingual gland cancer,UBERON:0001832,sublingual gland
-MONDO:0004724,submandibular gland cancer,UBERON:0001736,submandibular gland
-MONDO:0001724,supraglottis cancer,UBERON:0036263
-MONDO:0002206,sweat gland cancer,UBERON:0001820,sweat gland
-MONDO:0002403,synovium cancer,UBERON:0007616,layer of synovial tissue
-MONDO:0002218,temporal lobe neoplasm,UBERON:0001871,temporal lobe
-MONDO:0005447,testicular cancer,UBERON:0000473,testis
-MONDO:0003766,thalamic cancer,UBERON:0001897,dorsal plus ventral thalamus
-MONDO:0003274,thoracic cancer,UBERON:0000915,thoracic segment of trunk
-MONDO:0002586,thymus cancer,UBERON:0002370,thymus
-MONDO:0002108,thyroid cancer,UBERON:0002046,thyroid gland
-MONDO:0004631,tongue cancer,UBERON:0001723,tongue
-MONDO:0006998,tonsil cancer,UBERON:0002372,tonsil
-MONDO:0004690,tonsillar fossa cancer,UBERON:0035228,tonsillar fossa
-MONDO:0001407,tracheal cancer,UBERON:0003126,trachea
-MONDO:0002361,transverse colon cancer,UBERON:0001157,transverse colon
-MONDO:0004615,upper gum cancer,UBERON:0011601,gingiva of upper jaw
-MONDO:0004621,upper lip cancer,UBERON:0001834,upper lip
-MONDO:0001378,urachus cancer,UBERON:0002068,urachus
-MONDO:0008627,ureter cancer,UBERON:0000056,ureter
-MONDO:0001379,ureteric orifice cancer,UBERON:0012303,ureteral orifice
-MONDO:0004192,urethra cancer,UBERON:0000057,urethra
-MONDO:0001187,urinary bladder cancer,UBERON:0001255,urinary bladder
-MONDO:0002715,uterine cancer,UBERON:0000995,uterus
-MONDO:0006003,uterine corpus cancer,UBERON:0009853,body of uterus
-MONDO:0003612,uterine ligament cancer,UBERON:0036262
-MONDO:0002659,uveal cancer,UBERON:0001768,uvea
-MONDO:0004624,uvula cancer,UBERON:0001734,palatine uvula
-MONDO:0001402,vaginal cancer,UBERON:0000996,vagina
-MONDO:0004607,vallecula cancer,UBERON:0013165,epiglottic vallecula
-MONDO:0002095,vascular cancer,UBERON:0002012,pulmonary artery
-MONDO:0001528,vulva cancer,UBERON:0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0000954,Meckel diverticulum cancer,http://purl.obolibrary.org/obo/UBERON_0003705,Meckel's diverticulum
+http://purl.obolibrary.org/obo/MONDO_0004685,Waldeyer's ring cancer,http://purl.obolibrary.org/obo/UBERON_0001735,tonsillar ring
+http://purl.obolibrary.org/obo/MONDO_0002817,adrenal gland cancer,http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0003606,adrenal medulla cancer,http://purl.obolibrary.org/obo/UBERON_0001236,adrenal medulla
+http://purl.obolibrary.org/obo/MONDO_0000919,ampulla of vater cancer,http://purl.obolibrary.org/obo/UBERON_0004913,hepatopancreatic ampulla
+http://purl.obolibrary.org/obo/MONDO_0000405,anal canal cancer,http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0001879,anus cancer,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0004539,aortic malignant tumor,http://purl.obolibrary.org/obo/UBERON_0000947,aorta
+http://purl.obolibrary.org/obo/MONDO_0003215,apocrine sweat gland cancer,http://purl.obolibrary.org/obo/UBERON_0000382,apocrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0001235,appendix cancer,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0004637,aryepiglottic fold cancer,http://purl.obolibrary.org/obo/UBERON_0014385,aryepiglottic fold
+http://purl.obolibrary.org/obo/MONDO_0002238,ascending colon cancer,http://purl.obolibrary.org/obo/UBERON_0001156,ascending colon
+http://purl.obolibrary.org/obo/MONDO_0004532,auditory system cancer,http://purl.obolibrary.org/obo/UBERON_0016490,auditory system
+http://purl.obolibrary.org/obo/MONDO_0003059,bile duct cancer,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0003060,biliary tract cancer,http://purl.obolibrary.org/obo/UBERON_0001173,biliary tree
+http://purl.obolibrary.org/obo/MONDO_0001380,bladder dome cancer,http://purl.obolibrary.org/obo/UBERON_0006082,fundus of urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0001372,bladder neck cancer,http://purl.obolibrary.org/obo/UBERON_0001258,neck of urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0001375,bladder trigone cancer,http://purl.obolibrary.org/obo/UBERON_0001257,trigone of urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0002129,bone cancer,http://purl.obolibrary.org/obo/UBERON_0004765,skeletal element
+http://purl.obolibrary.org/obo/MONDO_0021138,bone marrow cancer,http://purl.obolibrary.org/obo/UBERON_0002371,bone marrow
+http://purl.obolibrary.org/obo/MONDO_0001657,brain cancer,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0002912,brainstem cancer,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0007254,breast cancer,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0001108,broad ligament malignant neoplasm,http://purl.obolibrary.org/obo/UBERON_0012332,broad ligament of uterus
+http://purl.obolibrary.org/obo/MONDO_0001672,bronchus cancer,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0024311,cancer affecting bone of limb skeleton,http://purl.obolibrary.org/obo/UBERON_0002428,limb bone
+http://purl.obolibrary.org/obo/MONDO_0021317,cancer of cerebellum,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0004792,cancer of isthmus of fallopian tube,http://purl.obolibrary.org/obo/UBERON_0016632,isthmus of fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0000952,cancer of long bone of lower limb,http://purl.obolibrary.org/obo/UBERON_0003608,hindlimb long bone
+http://purl.obolibrary.org/obo/MONDO_0001063,cardia cancer,http://purl.obolibrary.org/obo/UBERON_0001162,cardia of stomach
+http://purl.obolibrary.org/obo/MONDO_0002100,cardiovascular cancer,http://purl.obolibrary.org/obo/UBERON_0004535,cardiovascular system
+http://purl.obolibrary.org/obo/MONDO_0000639,cartilage cancer,http://purl.obolibrary.org/obo/UBERON_0002418,cartilage tissue
+http://purl.obolibrary.org/obo/MONDO_0037738,cauda equina cancer,http://purl.obolibrary.org/obo/UBERON_0012337,cauda equina
+http://purl.obolibrary.org/obo/MONDO_0002033,cecum cancer,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0002714,central nervous system cancer,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002731,cerebral hemisphere cancer,http://purl.obolibrary.org/obo/UBERON_0001869,cerebral hemisphere
+http://purl.obolibrary.org/obo/MONDO_0002682,cerebral ventricle cancer,http://purl.obolibrary.org/obo/UBERON_0004086,brain ventricle
+http://purl.obolibrary.org/obo/MONDO_0002974,cervical cancer,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0004645,cheek mucosa cancer,http://purl.obolibrary.org/obo/UBERON_0006956,buccal mucosa
+http://purl.obolibrary.org/obo/MONDO_0006700,choroid cancer,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0002681,choroid plexus cancer,http://purl.obolibrary.org/obo/UBERON_0001886,choroid plexus
+http://purl.obolibrary.org/obo/MONDO_0002969,ciliary body cancer,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0002290,clitoris cancer,http://purl.obolibrary.org/obo/UBERON_0002411,clitoris
+http://purl.obolibrary.org/obo/MONDO_0005575,colorectal cancer,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0003454,conjunctival cancer,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0002176,connective tissue cancer,http://purl.obolibrary.org/obo/UBERON_0002384,connective tissue
+http://purl.obolibrary.org/obo/MONDO_0003802,cornea cancer,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0001462,descending colon cancer,http://purl.obolibrary.org/obo/UBERON_0001158,descending colon
+http://purl.obolibrary.org/obo/MONDO_0002786,diencephalic cancer,http://purl.obolibrary.org/obo/UBERON_0001894,diencephalon
+http://purl.obolibrary.org/obo/MONDO_0002516,digestive system cancer,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0000920,duodenum cancer,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0005506,eccrine sweat gland cancer,http://purl.obolibrary.org/obo/UBERON_0000423,eccrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0003687,endocardium cancer,http://purl.obolibrary.org/obo/UBERON_0002165,endocardium
+http://purl.obolibrary.org/obo/MONDO_0011962,endometrial cancer,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0003104,epicardium cancer,http://purl.obolibrary.org/obo/UBERON_0002348,epicardium
+http://purl.obolibrary.org/obo/MONDO_0001016,epididymis cancer,http://purl.obolibrary.org/obo/UBERON_0001301,epididymis
+http://purl.obolibrary.org/obo/MONDO_0004473,epiglottis cancer,http://purl.obolibrary.org/obo/UBERON_0000388,epiglottis
+http://purl.obolibrary.org/obo/MONDO_0007576,esophageal cancer,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0001763,ethmoid sinus cancer,http://purl.obolibrary.org/obo/UBERON_0002453,ethmoid sinus
+http://purl.obolibrary.org/obo/MONDO_0003574,external ear cancer,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0021313,eyelid cancer,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0002158,fallopian tube cancer,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0002069,female breast axillary tail cancer,http://purl.obolibrary.org/obo/UBERON_0035289,axillary tail of breast
+http://purl.obolibrary.org/obo/MONDO_0001416,female reproductive organ cancer,http://purl.obolibrary.org/obo/UBERON_0003134,female reproductive organ
+http://purl.obolibrary.org/obo/MONDO_0004203,female urethral cancer,http://purl.obolibrary.org/obo/UBERON_0001334,female urethra
+http://purl.obolibrary.org/obo/MONDO_0003505,femoral cancer,http://purl.obolibrary.org/obo/UBERON_0000981,femur
+http://purl.obolibrary.org/obo/MONDO_0001756,frontal sinus cancer,http://purl.obolibrary.org/obo/UBERON_0001760,frontal sinus
+http://purl.obolibrary.org/obo/MONDO_0005411,gallbladder cancer,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0001056,gastric cancer,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0001058,gastric fundus cancer,http://purl.obolibrary.org/obo/UBERON_0001160,fundus of stomach
+http://purl.obolibrary.org/obo/MONDO_0005507,gingival cancer,http://purl.obolibrary.org/obo/UBERON_0001828,gingiva
+http://purl.obolibrary.org/obo/MONDO_0001388,glans penis cancer,http://purl.obolibrary.org/obo/UBERON_0001299,glans penis
+http://purl.obolibrary.org/obo/MONDO_0002351,glottis cancer,http://purl.obolibrary.org/obo/UBERON_0002486,glottis
+http://purl.obolibrary.org/obo/MONDO_0040676,great vessel cancer,http://purl.obolibrary.org/obo/UBERON_0013768,great vessel of heart
+http://purl.obolibrary.org/obo/MONDO_0004719,hard palate cancer,http://purl.obolibrary.org/obo/UBERON_0003216,hard palate
+http://purl.obolibrary.org/obo/MONDO_0005627,head and neck cancer,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0001340,heart cancer,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0002357,hepatic flexure cancer,http://purl.obolibrary.org/obo/UBERON_0022277,hepatic flexure of colon
+http://purl.obolibrary.org/obo/MONDO_0000955,ileum cancer,http://purl.obolibrary.org/obo/UBERON_0002116,ileum
+http://purl.obolibrary.org/obo/MONDO_0000621,immune system cancer,http://purl.obolibrary.org/obo/UBERON_0002405,immune system
+http://purl.obolibrary.org/obo/MONDO_0003278,inner ear cancer,http://purl.obolibrary.org/obo/UBERON_0001846,internal ear
+http://purl.obolibrary.org/obo/MONDO_0000653,integumentary system cancer,http://purl.obolibrary.org/obo/UBERON_0002416,integumental system
+http://purl.obolibrary.org/obo/MONDO_0005814,intestinal cancer,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0001487,intrahepatic bile duct cancer,http://purl.obolibrary.org/obo/UBERON_0003704,intrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002658,iris cancer,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0002131,jaw cancer,http://purl.obolibrary.org/obo/UBERON_0001708,jaw skeleton
+http://purl.obolibrary.org/obo/MONDO_0006815,jejunal cancer,http://purl.obolibrary.org/obo/UBERON_0002115,jejunum
+http://purl.obolibrary.org/obo/MONDO_0002367,kidney cancer,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0001526,labia minora cancer,http://purl.obolibrary.org/obo/UBERON_0004014,labium minora
+http://purl.obolibrary.org/obo/MONDO_0001403,labium majus cancer,http://purl.obolibrary.org/obo/UBERON_0004085,labium majora
+http://purl.obolibrary.org/obo/MONDO_0001580,lacrimal duct cancer,http://purl.obolibrary.org/obo/UBERON_0001850,lacrimal drainage system
+http://purl.obolibrary.org/obo/MONDO_0002464,lacrimal gland cancer,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0002460,lacrimal system cancer,http://purl.obolibrary.org/obo/UBERON_0001750,lacrimal apparatus
+http://purl.obolibrary.org/obo/MONDO_0001691,laryngeal cartilage cancer,http://purl.obolibrary.org/obo/UBERON_0001739,laryngeal cartilage
+http://purl.obolibrary.org/obo/MONDO_0002352,larynx cancer,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0006834,lip cancer,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0002813,lipomatous cancer,http://purl.obolibrary.org/obo/UBERON_0001013,adipose tissue
+http://purl.obolibrary.org/obo/MONDO_0002691,liver cancer,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0004713,lower gum cancer,http://purl.obolibrary.org/obo/UBERON_0011602,gingiva of lower jaw
+http://purl.obolibrary.org/obo/MONDO_0004673,lower lip cancer,http://purl.obolibrary.org/obo/UBERON_0001835,lower lip
+http://purl.obolibrary.org/obo/MONDO_0008903,lung cancer,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0004332,lung hilum cancer,http://purl.obolibrary.org/obo/UBERON_0004886,lung hilus
+http://purl.obolibrary.org/obo/MONDO_0001082,lymph node cancer,http://purl.obolibrary.org/obo/UBERON_0000029,lymph node
+http://purl.obolibrary.org/obo/MONDO_0000612,lymphatic system cancer,http://purl.obolibrary.org/obo/UBERON_0006558,lymphatic part of lymphoid system
+http://purl.obolibrary.org/obo/MONDO_0002811,main bronchus cancer,http://purl.obolibrary.org/obo/UBERON_0002182,main bronchus
+http://purl.obolibrary.org/obo/MONDO_0044743,major salivary gland cancer,http://purl.obolibrary.org/obo/UBERON_0001829,major salivary gland
+http://purl.obolibrary.org/obo/MONDO_0005836,male reproductive organ cancer,http://purl.obolibrary.org/obo/UBERON_0003135,male reproductive organ
+http://purl.obolibrary.org/obo/MONDO_0004197,male urethral cancer,http://purl.obolibrary.org/obo/UBERON_0001333,male urethra
+http://purl.obolibrary.org/obo/MONDO_0021063,malignant colon neoplasm,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0002433,malignant cranial nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001785,cranial nerve
+http://purl.obolibrary.org/obo/MONDO_0003363,malignant dermis tumor,http://purl.obolibrary.org/obo/UBERON_0002067,dermis
+http://purl.obolibrary.org/obo/MONDO_0003277,malignant ear neoplasm,http://purl.obolibrary.org/obo/UBERON_0001690,ear
+http://purl.obolibrary.org/obo/MONDO_0021069,malignant endocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002368,endocrine gland
+http://purl.obolibrary.org/obo/MONDO_0002116,malignant exocrine pancreas neoplasm,http://purl.obolibrary.org/obo/UBERON_0000017,exocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0006291,malignant jugulotympanic paraganglioma,http://purl.obolibrary.org/obo/UBERON_0034972,jugular body
+http://purl.obolibrary.org/obo/MONDO_0003762,malignant leptomeningeal tumor,http://purl.obolibrary.org/obo/UBERON_0000391,leptomeninx
+http://purl.obolibrary.org/obo/MONDO_0021324,malignant neoplasm of abdominal esophagus,http://purl.obolibrary.org/obo/UBERON_0035177,abdominal part of esophagus
+http://purl.obolibrary.org/obo/MONDO_0002432,malignant neoplasm of acoustic nerve,http://purl.obolibrary.org/obo/UBERON_0001648,vestibulocochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0021326,malignant neoplasm of cervical esophagus,http://purl.obolibrary.org/obo/UBERON_0035450,cervical part of esophagus
+http://purl.obolibrary.org/obo/MONDO_0021323,malignant neoplasm of chest wall,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0021309,malignant neoplasm of endocervix,http://purl.obolibrary.org/obo/UBERON_0000458,endocervix
+http://purl.obolibrary.org/obo/MONDO_0021325,malignant neoplasm of thoracic esophagus,http://purl.obolibrary.org/obo/UBERON_0035216,thoracic part of esophagus
+http://purl.obolibrary.org/obo/MONDO_0009831,malignant pancreatic neoplasm,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0044919,malignant renal pelvis neoplasm,http://purl.obolibrary.org/obo/UBERON_0001224,renal pelvis
+http://purl.obolibrary.org/obo/MONDO_0021312,malignant tumor of adrenal cortex,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0021321,malignant tumor of extrahepatic bile duct,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0021320,malignant tumor of floor of mouth,http://purl.obolibrary.org/obo/UBERON_0003679,mouth floor
+http://purl.obolibrary.org/obo/MONDO_0021322,malignant tumor of meninges,http://purl.obolibrary.org/obo/UBERON_0010743,meningeal cluster
+http://purl.obolibrary.org/obo/MONDO_0021316,malignant tumor of minor salivary gland,http://purl.obolibrary.org/obo/UBERON_0001830,minor salivary gland
+http://purl.obolibrary.org/obo/MONDO_0021315,malignant tumor of nasopharynx,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0021310,malignant tumor of neck,http://purl.obolibrary.org/obo/UBERON_0000974,neck
+http://purl.obolibrary.org/obo/MONDO_0020175,malignant tumor of palpebral epidermis,http://purl.obolibrary.org/obo/UBERON_0001457,skin of eyelid
+http://purl.obolibrary.org/obo/MONDO_0021311,malignant tumor of parathyroid gland,http://purl.obolibrary.org/obo/UBERON_0001132,parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0006295,malignant urinary system neoplasm,http://purl.obolibrary.org/obo/UBERON_0001008,renal system
+http://purl.obolibrary.org/obo/MONDO_0005837,mandibular cancer,http://purl.obolibrary.org/obo/UBERON_0001684,mandible
+http://purl.obolibrary.org/obo/MONDO_0005843,mediastinal cancer,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003275,middle ear cancer,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0005864,muscle cancer,http://purl.obolibrary.org/obo/UBERON_0005090,muscle structure
+http://purl.obolibrary.org/obo/MONDO_0000637,musculoskeletal system cancer,http://purl.obolibrary.org/obo/UBERON_0002204,musculoskeletal system
+http://purl.obolibrary.org/obo/MONDO_0004749,myocardium cancer,http://purl.obolibrary.org/obo/UBERON_0002349,myocardium
+http://purl.obolibrary.org/obo/MONDO_0001128,nasal cavity cancer,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0005872,nervous system cancer,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0002236,ocular cancer,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0002434,oculomotor nerve cancer,http://purl.obolibrary.org/obo/UBERON_0001643,oculomotor nerve
+http://purl.obolibrary.org/obo/MONDO_0005515,oral cavity cancer,http://purl.obolibrary.org/obo/UBERON_0000167,oral cavity
+http://purl.obolibrary.org/obo/MONDO_0002889,orbital cancer,http://purl.obolibrary.org/obo/UBERON_0001697,orbit of skull
+http://purl.obolibrary.org/obo/MONDO_0004608,oropharynx cancer,http://purl.obolibrary.org/obo/UBERON_0001729,oropharynx
+http://purl.obolibrary.org/obo/MONDO_0008170,ovarian cancer,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0001350,parametrium malignant neoplasm,http://purl.obolibrary.org/obo/UBERON_0010391,parametrium
+http://purl.obolibrary.org/obo/MONDO_0001869,paraurethral gland cancer,http://purl.obolibrary.org/obo/UBERON_0010145,paraurethral gland
+http://purl.obolibrary.org/obo/MONDO_0001952,parietal lobe cancer,http://purl.obolibrary.org/obo/UBERON_0001872,parietal lobe
+http://purl.obolibrary.org/obo/MONDO_0004700,parotid gland cancer,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0001325,penile cancer,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0001322,pericardium cancer,http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0021089,peripheral nervous system cancer,http://purl.obolibrary.org/obo/UBERON_0000010,peripheral nervous system
+http://purl.obolibrary.org/obo/MONDO_0002087,peritoneum cancer,http://purl.obolibrary.org/obo/UBERON_0002358,peritoneum
+http://purl.obolibrary.org/obo/MONDO_0005517,pharynx cancer,http://purl.obolibrary.org/obo/UBERON_0001042,chordate pharynx
+http://purl.obolibrary.org/obo/MONDO_0003249,pineal gland cancer,http://purl.obolibrary.org/obo/UBERON_0001905,pineal body
+http://purl.obolibrary.org/obo/MONDO_0002109,pituitary cancer,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0002178,placenta cancer,http://purl.obolibrary.org/obo/UBERON_0001987,placenta
+http://purl.obolibrary.org/obo/MONDO_0006294,pleural cancer,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0002972,posterior mediastinum cancer,http://purl.obolibrary.org/obo/UBERON_0008822,posterior mediastinum
+http://purl.obolibrary.org/obo/MONDO_0001653,prepuce cancer,http://purl.obolibrary.org/obo/UBERON_0011374,prepuce
+http://purl.obolibrary.org/obo/MONDO_0008315,prostate cancer,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0001062,pyloric antrum cancer,http://purl.obolibrary.org/obo/UBERON_0001165,pyloric antrum
+http://purl.obolibrary.org/obo/MONDO_0001061,pylorus cancer,http://purl.obolibrary.org/obo/UBERON_0001166,pylorus
+http://purl.obolibrary.org/obo/MONDO_0006519,rectal cancer,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002425,rectosigmoid junction cancer,http://purl.obolibrary.org/obo/UBERON_0036214,rectosigmoid junction
+http://purl.obolibrary.org/obo/MONDO_0002149,reproductive systen cancer,http://purl.obolibrary.org/obo/UBERON_0000990,reproductive system
+http://purl.obolibrary.org/obo/MONDO_0000376,respiratory system cancer,http://purl.obolibrary.org/obo/UBERON_0001004,respiratory system
+http://purl.obolibrary.org/obo/MONDO_0003072,retinal cancer,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0005941,retroperitoneal cancer,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0001352,round ligament malignant neoplasm,http://purl.obolibrary.org/obo/UBERON_0006589,round ligament of uterus
+http://purl.obolibrary.org/obo/MONDO_0004669,salivary gland cancer,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0021112,scrotum cancer,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0037735,sebaceous gland cancer,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0000649,sensory system cancer,http://purl.obolibrary.org/obo/UBERON_0001032,sensory system
+http://purl.obolibrary.org/obo/MONDO_0001464,sigmoid colon cancer,http://purl.obolibrary.org/obo/UBERON_0001159,sigmoid colon
+http://purl.obolibrary.org/obo/MONDO_0002847,skeletal muscle cancer,http://purl.obolibrary.org/obo/UBERON_0001134,skeletal muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0002898,skin cancer,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0002132,skull cancer,http://purl.obolibrary.org/obo/UBERON_0003129,skull
+http://purl.obolibrary.org/obo/MONDO_0000956,small intestine cancer,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0004611,soft palate cancer,http://purl.obolibrary.org/obo/UBERON_0001733,soft palate
+http://purl.obolibrary.org/obo/MONDO_0001654,spermatic cord cancer,http://purl.obolibrary.org/obo/UBERON_0005352,spermatic cord
+http://purl.obolibrary.org/obo/MONDO_0001994,sphenoidal sinus cancer,http://purl.obolibrary.org/obo/UBERON_0001724,sphenoidal sinus
+http://purl.obolibrary.org/obo/MONDO_0003544,spinal cord cancer,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0004151,spinal meninges cancer,http://purl.obolibrary.org/obo/UBERON_0003292,meninx of spinal cord
+http://purl.obolibrary.org/obo/MONDO_0005966,spleen cancer,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0001463,splenic flexure cancer,http://purl.obolibrary.org/obo/UBERON_0022276,splenic flexure of colon
+http://purl.obolibrary.org/obo/MONDO_0003273,sternum cancer,http://purl.obolibrary.org/obo/UBERON_0000975,sternum
+http://purl.obolibrary.org/obo/MONDO_0001293,subglottis cancer,http://purl.obolibrary.org/obo/UBERON_0036068,subglottis
+http://purl.obolibrary.org/obo/MONDO_0004667,sublingual gland cancer,http://purl.obolibrary.org/obo/UBERON_0001832,sublingual gland
+http://purl.obolibrary.org/obo/MONDO_0004724,submandibular gland cancer,http://purl.obolibrary.org/obo/UBERON_0001736,submandibular gland
+http://purl.obolibrary.org/obo/MONDO_0001724,supraglottis cancer,http://purl.obolibrary.org/obo/UBERON_0036263,supraglottic part of larynx
+http://purl.obolibrary.org/obo/MONDO_0002206,sweat gland cancer,http://purl.obolibrary.org/obo/UBERON_0001820,sweat gland
+http://purl.obolibrary.org/obo/MONDO_0002403,synovium cancer,http://purl.obolibrary.org/obo/UBERON_0002018,synovial membrane of synovial joint
+http://purl.obolibrary.org/obo/MONDO_0002218,temporal lobe cancer,http://purl.obolibrary.org/obo/UBERON_0001871,temporal lobe
+http://purl.obolibrary.org/obo/MONDO_0005447,testicular cancer,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0003766,thalamic cancer,http://purl.obolibrary.org/obo/UBERON_0001897,dorsal plus ventral thalamus
+http://purl.obolibrary.org/obo/MONDO_0003274,thoracic cancer,http://purl.obolibrary.org/obo/UBERON_0000915,thoracic segment of trunk
+http://purl.obolibrary.org/obo/MONDO_0002586,thymus cancer,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0002108,thyroid cancer,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0004631,tongue cancer,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0006998,tonsil cancer,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0004690,tonsillar fossa cancer,http://purl.obolibrary.org/obo/UBERON_0035228,tonsillar fossa
+http://purl.obolibrary.org/obo/MONDO_0004642,tonsillar pillar cancer,http://purl.obolibrary.org/obo/UBERON_0036274,
+http://purl.obolibrary.org/obo/MONDO_0001407,tracheal cancer,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0002361,transverse colon cancer,http://purl.obolibrary.org/obo/UBERON_0001157,transverse colon
+http://purl.obolibrary.org/obo/MONDO_0004615,upper gum cancer,http://purl.obolibrary.org/obo/UBERON_0011601,gingiva of upper jaw
+http://purl.obolibrary.org/obo/MONDO_0004621,upper lip cancer,http://purl.obolibrary.org/obo/UBERON_0001834,upper lip
+http://purl.obolibrary.org/obo/MONDO_0001378,urachus cancer,http://purl.obolibrary.org/obo/UBERON_0002068,urachus
+http://purl.obolibrary.org/obo/MONDO_0008627,ureter cancer,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0001379,ureteric orifice cancer,http://purl.obolibrary.org/obo/UBERON_0012303,ureteral orifice
+http://purl.obolibrary.org/obo/MONDO_0004192,urethra cancer,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0001187,urinary bladder cancer,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0002715,uterine cancer,http://purl.obolibrary.org/obo/UBERON_0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0006003,uterine corpus cancer,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003612,uterine ligament cancer,http://purl.obolibrary.org/obo/UBERON_0036262,uterine ligament
+http://purl.obolibrary.org/obo/MONDO_0002659,uveal cancer,http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0004624,uvula cancer,http://purl.obolibrary.org/obo/UBERON_0001734,palatine uvula
+http://purl.obolibrary.org/obo/MONDO_0001402,vaginal cancer,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0004607,vallecula cancer,http://purl.obolibrary.org/obo/UBERON_0013165,epiglottic vallecula
+http://purl.obolibrary.org/obo/MONDO_0002095,vascular cancer,http://purl.obolibrary.org/obo/UBERON_0002049,vasculature
+http://purl.obolibrary.org/obo/MONDO_0004727,vestibule of mouth cancer,http://purl.obolibrary.org/obo/UBERON_0000166,oral opening
+http://purl.obolibrary.org/obo/MONDO_0001528,vulva cancer,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/carcinoma.csv
+++ b/src/patterns/carcinoma.csv
@@ -1,83 +1,108 @@
 iri,iri label,location,location label
-MONDO:0002829,Bartholin's gland carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0018017,Goblet cell carcinoma,CL:0000160,goblet cell
-MONDO:0003975,Littre gland carcinoma,UBERON:0010186,male urethral gland
-MONDO:0004173,Skene gland carcinoma,UBERON:0010145,paraurethral gland
-MONDO:0004965,acinar cell carcinoma,CL:0000622,acinar cell
-MONDO:0002814,adrenal carcinoma,UBERON:0002369,adrenal gland
-MONDO:0004202,adrenal medulla carcinoma,UBERON:0001236,adrenal medulla
-MONDO:0007108,anal canal carcinoma,UBERON:0000159,anal canal
-MONDO:0003199,anal carcinoma,UBERON:0001245,anus
-MONDO:0002941,anal margin carcinoma,UBERON:0012336,perianal skin
-MONDO:0003196,appendix carcinoma,UBERON:0001154,vermiform appendix
-MONDO:0005496,bile duct carcinoma,UBERON:0002394,bile duct
-MONDO:0004986,bladder carcinoma (disease),UBERON:0001255,urinary bladder
-MONDO:0002415,bone carcinoma,UBERON:0001474,bone element
-MONDO:0004989,breast carcinoma,UBERON:0000310,breast
-MONDO:0000552,breast lobular carcinoma,UBERON:0001912,lobule of mammary gland
-MONDO:0002806,bronchus carcinoma,UBERON:0002185,bronchus
-MONDO:0019086,carcinoma of esophagus,UBERON:0001043,esophagus
-MONDO:0017590,carcinoma of the ampulla of vater,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0006029,cecum carcinoma,UBERON:0001153,caecum
-MONDO:0005131,cervical carcinoma,UBERON:0000002,uterine cervix
-MONDO:0005207,choriocarcinoma (disease),UBERON:0003124,chorion
-MONDO:0005220,collecting duct carcinoma,UBERON:0001232,collecting duct of renal tubule
-MONDO:0002032,colon carcinoma,UBERON:0001155,colon
-MONDO:0019210,cutaneous neuroendocrine carcinoma,CL:0000242,Merkel cell
-MONDO:0004259,endocervical carcinoma,UBERON:0000458,endocervix
-MONDO:0002447,endometrial carcinoma (disease),UBERON:0001295,endometrium
-MONDO:0002455,exocervical carcinoma,UBERON:0012249,ectocervix
-MONDO:0005192,exocrine pancreatic carcinoma,UBERON:0000017,exocrine pancreas
-MONDO:0002944,external ear carcinoma,UBERON:0001691,external ear
-MONDO:0003090,extrahepatic bile duct carcinoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0002466,eye carcinoma,UBERON:0000970,eye
-MONDO:0003876,eyelid carcinoma,UBERON:0001711,eyelid
-MONDO:0006206,fallopian tube carcinoma,UBERON:0003889,fallopian tube
-MONDO:0003220,gallbladder carcinoma,UBERON:0002110,gall bladder
-MONDO:0003972,gastric body carcinoma,UBERON:0001161,body of stomach
-MONDO:0004950,gastric carcinoma,UBERON:0000945,stomach
-MONDO:0003834,gastric cardia carcinoma,UBERON:0001162,cardia of stomach
-MONDO:0003970,gastric fundus carcinoma,UBERON:0001160,fundus of stomach
-MONDO:0002355,glottis carcinoma,UBERON:0002486,glottis
-MONDO:0002038,head and neck carcinoma,UBERON:0000974,neck
-MONDO:0005216,hypopharyngeal carcinoma,UBERON:0001051,hypopharynx
-MONDO:0001602,labia minora carcinoma,UBERON:0004014,labium minora
-MONDO:0002463,lacrimal gland carcinoma,UBERON:0001817,lacrimal gland
-MONDO:0002358,laryngeal carcinoma,UBERON:0001737,larynx
-MONDO:0004018,liver carcinoma,UBERON:0002107,liver
-MONDO:0005138,lung carcinoma,UBERON:0002048,lung
-MONDO:0006284,major salivary gland carcinoma,UBERON:0001829,major salivary gland
-MONDO:0005628,male breast carcinoma,UBERON:0016410,male breast
-MONDO:0015277,medullary thyroid gland carcinoma,CL:0000570,parafollicular cell
-MONDO:0003190,middle ear carcinoma,UBERON:0001756,middle ear
-MONDO:0004957,mucinous adenocarcinoma,GO:0070701,mucus layer
-MONDO:0003212,nasal cavity carcinoma,UBERON:0001707,nasal cavity
-MONDO:0015459,nasopharyngeal carcinoma,UBERON:0001728,nasopharynx
-MONDO:0003950,nipple carcinoma,UBERON:0002030,nipple
-MONDO:0005140,ovarian carcinoma,UBERON:0000992,ovary
-MONDO:0006346,pancreatic acinar cell carcinoma,CL:0002064,pancreatic acinar cell
-MONDO:0005893,pancreatic endocrine carcinoma,UBERON:0000016,endocrine pancreas
-MONDO:0012004,parathyroid gland carcinoma,UBERON:0001132,parathyroid gland
-MONDO:0006360,penile carcinoma,UBERON:0000989,penis
-MONDO:0002113,peritoneal carcinoma,UBERON:0002358,peritoneum
-MONDO:0005159,prostate carcinoma,UBERON:0002367,prostate gland
-MONDO:0002424,rectosigmoid carcinoma,UBERON:0036214,rectosigmoid junction
-MONDO:0005206,renal carcinoma,UBERON:0002113,kidney
-MONDO:0001502,retroperitoneum carcinoma,UBERON:0003693,retroperitoneal space
-MONDO:0000521,salivary gland carcinoma,UBERON:0001044,saliva-secreting gland
-MONDO:0002650,scrotal carcinoma,UBERON:0001300,scrotum
-MONDO:0006973,skin appendage carcinoma,UBERON:0000021,cutaneous appendage
-MONDO:0002656,skin carcinoma,UBERON:0000014,zone of skin
-MONDO:0005522,small intestine carcinoma,UBERON:0002108,small intestine
-MONDO:0004358,subglottis carcinoma,UBERON:0036068,subglottis
-MONDO:0021070,sublingual gland carcinoma,UBERON:0001832,sublingual gland
-MONDO:0005524,sweat gland carcinoma,UBERON:0001820,sweat gland
-MONDO:0006451,thymic carcinoma,UBERON:0002370,thymus
-MONDO:0015075,thyroid carcinoma (disease),UBERON:0002046,thyroid gland
-MONDO:0003184,trachea carcinoma,UBERON:0003126,trachea
-MONDO:0006474,transitional cell carcinoma,CL:0000731,urothelial cell
-MONDO:0006481,ureter carcinoma,UBERON:0000056,ureter
-MONDO:0005213,uterine carcinoma,UBERON:0000995,uterus
-MONDO:0015867,vaginal carcinoma,UBERON:0000996,vagina
-MONDO:0006490,vaginal squamous cell carcinoma,CL:1001578,vagina squamous cell
-MONDO:0005215,vulvar carcinoma,UBERON:0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0002829,Bartholin gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0003975,Littre gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0010186,male urethral gland
+http://purl.obolibrary.org/obo/MONDO_0004965,acinar cell carcinoma,http://purl.obolibrary.org/obo/CL_0000622,acinar cell
+http://purl.obolibrary.org/obo/MONDO_0002814,adrenal carcinoma,http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0006639,adrenal cortex carcinoma,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0004202,adrenal medulla carcinoma,http://purl.obolibrary.org/obo/UBERON_0001236,adrenal medulla
+http://purl.obolibrary.org/obo/MONDO_0007108,anal canal carcinoma,http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0003199,anal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0002941,anal margin carcinoma,http://purl.obolibrary.org/obo/UBERON_0012336,perianal skin
+http://purl.obolibrary.org/obo/MONDO_0003196,appendix carcinoma,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0005496,bile duct carcinoma,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0002415,bone carcinoma,http://purl.obolibrary.org/obo/UBERON_0001474,bone element
+http://purl.obolibrary.org/obo/MONDO_0004989,breast carcinoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0000552,breast lobular carcinoma,http://purl.obolibrary.org/obo/UBERON_0001912,lobule of mammary gland
+http://purl.obolibrary.org/obo/MONDO_0002806,bronchogenic carcinoma,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0004311,carcinoma of Cowper glands,http://purl.obolibrary.org/obo/UBERON_0002366,bulbo-urethral gland
+http://purl.obolibrary.org/obo/MONDO_0021335,carcinoma of duodenum,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0019086,carcinoma of esophagus,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0021343,carcinoma of floor of mouth,http://purl.obolibrary.org/obo/UBERON_0003679,mouth floor
+http://purl.obolibrary.org/obo/MONDO_0021339,carcinoma of hard palate,http://purl.obolibrary.org/obo/UBERON_0003216,hard palate
+http://purl.obolibrary.org/obo/MONDO_0021333,carcinoma of lip,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0018531,carcinoma of liver and intrahepatic biliary tract,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0021331,carcinoma of parotid gland,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0021345,carcinoma of pharynx,http://purl.obolibrary.org/obo/UBERON_0006562,pharynx
+http://purl.obolibrary.org/obo/MONDO_0021329,carcinoma of soft palate,http://purl.obolibrary.org/obo/UBERON_0001733,soft palate
+http://purl.obolibrary.org/obo/MONDO_0004357,carcinoma of supraglottis,http://purl.obolibrary.org/obo/UBERON_0036263,supraglottic part of larynx
+http://purl.obolibrary.org/obo/MONDO_0017590,carcinoma of the ampulla of vater,http://purl.obolibrary.org/obo/UBERON_0004913,hepatopancreatic ampulla
+http://purl.obolibrary.org/obo/MONDO_0022643,carcinoma of the vocal tract,http://purl.obolibrary.org/obo/UBERON_0003706,laryngeal vocal fold
+http://purl.obolibrary.org/obo/MONDO_0021327,carcinoma of urethra,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0006029,cecum carcinoma,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0005131,cervical carcinoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0024873,clitoral carcinoma,http://purl.obolibrary.org/obo/UBERON_0002411,clitoris
+http://purl.obolibrary.org/obo/MONDO_0005220,collecting duct carcinoma,http://purl.obolibrary.org/obo/UBERON_0001232,collecting duct of renal tubule
+http://purl.obolibrary.org/obo/MONDO_0002032,colon carcinoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0024331,colorectal carcinoma,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0019210,cutaneous neuroendocrine carcinoma,http://purl.obolibrary.org/obo/CL_0000242,Merkel cell
+http://purl.obolibrary.org/obo/MONDO_0006181,digestive system carcinoma,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0024240,eccrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000423,eccrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0004259,endocervical carcinoma,http://purl.obolibrary.org/obo/UBERON_0000458,endocervix
+http://purl.obolibrary.org/obo/MONDO_0002447,endometrial carcinoma (disease),http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0002455,exocervical carcinoma,http://purl.obolibrary.org/obo/UBERON_0012249,ectocervix
+http://purl.obolibrary.org/obo/MONDO_0005192,exocrine pancreatic carcinoma,http://purl.obolibrary.org/obo/UBERON_0000017,exocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0002944,external ear carcinoma,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0003090,extrahepatic bile duct carcinoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002466,eye carcinoma,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0003876,eyelid carcinoma,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0021588,eyelid sebaceous gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0013231,sebaceous gland of eyelid
+http://purl.obolibrary.org/obo/MONDO_0006206,fallopian tube carcinoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0003220,gallbladder carcinoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003972,gastric body carcinoma,http://purl.obolibrary.org/obo/UBERON_0001161,body of stomach
+http://purl.obolibrary.org/obo/MONDO_0004950,gastric carcinoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003834,gastric cardia carcinoma,http://purl.obolibrary.org/obo/UBERON_0001162,cardia of stomach
+http://purl.obolibrary.org/obo/MONDO_0003970,gastric fundus carcinoma,http://purl.obolibrary.org/obo/UBERON_0001160,fundus of stomach
+http://purl.obolibrary.org/obo/MONDO_0002355,glottis carcinoma,http://purl.obolibrary.org/obo/UBERON_0002486,glottis
+http://purl.obolibrary.org/obo/MONDO_0018017,goblet cell carcinoma,http://purl.obolibrary.org/obo/CL_0000160,goblet cell
+http://purl.obolibrary.org/obo/MONDO_0002038,head and neck carcinoma,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0005216,hypopharyngeal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001051,hypopharynx
+http://purl.obolibrary.org/obo/MONDO_0006260,kidney medullary carcinoma,http://purl.obolibrary.org/obo/UBERON_0000362,renal medulla
+http://purl.obolibrary.org/obo/MONDO_0001702,labia majora carcinoma,http://purl.obolibrary.org/obo/UBERON_0004085,labium majora
+http://purl.obolibrary.org/obo/MONDO_0001602,labia minora carcinoma,http://purl.obolibrary.org/obo/UBERON_0004014,labium minora
+http://purl.obolibrary.org/obo/MONDO_0002463,lacrimal gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0002358,laryngeal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0005138,lung carcinoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0004499,lung hilum carcinoma,http://purl.obolibrary.org/obo/UBERON_0004886,lung hilus
+http://purl.obolibrary.org/obo/MONDO_0006284,major salivary gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001829,major salivary gland
+http://purl.obolibrary.org/obo/MONDO_0005628,male breast carcinoma,http://purl.obolibrary.org/obo/UBERON_0016410,male breast
+http://purl.obolibrary.org/obo/MONDO_0001748,maxillary sinus carcinoma,http://purl.obolibrary.org/obo/UBERON_0001764,maxillary sinus
+http://purl.obolibrary.org/obo/MONDO_0015277,medullary thyroid gland carcinoma,http://purl.obolibrary.org/obo/CL_0000570,parafollicular cell
+http://purl.obolibrary.org/obo/MONDO_0003190,middle ear carcinoma,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0045069,minor salivary gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001830,minor salivary gland
+http://purl.obolibrary.org/obo/MONDO_0003212,nasal cavity carcinoma,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0015459,nasopharyngeal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0003950,nipple carcinoma,http://purl.obolibrary.org/obo/UBERON_0002030,nipple
+http://purl.obolibrary.org/obo/MONDO_0044925,oral cavity carcinoma,http://purl.obolibrary.org/obo/UBERON_0000167,oral cavity
+http://purl.obolibrary.org/obo/MONDO_0044926,oropharyngeal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001729,oropharynx
+http://purl.obolibrary.org/obo/MONDO_0006346,pancreatic acinar cell carcinoma,http://purl.obolibrary.org/obo/CL_0002064,pancreatic acinar cell
+http://purl.obolibrary.org/obo/MONDO_0005893,pancreatic endocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000016,endocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0000380,paranasal sinus carcinoma,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0012004,parathyroid gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001132,parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0006360,penile carcinoma,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0002113,peritoneal carcinoma,http://purl.obolibrary.org/obo/UBERON_0002358,peritoneum
+http://purl.obolibrary.org/obo/MONDO_0005159,prostate carcinoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0044937,rectal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002424,rectosigmoid carcinoma,http://purl.obolibrary.org/obo/UBERON_0036214,rectosigmoid junction
+http://purl.obolibrary.org/obo/MONDO_0005206,renal carcinoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0005519,renal pelvis carcinoma,http://purl.obolibrary.org/obo/UBERON_0001224,renal pelvis
+http://purl.obolibrary.org/obo/MONDO_0001502,retroperitoneum carcinoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0044915,salivary duct carcinoma,http://purl.obolibrary.org/obo/UBERON_0001837,duct of salivary gland
+http://purl.obolibrary.org/obo/MONDO_0000521,salivary gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0002650,scrotal carcinoma,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0006973,skin appendage carcinoma,http://purl.obolibrary.org/obo/UBERON_0000021,cutaneous appendage
+http://purl.obolibrary.org/obo/MONDO_0002656,skin carcinoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0005522,small intestine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0004358,subglottis carcinoma,http://purl.obolibrary.org/obo/UBERON_0036068,subglottis
+http://purl.obolibrary.org/obo/MONDO_0021070,sublingual gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001832,sublingual gland
+http://purl.obolibrary.org/obo/MONDO_0005524,sweat gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0001820,sweat gland
+http://purl.obolibrary.org/obo/MONDO_0006451,thymic carcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0015075,thyroid gland carcinoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0005034,thyroid gland follicular carcinoma,http://purl.obolibrary.org/obo/UBERON_0005305,thyroid follicle
+http://purl.obolibrary.org/obo/MONDO_0021337,tonsil carcinoma,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0003184,trachea carcinoma,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0006474,transitional cell carcinoma,http://purl.obolibrary.org/obo/CL_0000244,transitional epithelial cell
+http://purl.obolibrary.org/obo/MONDO_0006481,ureter carcinoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0004986,urinary bladder carcinoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0005213,uterine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0015867,vaginal carcinoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0005215,vulvar carcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/carcinoma_in_situ.csv
+++ b/src/patterns/carcinoma_in_situ.csv
@@ -1,28 +1,42 @@
 iri,iri label,location,location label
-MONDO:0004707,anal carcinoma in situ,UBERON:0000159,anal canal
-MONDO:0000374,bile duct carcinoma in situ,UBERON:0002394,bile duct
-MONDO:0004703,bladder carcinoma in situ,UBERON:0001255,urinary bladder
-MONDO:0004658,breast carcinoma in situ,UBERON:0000310,breast
-MONDO:0000375,bronchus carcinoma in situ,UBERON:0002185,bronchus
-MONDO:0004693,cervix uteri carcinoma in situ,UBERON:0000002,uterine cervix
-MONDO:0004663,colon carcinoma in situ,UBERON:0001155,colon
-MONDO:0003315,endometrium carcinoma in situ,UBERON:0001295,endometrium
-MONDO:0004708,esophagus carcinoma in situ,UBERON:0001043,esophagus
-MONDO:0004659,eye carcinoma in situ,UBERON:0000970,eye
-MONDO:0000373,gall bladder carcinoma in situ,UBERON:0002110,gall bladder
-MONDO:0004698,intestine carcinoma in situ,UBERON:0000160,intestine
-MONDO:0004732,kidney carcinoma in situ,UBERON:0002113,kidney
-MONDO:0004696,larynx carcinoma in situ,UBERON:0001737,larynx
-MONDO:0004636,lip carcinoma in situ,UBERON:0001833,lip
-MONDO:0004715,liver carcinoma in situ,UBERON:0002107,liver
-MONDO:0004660,lung carcinoma in situ,UBERON:0002048,lung
-MONDO:0003784,nasal cavity carcinoma in situ,UBERON:0001707,nasal cavity
-MONDO:0000371,oral cavity carcinoma in situ,UBERON:0000167,oral cavity
-MONDO:0004671,penis carcinoma in situ,UBERON:0000989,penis
-MONDO:0000372,pharynx carcinoma in situ,UBERON:0006562,pharynx
-MONDO:0004623,prostate carcinoma in situ,UBERON:0002367,prostate gland
-MONDO:0004725,rectum carcinoma in situ,UBERON:0001052,rectum
-MONDO:0004641,skin carcinoma in situ,UBERON:0000014,zone of skin
-MONDO:0004716,stomach carcinoma in situ,UBERON:0000945,stomach
-MONDO:0004661,trachea carcinoma in situ,UBERON:0003126,trachea
-MONDO:0004710,uterus carcinoma in situ,UBERON:0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0004707,anal canal carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0000374,bile duct carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0004703,bladder carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0004658,breast carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0000375,bronchus carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0021290,carcinoma in situ of appendix,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0021289,carcinoma in situ of cecum,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0021287,carcinoma in situ of epiglottis,http://purl.obolibrary.org/obo/UBERON_0000388,epiglottis
+http://purl.obolibrary.org/obo/MONDO_0021299,carcinoma in situ of extrahepatic bile duct,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0021291,carcinoma in situ of fundus of stomach,http://purl.obolibrary.org/obo/UBERON_0001160,fundus of stomach
+http://purl.obolibrary.org/obo/MONDO_0021292,carcinoma in situ of gastric body,http://purl.obolibrary.org/obo/UBERON_0001161,body of stomach
+http://purl.obolibrary.org/obo/MONDO_0021294,carcinoma in situ of gastric cardia,http://purl.obolibrary.org/obo/UBERON_0001162,cardia of stomach
+http://purl.obolibrary.org/obo/MONDO_0021288,carcinoma in situ of hypopharynx,http://purl.obolibrary.org/obo/UBERON_0001051,hypopharynx
+http://purl.obolibrary.org/obo/MONDO_0021297,carcinoma in situ of nasopharynx,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0021298,carcinoma in situ of oropharynx,http://purl.obolibrary.org/obo/UBERON_0001729,oropharynx
+http://purl.obolibrary.org/obo/MONDO_0021296,carcinoma in situ of renal pelvis,http://purl.obolibrary.org/obo/UBERON_0001224,renal pelvis
+http://purl.obolibrary.org/obo/MONDO_0021284,carcinoma in situ of ureter,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0021285,carcinoma in situ of urethra,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0004663,colon carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0005023,ductal breast carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001765,mammary duct
+http://purl.obolibrary.org/obo/MONDO_0003315,endometrium carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0004708,esophagus carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004659,eye carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0000373,gall bladder carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0004698,intestine carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0004732,kidney carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0004696,larynx carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0004636,lip carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0004715,liver carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0004660,lung carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003784,nasal cavity carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0000371,oral cavity carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000167,oral cavity
+http://purl.obolibrary.org/obo/MONDO_0004671,penis carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0000372,pharynx carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0006562,pharynx
+http://purl.obolibrary.org/obo/MONDO_0004623,prostate carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0004725,rectum carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0004641,skin carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0004716,stomach carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0004661,trachea carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0042487,uterine cervix carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0004710,uterus carcinoma in situ,http://purl.obolibrary.org/obo/UBERON_0000995,uterus

--- a/src/patterns/childhood.csv
+++ b/src/patterns/childhood.csv
@@ -1,0 +1,72 @@
+iri,iri label,disease,disease label
+http://purl.obolibrary.org/obo/MONDO_0016241,alternating hemiplegia of childhood,http://purl.obolibrary.org/obo/MONDO_0016210,alternating hemiplegia
+http://purl.obolibrary.org/obo/MONDO_0016114,bulbospinal muscular atrophy of childhood,http://purl.obolibrary.org/obo/MONDO_0016113,bulbospinal muscular atrophy
+http://purl.obolibrary.org/obo/MONDO_0004996,childhood acute myeloid leukemia,http://purl.obolibrary.org/obo/MONDO_0018874,acute myeloid leukemia
+http://purl.obolibrary.org/obo/MONDO_0002505,childhood astrocytic tumor,http://purl.obolibrary.org/obo/MONDO_0021636,astrocytic tumor
+http://purl.obolibrary.org/obo/MONDO_0003992,childhood botryoid rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0002578,botryoid rhabdomyosarcoma
+http://purl.obolibrary.org/obo/MONDO_0004217,childhood brain germinoma,http://purl.obolibrary.org/obo/MONDO_0002214,brain germinoma
+http://purl.obolibrary.org/obo/MONDO_0003869,childhood brain stem glioma,http://purl.obolibrary.org/obo/MONDO_0002911,brain stem glioma
+http://purl.obolibrary.org/obo/MONDO_0002914,childhood brain stem neoplasm,http://purl.obolibrary.org/obo/MONDO_0002912,brainstem cancer
+http://purl.obolibrary.org/obo/MONDO_0003870,childhood brainstem astrocytoma,http://purl.obolibrary.org/obo/MONDO_0003173,brain stem astrocytic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0022642,childhood carcinoid tumor,http://purl.obolibrary.org/obo/MONDO_0005369,carcinoid tumor (disease)
+http://purl.obolibrary.org/obo/MONDO_0004153,childhood central nervous system embryonal carcinoma,http://purl.obolibrary.org/obo/MONDO_0018843,embryonal carcinoma of the central nervous system
+http://purl.obolibrary.org/obo/MONDO_0004452,childhood central nervous system germinoma,http://purl.obolibrary.org/obo/MONDO_0002999,central nervous system germinoma
+http://purl.obolibrary.org/obo/MONDO_0003958,childhood central nervous system immature teratoma,http://purl.obolibrary.org/obo/MONDO_0003735,central nervous system immature teratoma
+http://purl.obolibrary.org/obo/MONDO_0003875,childhood central nervous system mature teratoma,http://purl.obolibrary.org/obo/MONDO_0003733,central nervous system mature teratoma
+http://purl.obolibrary.org/obo/MONDO_0004257,childhood central nervous system mixed germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0016742,mixed germ cell tumor of central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002798,childhood central nervous system primitive neuroectodermal neoplasm,http://purl.obolibrary.org/obo/MONDO_0000640,central nervous system primitive neuroectodermal neoplasm
+http://purl.obolibrary.org/obo/MONDO_0004535,childhood choriocarcinoma of the ovary,http://purl.obolibrary.org/obo/MONDO_0003507,choriocarcinoma of ovary
+http://purl.obolibrary.org/obo/MONDO_0002685,childhood choroid plexus carcinoma,http://purl.obolibrary.org/obo/MONDO_0016718,choroid plexus carcinoma
+http://purl.obolibrary.org/obo/MONDO_0024744,childhood choroid plexus neoplasm,http://purl.obolibrary.org/obo/MONDO_0016717,choroid plexus neoplasm
+http://purl.obolibrary.org/obo/MONDO_0000414,childhood electroclinical syndrome,http://purl.obolibrary.org/obo/MONDO_0000411,electroclinical syndrome
+http://purl.obolibrary.org/obo/MONDO_0003788,childhood embryonal testis carcinoma,http://purl.obolibrary.org/obo/MONDO_0006446,testicular embryonal carcinoma
+http://purl.obolibrary.org/obo/MONDO_0005407,childhood eosinophilic esophagitis,http://purl.obolibrary.org/obo/MONDO_0005361,eosinophilic esophagitis
+http://purl.obolibrary.org/obo/MONDO_0003478,childhood ependymoma,http://purl.obolibrary.org/obo/MONDO_0016698,ependymoma
+http://purl.obolibrary.org/obo/MONDO_0004105,childhood epithelioid sarcoma,http://purl.obolibrary.org/obo/MONDO_0017387,epithelioid sarcoma
+http://purl.obolibrary.org/obo/MONDO_0004176,childhood extraosseous osteosarcoma,http://purl.obolibrary.org/obo/MONDO_0002621,extraosseous osteosarcoma
+http://purl.obolibrary.org/obo/MONDO_0020577,childhood gonadal germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0018202,gonadal germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0009428,childhood hypophosphatasia,http://purl.obolibrary.org/obo/MONDO_0018570,hypophosphatasia
+http://purl.obolibrary.org/obo/MONDO_0004082,childhood immature teratoma of ovary,http://purl.obolibrary.org/obo/MONDO_0018369,immature ovarian teratoma
+http://purl.obolibrary.org/obo/MONDO_0002915,childhood infratentorial neoplasm,http://purl.obolibrary.org/obo/MONDO_0037736,infratentorial neoplasm
+http://purl.obolibrary.org/obo/MONDO_0004554,childhood kidney angiomyolipoma,http://purl.obolibrary.org/obo/MONDO_0004555,kidney angiomyolipoma
+http://purl.obolibrary.org/obo/MONDO_0003007,childhood kidney cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005086,renal cell carcinoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0002730,childhood kidney neoplasm,http://purl.obolibrary.org/obo/MONDO_0021163,kidney neoplasm
+http://purl.obolibrary.org/obo/MONDO_0004355,childhood leukemia,http://purl.obolibrary.org/obo/MONDO_0005059,leukemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0036511,childhood malignant kidney neoplasm,http://purl.obolibrary.org/obo/MONDO_0002367,kidney cancer
+http://purl.obolibrary.org/obo/MONDO_0042494,childhood malignant melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0003691,childhood malignant mesenchymoma,http://purl.obolibrary.org/obo/MONDO_0003633,malignant mesenchymoma
+http://purl.obolibrary.org/obo/MONDO_0003818,childhood mature teratoma of the ovary,http://purl.obolibrary.org/obo/MONDO_0003820,mature ovarian teratoma
+http://purl.obolibrary.org/obo/MONDO_0002797,childhood medulloblastoma,http://purl.obolibrary.org/obo/MONDO_0007959,medulloblastoma
+http://purl.obolibrary.org/obo/MONDO_0021079,childhood neoplasm,http://purl.obolibrary.org/obo/MONDO_0005070,neoplasm (disease)
+http://purl.obolibrary.org/obo/MONDO_0002540,childhood oligodendroglioma,http://purl.obolibrary.org/obo/MONDO_0016695,oligodendroglioma
+http://purl.obolibrary.org/obo/MONDO_0005405,childhood onset asthma,http://purl.obolibrary.org/obo/MONDO_0004979,asthma
+http://purl.obolibrary.org/obo/MONDO_0003932,childhood optic nerve glioma,http://purl.obolibrary.org/obo/MONDO_0003235,optic nerve glioma
+http://purl.obolibrary.org/obo/MONDO_0003931,childhood optic tract astrocytoma,http://purl.obolibrary.org/obo/MONDO_0024649,optic tract astrocytoma
+http://purl.obolibrary.org/obo/MONDO_0004441,childhood ovarian embryonal carcinoma,http://purl.obolibrary.org/obo/MONDO_0003581,ovarian embryonal carcinoma
+http://purl.obolibrary.org/obo/MONDO_0004000,childhood pilocytic astrocytoma,http://purl.obolibrary.org/obo/MONDO_0016691,pilocytic astrocytoma
+http://purl.obolibrary.org/obo/MONDO_0004233,childhood pleomorphic rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0017386,pleomorphic rhabdomyosarcoma
+http://purl.obolibrary.org/obo/MONDO_0004403,childhood precursor T-lymphoblastic lymphoma/leukemia,http://purl.obolibrary.org/obo/MONDO_0003537,precursor T-lymphoblastic lymphoma/leukemia
+http://purl.obolibrary.org/obo/MONDO_0002716,childhood spinal cord tumor,http://purl.obolibrary.org/obo/MONDO_0021234,spinal cord neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003819,childhood teratoma of the ovary,http://purl.obolibrary.org/obo/MONDO_0005602,ovarian teratoma
+http://purl.obolibrary.org/obo/MONDO_0003786,childhood testicular choriocarcinoma,http://purl.obolibrary.org/obo/MONDO_0003508,choriocarcinoma of testis
+http://purl.obolibrary.org/obo/MONDO_0003758,childhood testicular germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0010108,testicular germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0003787,childhood testicular mixed germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0003120,mixed testicular germ cell cancer
+http://purl.obolibrary.org/obo/MONDO_0037250,childhood testicular neoplasm,http://purl.obolibrary.org/obo/MONDO_0021348,neoplasm of testis
+http://purl.obolibrary.org/obo/MONDO_0003993,childhood vagina botryoid rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0003994,botryoid-type embryonal rhabdomyosarcoma of the vagina
+http://purl.obolibrary.org/obo/MONDO_0020072,childhood-onset epilepsy syndrome,http://purl.obolibrary.org/obo/MONDO_0015650,epilepsy syndrome
+http://purl.obolibrary.org/obo/MONDO_0017014,interstitial lung disease specific to childhood,http://purl.obolibrary.org/obo/MONDO_0015925,interstitial lung disease
+http://purl.obolibrary.org/obo/MONDO_0018325,juvenile myasthenia gravis,http://purl.obolibrary.org/obo/MONDO_0009688,myasthenia gravis
+http://purl.obolibrary.org/obo/MONDO_0020367,juvenile open angle glaucoma,http://purl.obolibrary.org/obo/MONDO_0005041,glaucoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0009672,juvenile spinal muscular atrophy,http://purl.obolibrary.org/obo/MONDO_0001516,spinal muscular atrophy
+http://purl.obolibrary.org/obo/MONDO_0003953,pediatric CNS choriocarcinoma,http://purl.obolibrary.org/obo/MONDO_0016740,choriocarcinoma of the central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003022,pediatric angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0004350,pediatric extraocular retinoblastoma,http://purl.obolibrary.org/obo/MONDO_0003078,extraocular retinoblastoma
+http://purl.obolibrary.org/obo/MONDO_0002678,pediatric fibrosarcoma,http://purl.obolibrary.org/obo/MONDO_0002676,adult fibrosarcoma
+http://purl.obolibrary.org/obo/MONDO_0004045,pediatric intraocular retinoblastoma,http://purl.obolibrary.org/obo/MONDO_0003077,intraocular retinoblastoma
+http://purl.obolibrary.org/obo/MONDO_0003057,pediatric meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease)
+http://purl.obolibrary.org/obo/MONDO_0003041,pediatric mesenchymal chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0006853,mesenchymal chondrosarcoma
+http://purl.obolibrary.org/obo/MONDO_0003898,pediatric myxoid chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0003681,myxoid chondrosarcoma
+http://purl.obolibrary.org/obo/MONDO_0002623,pediatric osteosarcoma,http://purl.obolibrary.org/obo/MONDO_0009807,osteosarcoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0004193,pediatric ovarian dysgerminoma,http://purl.obolibrary.org/obo/MONDO_0003481,dysgerminoma of ovary
+http://purl.obolibrary.org/obo/MONDO_0003760,pediatric ovarian germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0011366,ovarian germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0011014,pleuropulmonary blastoma,http://purl.obolibrary.org/obo/MONDO_0005933,pulmonary blastoma

--- a/src/patterns/chronic.csv
+++ b/src/patterns/chronic.csv
@@ -1,49 +1,64 @@
 iri,iri label,disease,disease label
-MONDO:0005607,chronic bronchitis,MONDO:0003781,bronchitis
-MONDO:0004924,chronic canaliculitis,MONDO:0005631,actinomycosis
-MONDO:0002030,chronic cervicitis,MONDO:0002345,cervicitis (disease)
-MONDO:0004786,chronic cholangitis,MONDO:0004789,cholangitis
-MONDO:0001966,chronic closed-angle glaucoma,MONDO:0001744,angle-closure glaucoma
-MONDO:0002314,chronic conjunctivitis,MONDO:0003799,conjunctivitis (disease)
-MONDO:0015574,chronic cutaneous lupus erythematosus,MONDO:0005282,cutaneous lupus erythematosus
-MONDO:0006030,chronic cystitis,MONDO:0006032,cystitis
-MONDO:0004800,chronic dacryoadenitis,MONDO:0004804,dacryoadenitis
-MONDO:0004925,chronic dacryocystitis,MONDO:0004926,dacryocystitis
-MONDO:0020069,chronic encephalitis,MONDO:0019956,encephalitis
-MONDO:0017203,chronic endophthalmitis,MONDO:0016047,endophthalmitis
-MONDO:0004806,chronic eosinophilic pneumonia,MONDO:0005749,eosinophilic pneumonia
-MONDO:0004757,chronic ethmoidal sinusitis,MONDO:0005756,ethmoid sinusitis
-MONDO:0002170,chronic eustachian salpingitis,MONDO:0002172,otosalpingitis
-MONDO:0001120,chronic frontal sinusitis,MONDO:0001121,frontal sinusitis
-MONDO:0005001,chronic gastritis (disease),MONDO:0004966,gastritis (disease)
-MONDO:0020547,chronic graft versus host disease,MONDO:0013730,graft versus host disease
-MONDO:0005366,chronic hepatitis B infection,MONDO:0005344,hepatitis B infection
-MONDO:0005354,chronic hepatitis C infection,MONDO:0005231,hepatitis C infection
-MONDO:0006703,chronic interstitial cystitis,MONDO:0018301,interstitial cystitis
-MONDO:0017574,chronic intestinal pseudoobstruction,MONDO:0002803,intestinal pseudo-obstruction
-MONDO:0005300,chronic kidney disease,MONDO:0005240,kidney disease
-MONDO:0001369,chronic laryngitis,MONDO:0002647,laryngitis
-MONDO:0001014,chronic leukemia,MONDO:0005059,leukemia (disease)
-MONDO:0001122,chronic maxillary sinusitis,MONDO:0005842,maxillary sinusitis
-MONDO:0001007,chronic meningitis,MONDO:0021108,meningitis (disease)
-MONDO:0004614,chronic monocytic leukemia,MONDO:0004600,monocytic leukemia
-MONDO:0011996,chronic myelogenous leukemia,MONDO:0004643,myeloid leukemia
-MONDO:0005171,chronic myeloproliferative disorder,MONDO:0020076,myeloproliferative neoplasm
-MONDO:0005002,chronic obstructive pulmonary disease,MONDO:0002267,obstructive lung disease
-MONDO:0005003,chronic pancreatitis,MONDO:0004982,pancreatitis
-MONDO:0001917,chronic perichondritis of pinna,MONDO:0002246,perichondritis of auricle
-MONDO:0005593,chronic periodontitis,MONDO:0005076,periodontitis
-MONDO:0003335,chronic polyneuropathy,MONDO:0001824,polyneuropathy
-MONDO:0016170,chronic polyradiculoneuropathy,MONDO:0006915,polyradiculoneuropathy
-MONDO:0015129,chronic primary adrenal insufficiency,MONDO:0015128,primary adrenal insufficiency
-MONDO:0001920,chronic purulent otitis media,MONDO:0005975,suppurative otitis media
-MONDO:0001110,chronic pyelonephritis,MONDO:0006939,pyelonephritis
-MONDO:0001184,chronic rapidly progressive glomerulonephritis,MONDO:0017236,rapidly progressive glomerulonephritis
-MONDO:0004514,chronic rhinitis,MONDO:0003014,rhinitis
-MONDO:0003617,chronic salpingitis,MONDO:0003619,salpingitis
-MONDO:0001474,chronic salpingo-oophoritis,MONDO:0001172,salpingo-oophoritis
-MONDO:0001123,chronic sphenoidal sinusitis,MONDO:0005964,sphenoid sinusitis
-MONDO:0001074,chronic tic disorder,MONDO:0002420,tic disorder
-MONDO:0000492,chronic venous insufficiency,MONDO:0000945,venous insufficiency (disease)
-MONDO:0009847,"pericardial effusion, chronic",MONDO:0001370,pericardial effusion (disease)
-MONDO:0001025,seminal vesicle chronic gonorrhea,MONDO:0001027,gonococcal seminal vesiculitis
+http://purl.obolibrary.org/obo/MONDO_0016169,chronic acquired demyelinating polyneuropathy,http://purl.obolibrary.org/obo/MONDO_0015923,acquired peripheral neuropathy
+http://purl.obolibrary.org/obo/MONDO_0001251,chronic apical periodontitis,http://purl.obolibrary.org/obo/MONDO_0004508,periapical periodontitis
+http://purl.obolibrary.org/obo/MONDO_0005607,chronic bronchitis,http://purl.obolibrary.org/obo/MONDO_0003781,bronchitis
+http://purl.obolibrary.org/obo/MONDO_0004924,chronic canaliculitis,http://purl.obolibrary.org/obo/MONDO_0005631,actinomycosis
+http://purl.obolibrary.org/obo/MONDO_0002030,chronic cervicitis,http://purl.obolibrary.org/obo/MONDO_0002345,cervicitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0004786,chronic cholangitis,http://purl.obolibrary.org/obo/MONDO_0004789,cholangitis
+http://purl.obolibrary.org/obo/MONDO_0001966,chronic closed-angle glaucoma,http://purl.obolibrary.org/obo/MONDO_0001744,angle-closure glaucoma
+http://purl.obolibrary.org/obo/MONDO_0001367,chronic congestive splenomegaly,http://purl.obolibrary.org/obo/MONDO_0037251,congestive splenomegaly
+http://purl.obolibrary.org/obo/MONDO_0002314,chronic conjunctivitis,http://purl.obolibrary.org/obo/MONDO_0003799,conjunctivitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0015574,chronic cutaneous lupus erythematosus,http://purl.obolibrary.org/obo/MONDO_0005282,cutaneous lupus erythematosus
+http://purl.obolibrary.org/obo/MONDO_0006030,chronic cystitis,http://purl.obolibrary.org/obo/MONDO_0006032,cystitis
+http://purl.obolibrary.org/obo/MONDO_0004800,chronic dacryoadenitis,http://purl.obolibrary.org/obo/MONDO_0004804,dacryoadenitis
+http://purl.obolibrary.org/obo/MONDO_0004925,chronic dacryocystitis,http://purl.obolibrary.org/obo/MONDO_0004926,dacryocystitis
+http://purl.obolibrary.org/obo/MONDO_0044751,chronic diarrheal disease,http://purl.obolibrary.org/obo/MONDO_0001673,diarrheal disease
+http://purl.obolibrary.org/obo/MONDO_0020069,chronic encephalitis,http://purl.obolibrary.org/obo/MONDO_0019956,encephalitis
+http://purl.obolibrary.org/obo/MONDO_0024279,chronic endometritis,http://purl.obolibrary.org/obo/MONDO_0000918,endometritis
+http://purl.obolibrary.org/obo/MONDO_0017203,chronic endophthalmitis,http://purl.obolibrary.org/obo/MONDO_0016047,endophthalmitis
+http://purl.obolibrary.org/obo/MONDO_0004806,chronic eosinophilic pneumonia,http://purl.obolibrary.org/obo/MONDO_0005749,eosinophilic pneumonia
+http://purl.obolibrary.org/obo/MONDO_0004757,chronic ethmoidal sinusitis,http://purl.obolibrary.org/obo/MONDO_0005756,ethmoid sinusitis
+http://purl.obolibrary.org/obo/MONDO_0002170,chronic eustachian salpingitis,http://purl.obolibrary.org/obo/MONDO_0002172,otosalpingitis
+http://purl.obolibrary.org/obo/MONDO_0001120,chronic frontal sinusitis,http://purl.obolibrary.org/obo/MONDO_0001121,frontal sinusitis
+http://purl.obolibrary.org/obo/MONDO_0001052,chronic fungal otitis externa,http://purl.obolibrary.org/obo/MONDO_0000262,otomycosis
+http://purl.obolibrary.org/obo/MONDO_0005001,chronic gastritis (disease),http://purl.obolibrary.org/obo/MONDO_0004966,gastritis (disease)
+http://purl.obolibrary.org/obo/MONDO_0001575,chronic gonococcal salpingitis,http://purl.obolibrary.org/obo/MONDO_0021159,gonococcal salpingitis
+http://purl.obolibrary.org/obo/MONDO_0002029,chronic gonorrhea of cervix,http://purl.obolibrary.org/obo/MONDO_0021157,gonococcal cervicitis
+http://purl.obolibrary.org/obo/MONDO_0020547,chronic graft versus host disease,http://purl.obolibrary.org/obo/MONDO_0013730,graft versus host disease
+http://purl.obolibrary.org/obo/MONDO_0019800,chronic hepatic porphyria,http://purl.obolibrary.org/obo/MONDO_0002520,acute hepatic porphyria
+http://purl.obolibrary.org/obo/MONDO_0005366,chronic hepatitis B,http://purl.obolibrary.org/obo/MONDO_0005344,hepatitis B
+http://purl.obolibrary.org/obo/MONDO_0005354,chronic hepatitis C,http://purl.obolibrary.org/obo/MONDO_0005231,hepatitis C
+http://purl.obolibrary.org/obo/MONDO_0044212,chronic idiopathic urticaria,http://purl.obolibrary.org/obo/MONDO_0044211,idiopathic urticaria
+http://purl.obolibrary.org/obo/MONDO_0017574,chronic intestinal pseudoobstruction,http://purl.obolibrary.org/obo/MONDO_0002803,intestinal pseudo-obstruction
+http://purl.obolibrary.org/obo/MONDO_0005300,chronic kidney disease,http://purl.obolibrary.org/obo/MONDO_0005240,kidney disease
+http://purl.obolibrary.org/obo/MONDO_0001369,chronic laryngitis,http://purl.obolibrary.org/obo/MONDO_0002647,laryngitis
+http://purl.obolibrary.org/obo/MONDO_0001014,chronic leukemia,http://purl.obolibrary.org/obo/MONDO_0005059,leukemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0001122,chronic maxillary sinusitis,http://purl.obolibrary.org/obo/MONDO_0005842,maxillary sinusitis
+http://purl.obolibrary.org/obo/MONDO_0001007,chronic meningitis,http://purl.obolibrary.org/obo/MONDO_0021108,meningitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0004614,chronic monocytic leukemia,http://purl.obolibrary.org/obo/MONDO_0004600,monocytic leukemia
+http://purl.obolibrary.org/obo/MONDO_0021206,chronic non-suppurative otitis media,http://purl.obolibrary.org/obo/MONDO_0001212,non-suppurative otitis media
+http://purl.obolibrary.org/obo/MONDO_0005002,chronic obstructive pulmonary disease,http://purl.obolibrary.org/obo/MONDO_0002267,obstructive lung disease
+http://purl.obolibrary.org/obo/MONDO_0021204,chronic otitis media,http://purl.obolibrary.org/obo/MONDO_0005441,otitis media (disease)
+http://purl.obolibrary.org/obo/MONDO_0024317,chronic pain syndrome,http://purl.obolibrary.org/obo/MONDO_0021668,disorder involving pain
+http://purl.obolibrary.org/obo/MONDO_0005003,chronic pancreatitis,http://purl.obolibrary.org/obo/MONDO_0004982,pancreatitis
+http://purl.obolibrary.org/obo/MONDO_0001917,chronic perichondritis of pinna,http://purl.obolibrary.org/obo/MONDO_0002246,perichondritis of auricle
+http://purl.obolibrary.org/obo/MONDO_0005593,chronic periodontitis,http://purl.obolibrary.org/obo/MONDO_0005076,periodontitis
+http://purl.obolibrary.org/obo/MONDO_0003335,chronic polyneuropathy,http://purl.obolibrary.org/obo/MONDO_0001824,polyneuropathy
+http://purl.obolibrary.org/obo/MONDO_0016170,chronic polyradiculoneuropathy,http://purl.obolibrary.org/obo/MONDO_0006915,polyradiculoneuropathy
+http://purl.obolibrary.org/obo/MONDO_0015129,chronic primary adrenal insufficiency,http://purl.obolibrary.org/obo/MONDO_0015128,primary adrenal insufficiency
+http://purl.obolibrary.org/obo/MONDO_0001920,chronic purulent otitis media,http://purl.obolibrary.org/obo/MONDO_0005975,suppurative otitis media
+http://purl.obolibrary.org/obo/MONDO_0001110,chronic pyelonephritis,http://purl.obolibrary.org/obo/MONDO_0006939,pyelonephritis
+http://purl.obolibrary.org/obo/MONDO_0001184,chronic rapidly progressive glomerulonephritis,http://purl.obolibrary.org/obo/MONDO_0017236,rapidly progressive glomerulonephritis
+http://purl.obolibrary.org/obo/MONDO_0024327,chronic renal failure syndrome,http://purl.obolibrary.org/obo/MONDO_0001106,kidney failure
+http://purl.obolibrary.org/obo/MONDO_0002133,chronic rheumatic pericarditis,http://purl.obolibrary.org/obo/MONDO_0024655,rheumatic pericarditis
+http://purl.obolibrary.org/obo/MONDO_0004514,chronic rhinitis,http://purl.obolibrary.org/obo/MONDO_0003014,rhinitis
+http://purl.obolibrary.org/obo/MONDO_0006031,chronic rhinosinusitis,http://purl.obolibrary.org/obo/MONDO_0005961,sinusitis
+http://purl.obolibrary.org/obo/MONDO_0003617,chronic salpingitis,http://purl.obolibrary.org/obo/MONDO_0003619,salpingitis
+http://purl.obolibrary.org/obo/MONDO_0001474,chronic salpingo-oophoritis,http://purl.obolibrary.org/obo/MONDO_0001172,salpingo-oophoritis
+http://purl.obolibrary.org/obo/MONDO_0001123,chronic sphenoidal sinusitis,http://purl.obolibrary.org/obo/MONDO_0005964,sphenoid sinusitis
+http://purl.obolibrary.org/obo/MONDO_0001074,chronic tic disorder,http://purl.obolibrary.org/obo/MONDO_0002420,tic disorder
+http://purl.obolibrary.org/obo/MONDO_0001227ub,chronic tympanitis,http://purl.obolibrary.org/obo/MONDO_0024616,tympanitis
+http://purl.obolibrary.org/obo/MONDO_0000492,chronic venous insufficiency,http://purl.obolibrary.org/obo/MONDO_0000945,venous insufficiency (disease)
+http://purl.obolibrary.org/obo/MONDO_0009847,"pericardial effusion, chronic",http://purl.obolibrary.org/obo/MONDO_0001370,pericardial effusion (disease)
+http://purl.obolibrary.org/obo/MONDO_0001025,seminal vesicle chronic gonorrhea,http://purl.obolibrary.org/obo/MONDO_0001027,gonococcal seminal vesiculitis
+http://purl.obolibrary.org/obo/MONDO_0001213,serous glue ear,http://purl.obolibrary.org/obo/MONDO_0021203,serous otitis media

--- a/src/patterns/congenital.csv
+++ b/src/patterns/congenital.csv
@@ -1,1 +1,9 @@
 iri,iri label,disease,disease label
+http://purl.obolibrary.org/obo/MONDO_0001902,congenital agammaglobulinemia,http://purl.obolibrary.org/obo/MONDO_0015977,agammaglobulinemia
+http://purl.obolibrary.org/obo/MONDO_0000577,congenital anemia,http://purl.obolibrary.org/obo/MONDO_0002280,anemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0017375,congenital enterovirus infection,http://purl.obolibrary.org/obo/MONDO_0005747,enterovirus infectious disease
+http://purl.obolibrary.org/obo/MONDO_0004527,congenital granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor
+http://purl.obolibrary.org/obo/MONDO_0009332,congenital hematological disorder,http://purl.obolibrary.org/obo/MONDO_0005570,hematological system disease
+http://purl.obolibrary.org/obo/MONDO_0016349,congenital hydrocephalus,http://purl.obolibrary.org/obo/MONDO_0001150,hydrocephalus
+http://purl.obolibrary.org/obo/MONDO_0018612,congenital hypothyroidism,http://purl.obolibrary.org/obo/MONDO_0005420,hypothyroidism
+http://purl.obolibrary.org/obo/MONDO_0024287,congenital vascular malformation,http://purl.obolibrary.org/obo/MONDO_0024291,vascular malformation

--- a/src/patterns/disease_by_dysfunctional_structure.csv
+++ b/src/patterns/disease_by_dysfunctional_structure.csv
@@ -1,1 +1,4 @@
 iri,iri label,structure,structure label
+http://purl.obolibrary.org/obo/MONDO_0004880,bowel dysfunction,http://purl.obolibrary.org/obo/UBERON_0004907,lower digestive tract
+http://purl.obolibrary.org/obo/MONDO_0001343,impaired renal function disease,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0019744,rare renal tubular disease,http://purl.obolibrary.org/obo/UBERON_0009773,renal tubule

--- a/src/patterns/disease_series_by_gene.csv
+++ b/src/patterns/disease_series_by_gene.csv
@@ -1,0 +1,2086 @@
+iri,iri label,disease,disease label,gene,gene label
+http://purl.obolibrary.org/obo/MONDO_0008861,3-methylcrotonyl-CoA carboxylase 1 deficiency,http://purl.obolibrary.org/obo/MONDO_0018950,3-methylcrotonyl-CoA carboxylase deficiency,http://identifiers.org/hgnc/6936,MCCC1
+http://purl.obolibrary.org/obo/MONDO_0008862,3-methylcrotonyl-CoA carboxylase 2 deficiency,http://purl.obolibrary.org/obo/MONDO_0018950,3-methylcrotonyl-CoA carboxylase deficiency,http://identifiers.org/hgnc/6937,MCCC2
+http://purl.obolibrary.org/obo/MONDO_0009610,3-methylglutaconic aciduria type 1,http://purl.obolibrary.org/obo/MONDO_0017359,3-methylglutaconic aciduria,http://identifiers.org/hgnc/890,AUH
+http://purl.obolibrary.org/obo/MONDO_0009787,3-methylglutaconic aciduria type 3,http://purl.obolibrary.org/obo/MONDO_0017359,3-methylglutaconic aciduria,http://identifiers.org/hgnc/8142,OPA3
+http://purl.obolibrary.org/obo/MONDO_0012435,3-methylglutaconic aciduria type 5,http://purl.obolibrary.org/obo/MONDO_0017359,3-methylglutaconic aciduria,http://identifiers.org/hgnc/30528,DNAJC19
+http://purl.obolibrary.org/obo/MONDO_0014561,"3-methylglutaconic aciduria with cataracts, neurologic involvement and neutropenia",http://purl.obolibrary.org/obo/MONDO_0017359,3-methylglutaconic aciduria,http://identifiers.org/hgnc/30664,CLPB
+http://purl.obolibrary.org/obo/MONDO_0013875,"3-methylglutaconic aciduria with deafness, encephalopathy, and Leigh-like syndrome",http://purl.obolibrary.org/obo/MONDO_0017359,3-methylglutaconic aciduria,http://identifiers.org/hgnc/21061,SERAC1
+http://purl.obolibrary.org/obo/MONDO_0009770,3MC syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017398,3MC syndrome,http://identifiers.org/hgnc/6901,MASP1
+http://purl.obolibrary.org/obo/MONDO_0009927,3MC syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017398,3MC syndrome,http://identifiers.org/hgnc/17213,COLEC11
+http://purl.obolibrary.org/obo/MONDO_0009554,3MC syndrome 3,http://purl.obolibrary.org/obo/MONDO_0017398,3MC syndrome,http://identifiers.org/hgnc/2220,COLEC10
+http://purl.obolibrary.org/obo/MONDO_0014416,ACTH-independent macronodular adrenal hyperplasia 2,http://purl.obolibrary.org/obo/MONDO_0009049,Cushing syndrome due to macronodular adrenal hyperplasia,http://identifiers.org/hgnc/25781,ARMC5
+http://purl.obolibrary.org/obo/MONDO_0024506,Adams-Oliver syndrome 1,http://purl.obolibrary.org/obo/MONDO_0007034,Adams-Oliver syndrome,http://identifiers.org/hgnc/29216,ARHGAP31
+http://purl.obolibrary.org/obo/MONDO_0013635,Adams-Oliver syndrome 2,http://purl.obolibrary.org/obo/MONDO_0007034,Adams-Oliver syndrome,http://identifiers.org/hgnc/19189,DOCK6
+http://purl.obolibrary.org/obo/MONDO_0013895,Adams-Oliver syndrome 3,http://purl.obolibrary.org/obo/MONDO_0007034,Adams-Oliver syndrome,http://identifiers.org/hgnc/5724,RBPJ
+http://purl.obolibrary.org/obo/MONDO_0014124,Adams-Oliver syndrome 4,http://purl.obolibrary.org/obo/MONDO_0007034,Adams-Oliver syndrome,http://identifiers.org/hgnc/28526,EOGT
+http://purl.obolibrary.org/obo/MONDO_0014459,Adams-Oliver syndrome 5,http://purl.obolibrary.org/obo/MONDO_0007034,Adams-Oliver syndrome,http://identifiers.org/hgnc/7881,NOTCH1
+http://purl.obolibrary.org/obo/MONDO_0014703,Adams-Oliver syndrome 6,http://purl.obolibrary.org/obo/MONDO_0007034,Adams-Oliver syndrome,http://identifiers.org/hgnc/2910,DLL4
+http://purl.obolibrary.org/obo/MONDO_0009165,Aicardi-Goutieres syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/12269,TREX1
+http://purl.obolibrary.org/obo/MONDO_0012429,Aicardi-Goutieres syndrome 2,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/25671,RNASEH2B
+http://purl.obolibrary.org/obo/MONDO_0012471,Aicardi-Goutieres syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/24116,RNASEH2C
+http://purl.obolibrary.org/obo/MONDO_0012472,Aicardi-Goutieres syndrome 4,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/18518,RNASEH2A
+http://purl.obolibrary.org/obo/MONDO_0013059,Aicardi-Goutieres syndrome 5,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/15925,SAMHD1
+http://purl.obolibrary.org/obo/MONDO_0014007,Aicardi-Goutieres syndrome 6,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/225,ADAR
+http://purl.obolibrary.org/obo/MONDO_0014367,Aicardi-Goutieres syndrome 7,http://purl.obolibrary.org/obo/MONDO_0018866,Aicardi-Goutieres syndrome,http://identifiers.org/hgnc/18873,IFIH1
+http://purl.obolibrary.org/obo/MONDO_0014265,Alzheimer disease 18,http://purl.obolibrary.org/obo/MONDO_0004975,Alzheimer disease,http://identifiers.org/hgnc/188,ADAM10
+http://purl.obolibrary.org/obo/MONDO_0014316,Alzheimer disease 19,http://purl.obolibrary.org/obo/MONDO_0004975,Alzheimer disease,http://identifiers.org/hgnc/17158,PLD3
+http://purl.obolibrary.org/obo/MONDO_0011913,Alzheimer disease 3,http://purl.obolibrary.org/obo/MONDO_0015140,early-onset autosomal dominant Alzheimer disease,http://identifiers.org/hgnc/9508,PSEN1
+http://purl.obolibrary.org/obo/MONDO_0008386,Axenfeld-Rieger syndrome type 1,http://purl.obolibrary.org/obo/MONDO_0019187,Axenfeld-Rieger syndrome,http://identifiers.org/hgnc/9005,PITX2
+http://purl.obolibrary.org/obo/MONDO_0011233,Axenfeld-Rieger syndrome type 3,http://purl.obolibrary.org/obo/MONDO_0019187,Axenfeld-Rieger syndrome,http://identifiers.org/hgnc/3800,FOXC1
+http://purl.obolibrary.org/obo/MONDO_0009470,Baraitser-Winter syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017579,Baraitser-Winter cerebrofrontofacial syndrome,http://identifiers.org/hgnc/132,ACTB
+http://purl.obolibrary.org/obo/MONDO_0013812,Baraitser-winter syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017579,Baraitser-Winter cerebrofrontofacial syndrome,http://identifiers.org/hgnc/144,ACTG1
+http://purl.obolibrary.org/obo/MONDO_0014438,Bardet-Biedl syndrome 10,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/26291,BBS10
+http://purl.obolibrary.org/obo/MONDO_0014439,Bardet-Biedl syndrome 11,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/16380,TRIM32
+http://purl.obolibrary.org/obo/MONDO_0014440,Bardet-Biedl syndrome 12,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/26648,BBS12
+http://purl.obolibrary.org/obo/MONDO_0014441,Bardet-Biedl syndrome 13,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/7121,MKS1
+http://purl.obolibrary.org/obo/MONDO_0014443,Bardet-Biedl syndrome 15,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/28027,WDPCP
+http://purl.obolibrary.org/obo/MONDO_0014444,Bardet-Biedl syndrome 16,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/10671,SDCCAG8
+http://purl.obolibrary.org/obo/MONDO_0014445,Bardet-Biedl syndrome 17,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/6741,LZTFL1
+http://purl.obolibrary.org/obo/MONDO_0014446,Bardet-Biedl syndrome 18,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/28093,BBIP1
+http://purl.obolibrary.org/obo/MONDO_0014447,Bardet-Biedl syndrome 19,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/18626,IFT27
+http://purl.obolibrary.org/obo/MONDO_0014432,Bardet-Biedl syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/967,BBS2
+http://purl.obolibrary.org/obo/MONDO_0014926,Bardet-Biedl syndrome 20; BBS20,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/21424,IFT74
+http://purl.obolibrary.org/obo/MONDO_0014434,Bardet-Biedl syndrome 5,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/970,BBS5
+http://purl.obolibrary.org/obo/MONDO_0014435,Bardet-Biedl syndrome 7,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/18758,BBS7
+http://purl.obolibrary.org/obo/MONDO_0014436,Bardet-Biedl syndrome 8,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/20087,TTC8
+http://purl.obolibrary.org/obo/MONDO_0014437,Bardet-Biedl syndrome 9,http://purl.obolibrary.org/obo/MONDO_0015229,Bardet-Biedl syndrome,http://identifiers.org/hgnc/30000,BBS9
+http://purl.obolibrary.org/obo/MONDO_0011127,Bartter disease type 1,http://purl.obolibrary.org/obo/MONDO_0015231,Bartter syndrome,http://identifiers.org/hgnc/10910,SLC12A1
+http://purl.obolibrary.org/obo/MONDO_0009424,Bartter disease type 2,http://purl.obolibrary.org/obo/MONDO_0015231,Bartter syndrome,http://identifiers.org/hgnc/6255,KCNJ1
+http://purl.obolibrary.org/obo/MONDO_0011242,Bartter disease type 4a,http://purl.obolibrary.org/obo/MONDO_0015231,Bartter syndrome,http://identifiers.org/hgnc/16512,BSND
+http://purl.obolibrary.org/obo/MONDO_0010503,Bartter disease type 5,http://purl.obolibrary.org/obo/MONDO_0015231,Bartter syndrome,http://identifiers.org/hgnc/16353,MAGED2
+http://purl.obolibrary.org/obo/MONDO_0014655,Bethlem myopathy 2,http://purl.obolibrary.org/obo/MONDO_0008029,Bethlem myopathy,http://identifiers.org/hgnc/2188,COL12A1
+http://purl.obolibrary.org/obo/MONDO_0024537,Brown-Vialetto-van Laere syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000406,Brown-Vialetto-van Laere syndrome,http://identifiers.org/hgnc/16187,SLC52A3
+http://purl.obolibrary.org/obo/MONDO_0009806,Bruck syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017195,Bruck syndrome,http://identifiers.org/hgnc/18169,FKBP10
+http://purl.obolibrary.org/obo/MONDO_0012217,Bruck syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017195,Bruck syndrome,http://identifiers.org/hgnc/9082,PLOD2
+http://purl.obolibrary.org/obo/MONDO_0011001,Brugada syndrome 1,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/10593,SCN5A
+http://purl.obolibrary.org/obo/MONDO_0012728,Brugada syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/28956,GPD1L
+http://purl.obolibrary.org/obo/MONDO_0012742,Brugada syndrome 3,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/1390,CACNA1C
+http://purl.obolibrary.org/obo/MONDO_0012743,Brugada syndrome 4,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/1402,CACNB2
+http://purl.obolibrary.org/obo/MONDO_0013015,Brugada syndrome 5,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/10586,SCN1B
+http://purl.obolibrary.org/obo/MONDO_0013145,Brugada syndrome 6,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/6243,KCNE3
+http://purl.obolibrary.org/obo/MONDO_0013146,Brugada syndrome 7,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/20665,SCN3B
+http://purl.obolibrary.org/obo/MONDO_0013148,Brugada syndrome 8,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/16882,HCN4
+http://purl.obolibrary.org/obo/MONDO_0014621,Brugada syndrome 9,http://purl.obolibrary.org/obo/MONDO_0015263,Brugada syndrome,http://identifiers.org/hgnc/6239,KCND3
+http://purl.obolibrary.org/obo/MONDO_0100039,CDKL5 disorder,http://purl.obolibrary.org/obo/MONDO_0003847,inherited genetic disease,http://identifiers.org/hgnc/11411,CDKL5
+http://purl.obolibrary.org/obo/MONDO_0008057,"Carney complex, type 1",http://purl.obolibrary.org/obo/MONDO_0015285,Carney complex,http://identifiers.org/hgnc/9388,PRKAR1A
+http://purl.obolibrary.org/obo/MONDO_0008710,Carpenter syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019012,Carpenter syndrome,http://identifiers.org/hgnc/14263,RAB23
+http://purl.obolibrary.org/obo/MONDO_0013998,Carpenter syndrome 2,http://purl.obolibrary.org/obo/MONDO_0019012,Carpenter syndrome,http://identifiers.org/hgnc/3233,MEGF8
+http://purl.obolibrary.org/obo/MONDO_0010549,Charcot-Marie-tooth disease X-linked dominant 1,http://purl.obolibrary.org/obo/MONDO_0018994,Charcot-Marie-tooth disease type X,http://identifiers.org/hgnc/4283,GJB1
+http://purl.obolibrary.org/obo/MONDO_0011633,Charcot-Marie-tooth disease axonal type 2C,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/18083,TRPV4
+http://purl.obolibrary.org/obo/MONDO_0014836,Charcot-Marie-tooth disease axonal type 2CC,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/7737,NEFH
+http://purl.obolibrary.org/obo/MONDO_0011687,Charcot-Marie-tooth disease axonal type 2F,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/5246,HSPB1
+http://purl.obolibrary.org/obo/MONDO_0012096,Charcot-Marie-tooth disease axonal type 2L,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/30171,HSPB8
+http://purl.obolibrary.org/obo/MONDO_0013212,Charcot-Marie-tooth disease axonal type 2N,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/20,AARS
+http://purl.obolibrary.org/obo/MONDO_0013644,Charcot-Marie-tooth disease axonal type 2O,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/2961,DYNC1H1
+http://purl.obolibrary.org/obo/MONDO_0013753,Charcot-Marie-tooth disease axonal type 2P,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/25135,LRSAM1
+http://purl.obolibrary.org/obo/MONDO_0014012,Charcot-Marie-tooth disease axonal type 2Q,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/23537,DHTKD1
+http://purl.obolibrary.org/obo/MONDO_0014511,Charcot-Marie-tooth disease axonal type 2S,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/5542,IGHMBP2
+http://purl.obolibrary.org/obo/MONDO_0014566,Charcot-Marie-tooth disease axonal type 2U,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/6898,MARS
+http://purl.obolibrary.org/obo/MONDO_0014665,Charcot-Marie-tooth disease axonal type 2V,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/7632,NAGLU
+http://purl.obolibrary.org/obo/MONDO_0014726,Charcot-Marie-tooth disease axonal type 2X,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/11226,SPG11
+http://purl.obolibrary.org/obo/MONDO_0014736,Charcot-Marie-tooth disease axonal type 2Z,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/23573,MORC2
+http://purl.obolibrary.org/obo/MONDO_0011674,Charcot-Marie-tooth disease dominant intermediate b,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/2974,DNM2
+http://purl.obolibrary.org/obo/MONDO_0012012,Charcot-Marie-tooth disease dominant intermediate c,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/12840,YARS
+http://purl.obolibrary.org/obo/MONDO_0011909,Charcot-Marie-tooth disease dominant intermediate d,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/7225,MPZ
+http://purl.obolibrary.org/obo/MONDO_0012014,Charcot-Marie-tooth disease recessive intermediate a,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/15968,GDAP1
+http://purl.obolibrary.org/obo/MONDO_0013338,Charcot-Marie-tooth disease recessive intermediate b,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/6215,KARS
+http://purl.obolibrary.org/obo/MONDO_0014154,Charcot-Marie-tooth disease recessive intermediate c,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/29105,PLEKHG5
+http://purl.obolibrary.org/obo/MONDO_0014467,Charcot-Marie-tooth disease recessive intermediate d,http://purl.obolibrary.org/obo/MONDO_0015626,Charcot-Marie-tooth disease,http://identifiers.org/hgnc/2277,COX6A1
+http://purl.obolibrary.org/obo/MONDO_0007307,Charcot-Marie-tooth disease type 1B,http://purl.obolibrary.org/obo/MONDO_0019011,Charcot-Marie-tooth disease type 1,http://identifiers.org/hgnc/7225,MPZ
+http://purl.obolibrary.org/obo/MONDO_0010995,Charcot-Marie-tooth disease type 1C,http://purl.obolibrary.org/obo/MONDO_0019011,Charcot-Marie-tooth disease type 1,http://identifiers.org/hgnc/16841,LITAF
+http://purl.obolibrary.org/obo/MONDO_0011890,Charcot-Marie-tooth disease type 1D,http://purl.obolibrary.org/obo/MONDO_0019011,Charcot-Marie-tooth disease type 1,http://identifiers.org/hgnc/3239,EGR2
+http://purl.obolibrary.org/obo/MONDO_0011902,Charcot-Marie-tooth disease type 1F,http://purl.obolibrary.org/obo/MONDO_0019011,Charcot-Marie-tooth disease type 1,http://identifiers.org/hgnc/7739,NEFL
+http://purl.obolibrary.org/obo/MONDO_0007308,Charcot-Marie-tooth disease type 2A1,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/16636,KIF1B
+http://purl.obolibrary.org/obo/MONDO_0012231,Charcot-Marie-tooth disease type 2A2,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/16877,MFN2
+http://purl.obolibrary.org/obo/MONDO_0010949,Charcot-Marie-tooth disease type 2B,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/9788,RAB7A
+http://purl.obolibrary.org/obo/MONDO_0011569,Charcot-Marie-tooth disease type 2B1,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/6636,LMNA
+http://purl.obolibrary.org/obo/MONDO_0011570,Charcot-Marie-tooth disease type 2B2,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/28845,MED25
+http://purl.obolibrary.org/obo/MONDO_0011091,Charcot-Marie-tooth disease type 2D,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/4162,GARS
+http://purl.obolibrary.org/obo/MONDO_0011894,Charcot-Marie-tooth disease type 2E,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/7739,NEFL
+http://purl.obolibrary.org/obo/MONDO_0014208,Charcot-Marie-tooth disease type 2R,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/15974,TRIM2
+http://purl.obolibrary.org/obo/MONDO_0014735,Charcot-Marie-tooth disease type 2Y,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/12666,VCP
+http://purl.obolibrary.org/obo/MONDO_0008961,Charcot-Marie-tooth disease type 4A,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/15968,GDAP1
+http://purl.obolibrary.org/obo/MONDO_0011066,Charcot-Marie-tooth disease type 4B1,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/7450,MTMR2
+http://purl.obolibrary.org/obo/MONDO_0011475,Charcot-Marie-tooth disease type 4B2,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/2135,SBF2
+http://purl.obolibrary.org/obo/MONDO_0014117,Charcot-Marie-tooth disease type 4B3,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/10542,SBF1
+http://purl.obolibrary.org/obo/MONDO_0011113,Charcot-Marie-tooth disease type 4C,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/29427,SH3TC2
+http://purl.obolibrary.org/obo/MONDO_0011085,Charcot-Marie-tooth disease type 4D,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/7679,NDRG1
+http://purl.obolibrary.org/obo/MONDO_0013959,Charcot-Marie-tooth disease type 4F,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/13797,PRX
+http://purl.obolibrary.org/obo/MONDO_0011534,Charcot-Marie-tooth disease type 4G,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/4922,HK1
+http://purl.obolibrary.org/obo/MONDO_0012250,Charcot-Marie-tooth disease type 4H,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/19125,FGD4
+http://purl.obolibrary.org/obo/MONDO_0012640,Charcot-Marie-tooth disease type 4J,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/16873,FIG4
+http://purl.obolibrary.org/obo/MONDO_0014733,Charcot-Marie-tooth disease type 4K,http://purl.obolibrary.org/obo/MONDO_0018995,Charcot-Marie-tooth disease type 4,http://identifiers.org/hgnc/11474,SURF1
+http://purl.obolibrary.org/obo/MONDO_0009892,Chuvash polycythemia,http://purl.obolibrary.org/obo/MONDO_0001115,familial polycythemia,http://identifiers.org/hgnc/12687,VHL
+http://purl.obolibrary.org/obo/MONDO_0019569,Cockayne syndrome type 1,http://purl.obolibrary.org/obo/MONDO_0016006,Cockayne syndrome,http://identifiers.org/hgnc/3439,ERCC8
+http://purl.obolibrary.org/obo/MONDO_0014838,Coffin-Siris syndrome 5,http://purl.obolibrary.org/obo/MONDO_0015452,Coffin-Siris syndrome,http://identifiers.org/hgnc/11109,SMARCE1
+http://purl.obolibrary.org/obo/MONDO_0007204,Cole-Carpenter syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016085,Cole-Carpenter syndrome,http://identifiers.org/hgnc/8548,P4HB
+http://purl.obolibrary.org/obo/MONDO_0014573,Cole-Carpenter syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016085,Cole-Carpenter syndrome,http://identifiers.org/hgnc/10706,SEC24D
+http://purl.obolibrary.org/obo/MONDO_0007387,Cornelia de Lange syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016033,Cornelia de Lange syndrome,http://identifiers.org/hgnc/28862,NIPBL
+http://purl.obolibrary.org/obo/MONDO_0010370,Cornelia de Lange syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016033,Cornelia de Lange syndrome,http://identifiers.org/hgnc/11111,SMC1A
+http://purl.obolibrary.org/obo/MONDO_0012555,Cornelia de Lange syndrome 3,http://purl.obolibrary.org/obo/MONDO_0016033,Cornelia de Lange syndrome,http://identifiers.org/hgnc/2468,SMC3
+http://purl.obolibrary.org/obo/MONDO_0013864,Cornelia de Lange syndrome 4,http://purl.obolibrary.org/obo/MONDO_0016033,Cornelia de Lange syndrome,http://identifiers.org/hgnc/9811,RAD21
+http://purl.obolibrary.org/obo/MONDO_0008021,Cowden syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/9588,PTEN
+http://purl.obolibrary.org/obo/MONDO_0012878,Cowden syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/10681,SDHB
+http://purl.obolibrary.org/obo/MONDO_0014045,Cowden syndrome 3,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/10683,SDHD
+http://purl.obolibrary.org/obo/MONDO_0014046,Cowden syndrome 4,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/37212,KLLN
+http://purl.obolibrary.org/obo/MONDO_0014047,Cowden syndrome 5,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/8975,PIK3CA
+http://purl.obolibrary.org/obo/MONDO_0014048,Cowden syndrome 6,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/391,AKT1
+http://purl.obolibrary.org/obo/MONDO_0014802,Cowden syndrome 7,http://purl.obolibrary.org/obo/MONDO_0016063,Cowden disease,http://identifiers.org/hgnc/10702,SEC23B
+http://purl.obolibrary.org/obo/MONDO_0024554,D-2-hydroxyglutaric aciduria 1,http://purl.obolibrary.org/obo/MONDO_0010924,D-2-hydroxyglutaric aciduria,http://identifiers.org/hgnc/28358,D2HGDH
+http://purl.obolibrary.org/obo/MONDO_0014809,DDX41-related hematologic malignancy predisposition syndrome,http://purl.obolibrary.org/obo/MONDO_0015356,hereditary neoplastic syndrome,http://identifiers.org/hgnc/18674,DDX41
+http://purl.obolibrary.org/obo/MONDO_0010225,Dent disease type 1,http://purl.obolibrary.org/obo/MONDO_0015612,Dent disease,http://identifiers.org/hgnc/2023,CLCN5
+http://purl.obolibrary.org/obo/MONDO_0010359,Dent disease type 2,http://purl.obolibrary.org/obo/MONDO_0015612,Dent disease,http://identifiers.org/hgnc/8108,OCRL
+http://purl.obolibrary.org/obo/MONDO_0009629,Desbuquois dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0015426,Desbuquois dysplasia,http://identifiers.org/hgnc/19721,CANT1
+http://purl.obolibrary.org/obo/MONDO_0014343,Desbuquois dysplasia 2,http://purl.obolibrary.org/obo/MONDO_0015426,Desbuquois dysplasia,http://identifiers.org/hgnc/15516,XYLT1
+http://purl.obolibrary.org/obo/MONDO_0007110,Diamond-Blackfan anemia 1,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10402,RPS19
+http://purl.obolibrary.org/obo/MONDO_0013217,Diamond-Blackfan anemia 10,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10414,RPS26
+http://purl.obolibrary.org/obo/MONDO_0013964,Diamond-Blackfan anemia 11,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10327,RPL26
+http://purl.obolibrary.org/obo/MONDO_0014245,Diamond-Blackfan anemia 12,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10306,RPL15
+http://purl.obolibrary.org/obo/MONDO_0014394,Diamond-Blackfan anemia 13,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10419,RPS29
+http://purl.obolibrary.org/obo/MONDO_0010493,Diamond-Blackfan anemia 14 with mandibulofacial dysostosis,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/25455,TSR2
+http://purl.obolibrary.org/obo/MONDO_0011639,Diamond-Blackfan anemia 15 with mandibulofacial dysostosis,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10418,RPS28
+http://purl.obolibrary.org/obo/MONDO_0012529,Diamond-Blackfan anemia 3,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10411,RPS24
+http://purl.obolibrary.org/obo/MONDO_0012924,Diamond-Blackfan anemia 4,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10397,RPS17
+http://purl.obolibrary.org/obo/MONDO_0012925,Diamond-Blackfan anemia 5,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10345,RPL35A
+http://purl.obolibrary.org/obo/MONDO_0012937,Diamond-Blackfan anemia 6,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10360,RPL5
+http://purl.obolibrary.org/obo/MONDO_0012938,Diamond-Blackfan anemia 7,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10301,RPL11
+http://purl.obolibrary.org/obo/MONDO_0012939,Diamond-Blackfan anemia 8,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10440,RPS7
+http://purl.obolibrary.org/obo/MONDO_0013216,Diamond-Blackfan anemia 9,http://purl.obolibrary.org/obo/MONDO_0015253,Diamond-Blackfan anemia,http://identifiers.org/hgnc/10383,RPS10
+http://purl.obolibrary.org/obo/MONDO_0024534,Dowling-Degos disease 1,http://purl.obolibrary.org/obo/MONDO_0008371,Dowling-Degos disease,http://identifiers.org/hgnc/6442,KRT5
+http://purl.obolibrary.org/obo/MONDO_0014130,Dowling-Degos disease 2,http://purl.obolibrary.org/obo/MONDO_0008371,Dowling-Degos disease,http://identifiers.org/hgnc/14988,POFUT1
+http://purl.obolibrary.org/obo/MONDO_0014307,Dowling-Degos disease 4,http://purl.obolibrary.org/obo/MONDO_0008371,Dowling-Degos disease,http://identifiers.org/hgnc/22954,POGLUT1
+http://purl.obolibrary.org/obo/MONDO_0011444,Duane retraction syndrome 2,http://purl.obolibrary.org/obo/MONDO_0007473,Duane retraction syndrome,http://identifiers.org/hgnc/1943,CHN1
+http://purl.obolibrary.org/obo/MONDO_0014880,Duane retraction syndrome 3 with or without deafness,http://purl.obolibrary.org/obo/MONDO_0007473,Duane retraction syndrome,http://identifiers.org/hgnc/6408,MAFB
+http://purl.obolibrary.org/obo/MONDO_0014236,"Ehlers-Danlos syndrome, musculocontractural type 2",http://purl.obolibrary.org/obo/MONDO_0011142,"Ehlers-Danlos syndrome, musculocontractural type",http://identifiers.org/hgnc/21144,DSE
+http://purl.obolibrary.org/obo/MONDO_0014139,"Ehlers-Danlos syndrome, progeroid type, 2",http://purl.obolibrary.org/obo/MONDO_0007526,Ehlers-Danlos syndrome progeroid type,http://identifiers.org/hgnc/17978,B3GALT6
+http://purl.obolibrary.org/obo/MONDO_0014676,"Emery-Dreifuss muscular dystrophy 3, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0008406,autosomal recessive Emery-Dreifuss muscular dystrophy,http://identifiers.org/hgnc/6636,LMNA
+http://purl.obolibrary.org/obo/MONDO_0013071,"Emery-Dreifuss muscular dystrophy 4, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0020336,autosomal dominant Emery-Dreifuss muscular dystrophy,http://identifiers.org/hgnc/17089,SYNE1
+http://purl.obolibrary.org/obo/MONDO_0013072,"Emery-Dreifuss muscular dystrophy 5, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0020336,autosomal dominant Emery-Dreifuss muscular dystrophy,http://identifiers.org/hgnc/17084,SYNE2
+http://purl.obolibrary.org/obo/MONDO_0013677,"Emery-Dreifuss muscular dystrophy 7, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0020336,autosomal dominant Emery-Dreifuss muscular dystrophy,http://identifiers.org/hgnc/28472,TMEM43
+http://purl.obolibrary.org/obo/MONDO_0010590,FG syndrome 1,http://purl.obolibrary.org/obo/MONDO_0002010,FG syndrome,http://identifiers.org/hgnc/11957,MED12
+http://purl.obolibrary.org/obo/MONDO_0010297,FG syndrome 2,http://purl.obolibrary.org/obo/MONDO_0002010,FG syndrome,http://identifiers.org/hgnc/3754,FLNA
+http://purl.obolibrary.org/obo/MONDO_0010318,FG syndrome 4,http://purl.obolibrary.org/obo/MONDO_0002010,FG syndrome,http://identifiers.org/hgnc/1497,CASK
+http://purl.obolibrary.org/obo/MONDO_0100040,FOXG1 disorder,http://purl.obolibrary.org/obo/MONDO_0003847,inherited genetic disease,http://identifiers.org/hgnc/3811,FOXG1
+http://purl.obolibrary.org/obo/MONDO_0009215,Fanconi anemia complementation group A,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/3582,FANCA
+http://purl.obolibrary.org/obo/MONDO_0010953,Fanconi anemia complementation group E,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/3586,FANCE
+http://purl.obolibrary.org/obo/MONDO_0013566,Fanconi anemia complementation group L,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/20748,FANCL
+http://purl.obolibrary.org/obo/MONDO_0012565,Fanconi anemia complementation group N,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/26144,PALB2
+http://purl.obolibrary.org/obo/MONDO_0013248,Fanconi anemia complementation group O,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/9820,RAD51C
+http://purl.obolibrary.org/obo/MONDO_0013499,Fanconi anemia complementation group P,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/23845,SLX4
+http://purl.obolibrary.org/obo/MONDO_0014108,Fanconi anemia complementation group Q,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/3436,ERCC4
+http://purl.obolibrary.org/obo/MONDO_0014638,Fanconi anemia complementation group T,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/25009,UBE2T
+http://purl.obolibrary.org/obo/MONDO_0014987,Fanconi anemia complementation group U,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/12829,XRCC2
+http://purl.obolibrary.org/obo/MONDO_0014986,Fanconi anemia complementation group r,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/9817,RAD51
+http://purl.obolibrary.org/obo/MONDO_0014985,Fanconi anemia complementation group v,http://purl.obolibrary.org/obo/MONDO_0019391,Fanconi anemia,http://identifiers.org/hgnc/6764,MAD2L2
+http://purl.obolibrary.org/obo/MONDO_0013247,Fanconi renotubular syndrome 2,http://purl.obolibrary.org/obo/MONDO_0001083,Fanconi syndrome,http://identifiers.org/hgnc/11019,SLC34A1
+http://purl.obolibrary.org/obo/MONDO_0014275,Fanconi renotubular syndrome 3,http://purl.obolibrary.org/obo/MONDO_0001083,Fanconi syndrome,http://identifiers.org/hgnc/3247,EHHADH
+http://purl.obolibrary.org/obo/MONDO_0014458,Fanconi renotubular syndrome 4 with maturity-onset diabetes of the young,http://purl.obolibrary.org/obo/MONDO_0001083,Fanconi syndrome,http://identifiers.org/hgnc/5024,HNF4A
+http://purl.obolibrary.org/obo/MONDO_0008115,Feingold syndrome type 1,http://purl.obolibrary.org/obo/MONDO_0015267,Feingold syndrome,http://identifiers.org/hgnc/7559,MYCN
+http://purl.obolibrary.org/obo/MONDO_0013612,Geleophysic dysplasia 2,http://purl.obolibrary.org/obo/MONDO_0000127,geleophysic dysplasia,http://identifiers.org/hgnc/3603,FBN1
+http://purl.obolibrary.org/obo/MONDO_0009337,Hennekam lymphangiectasia-lymphedema syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016256,Hennekam syndrome,http://identifiers.org/hgnc/29426,CCBE1
+http://purl.obolibrary.org/obo/MONDO_0014454,Hennekam lymphangiectasia-lymphedema syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016256,Hennekam syndrome,http://identifiers.org/hgnc/23109,FAT4
+http://purl.obolibrary.org/obo/MONDO_0008748,Hermansky-Pudlak syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/5163,HPS1
+http://purl.obolibrary.org/obo/MONDO_0014885,Hermansky-Pudlak syndrome 10; HPS10,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/568,AP3D1
+http://purl.obolibrary.org/obo/MONDO_0011997,Hermansky-Pudlak syndrome 2,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/566,AP3B1
+http://purl.obolibrary.org/obo/MONDO_0013555,Hermansky-Pudlak syndrome 3,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/15597,HPS3
+http://purl.obolibrary.org/obo/MONDO_0013556,Hermansky-Pudlak syndrome 4,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/15844,HPS4
+http://purl.obolibrary.org/obo/MONDO_0013557,Hermansky-Pudlak syndrome 5,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/17022,HPS5
+http://purl.obolibrary.org/obo/MONDO_0013558,Hermansky-Pudlak syndrome 6,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/18817,HPS6
+http://purl.obolibrary.org/obo/MONDO_0013559,Hermansky-Pudlak syndrome 7,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/17328,DTNBP1
+http://purl.obolibrary.org/obo/MONDO_0013560,Hermansky-Pudlak syndrome 8,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/20914,BLOC1S3
+http://purl.obolibrary.org/obo/MONDO_0013606,Hermansky-Pudlak syndrome 9,http://purl.obolibrary.org/obo/MONDO_0019312,Hermansky-Pudlak syndrome,http://identifiers.org/hgnc/8549,BLOC1S6
+http://purl.obolibrary.org/obo/MONDO_0007723,"Hirschsprung disease, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0018309,Hirschsprung disease,http://identifiers.org/hgnc/9967,RET
+http://purl.obolibrary.org/obo/MONDO_0010833,"Hirschsprung disease, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0018309,Hirschsprung disease,http://identifiers.org/hgnc/3180,EDNRB
+http://purl.obolibrary.org/obo/MONDO_0013383,"Hirschsprung disease, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0018309,Hirschsprung disease,http://identifiers.org/hgnc/4232,GDNF
+http://purl.obolibrary.org/obo/MONDO_0013384,"Hirschsprung disease, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0018309,Hirschsprung disease,http://identifiers.org/hgnc/3178,EDN3
+http://purl.obolibrary.org/obo/MONDO_0011299,Huntington disease-like 1,http://purl.obolibrary.org/obo/MONDO_0017646,neurodegenerative disease with chorea,http://identifiers.org/hgnc/9449,PRNP
+http://purl.obolibrary.org/obo/MONDO_0014786,"IgA nephropathy, susceptibility to, 3; IGAN3",http://purl.obolibrary.org/obo/MONDO_0005342,IgA glomerulonephritis,http://identifiers.org/hgnc/11270,SPRY2
+http://purl.obolibrary.org/obo/MONDO_0024540,Jervell and Lange-Nielsen syndrome 1,http://purl.obolibrary.org/obo/MONDO_0009078,Jervell and Lange-Nielsen syndrome,http://identifiers.org/hgnc/6294,KCNQ1
+http://purl.obolibrary.org/obo/MONDO_0012871,Jervell and Lange-Nielsen syndrome 2,http://purl.obolibrary.org/obo/MONDO_0009078,Jervell and Lange-Nielsen syndrome,http://identifiers.org/hgnc/6240,KCNE1
+http://purl.obolibrary.org/obo/MONDO_0008944,Joubert syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/21474,INPP5E
+http://purl.obolibrary.org/obo/MONDO_0010431,Joubert syndrome 10,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/2567,OFD1
+http://purl.obolibrary.org/obo/MONDO_0013608,Joubert syndrome 13,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/26113,TCTN1
+http://purl.obolibrary.org/obo/MONDO_0013745,Joubert syndrome 14,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/14432,TMEM237
+http://purl.obolibrary.org/obo/MONDO_0013763,Joubert syndrome 15,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/12370,CEP41
+http://purl.obolibrary.org/obo/MONDO_0013764,Joubert syndrome 16,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/26944,TMEM138
+http://purl.obolibrary.org/obo/MONDO_0013824,Joubert syndrome 17,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/25801,CPLANE1
+http://purl.obolibrary.org/obo/MONDO_0013896,Joubert syndrome 18,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/24519,TCTN3
+http://purl.obolibrary.org/obo/MONDO_0011963,Joubert syndrome 2,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/25018,TMEM216
+http://purl.obolibrary.org/obo/MONDO_0013994,Joubert syndrome 20,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/37234,TMEM231
+http://purl.obolibrary.org/obo/MONDO_0014288,Joubert syndrome 21,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/26193,CSPP1
+http://purl.obolibrary.org/obo/MONDO_0014297,Joubert syndrome 22,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/8788,PDE6D
+http://purl.obolibrary.org/obo/MONDO_0014664,Joubert syndrome 23,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/19960,KIAA0586
+http://purl.obolibrary.org/obo/MONDO_0014724,Joubert syndrome 24,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/25774,TCTN2
+http://purl.obolibrary.org/obo/MONDO_0014770,Joubert syndrome 25,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/24866,CEP104
+http://purl.obolibrary.org/obo/MONDO_0014771,Joubert syndrome 26,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/29068,KIAA0556
+http://purl.obolibrary.org/obo/MONDO_0014927,Joubert syndrome 27,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/24123,B9D1
+http://purl.obolibrary.org/obo/MONDO_0014928,Joubert syndrome 28,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/7121,MKS1
+http://purl.obolibrary.org/obo/MONDO_0012078,Joubert syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/21575,AHI1
+http://purl.obolibrary.org/obo/MONDO_0012432,Joubert syndrome 5,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/29021,CEP290
+http://purl.obolibrary.org/obo/MONDO_0012539,Joubert syndrome 6,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/28396,TMEM67
+http://purl.obolibrary.org/obo/MONDO_0012694,Joubert syndrome 7,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/29168,RPGRIP1L
+http://purl.obolibrary.org/obo/MONDO_0012855,Joubert syndrome 8,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/25419,ARL13B
+http://purl.obolibrary.org/obo/MONDO_0012849,Joubert syndrome 9,http://purl.obolibrary.org/obo/MONDO_0018772,Joubert syndrome,http://identifiers.org/hgnc/29253,CC2D2A
+http://purl.obolibrary.org/obo/MONDO_0007306,"Klippel-Feil syndrome 1, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0016520,isolated Klippel-Feil syndrome,http://identifiers.org/hgnc/4221,GDF6
+http://purl.obolibrary.org/obo/MONDO_0008958,"Klippel-Feil syndrome 2, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016520,isolated Klippel-Feil syndrome,http://identifiers.org/hgnc/7013,MEOX1
+http://purl.obolibrary.org/obo/MONDO_0013375,"Klippel-Feil syndrome 3, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0016520,isolated Klippel-Feil syndrome,http://identifiers.org/hgnc/4218,GDF3
+http://purl.obolibrary.org/obo/MONDO_0012691,LEOPARD syndrome 2,http://purl.obolibrary.org/obo/MONDO_0007893,Noonan syndrome with multiple lentigines,http://identifiers.org/hgnc/9829,RAF1
+http://purl.obolibrary.org/obo/MONDO_0013380,LEOPARD syndrome 3,http://purl.obolibrary.org/obo/MONDO_0007893,Noonan syndrome with multiple lentigines,http://identifiers.org/hgnc/1097,BRAF
+http://purl.obolibrary.org/obo/MONDO_0008764,Leber congenital amaurosis 1,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/4689,GUCY2D
+http://purl.obolibrary.org/obo/MONDO_0012723,Leber congenital amaurosis 10,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/29021,CEP290
+http://purl.obolibrary.org/obo/MONDO_0013454,Leber congenital amaurosis 11,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/6052,IMPDH1
+http://purl.obolibrary.org/obo/MONDO_0012525,Leber congenital amaurosis 12,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/19689,RD3
+http://purl.obolibrary.org/obo/MONDO_0012990,Leber congenital amaurosis 13,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/19977,RDH12
+http://purl.obolibrary.org/obo/MONDO_0013231,Leber congenital amaurosis 14,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/6685,LRAT
+http://purl.obolibrary.org/obo/MONDO_0013457,Leber congenital amaurosis 15,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/12423,TULP1
+http://purl.obolibrary.org/obo/MONDO_0013613,Leber congenital amaurosis 16,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/6259,KCNJ13
+http://purl.obolibrary.org/obo/MONDO_0014145,Leber congenital amaurosis 17,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/4221,GDF6
+http://purl.obolibrary.org/obo/MONDO_0008765,Leber congenital amaurosis 2,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/10294,RPE65
+http://purl.obolibrary.org/obo/MONDO_0011415,Leber congenital amaurosis 3,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/20423,SPATA7
+http://purl.obolibrary.org/obo/MONDO_0011458,Leber congenital amaurosis 4,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/359,AIPL1
+http://purl.obolibrary.org/obo/MONDO_0011473,Leber congenital amaurosis 5,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/31923,LCA5
+http://purl.obolibrary.org/obo/MONDO_0013446,Leber congenital amaurosis 6,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/13436,RPGRIP1
+http://purl.obolibrary.org/obo/MONDO_0013449,Leber congenital amaurosis 7,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/2383,CRX
+http://purl.obolibrary.org/obo/MONDO_0013453,Leber congenital amaurosis 8,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/2343,CRB1
+http://purl.obolibrary.org/obo/MONDO_0012056,Leber congenital amaurosis 9,http://purl.obolibrary.org/obo/MONDO_0018998,Leber congenital amaurosis,http://identifiers.org/hgnc/17877,NMNAT1
+http://purl.obolibrary.org/obo/MONDO_0009384,"Leydig cell hypoplasia, type 1",http://purl.obolibrary.org/obo/MONDO_0019155,Leydig cell hypoplasia,http://identifiers.org/hgnc/6585,LHCGR
+http://purl.obolibrary.org/obo/MONDO_0007903,Li-Fraumeni syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018875,Li-Fraumeni syndrome,http://identifiers.org/hgnc/11998,TP53
+http://purl.obolibrary.org/obo/MONDO_0012233,Li-Fraumeni syndrome 2,http://purl.obolibrary.org/obo/MONDO_0018875,Li-Fraumeni syndrome,http://identifiers.org/hgnc/16627,CHEK2
+http://purl.obolibrary.org/obo/MONDO_0012212,Loeys-Dietz syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018954,Loeys-Dietz syndrome,http://identifiers.org/hgnc/11772,TGFBR1
+http://purl.obolibrary.org/obo/MONDO_0012427,Loeys-Dietz syndrome 2,http://purl.obolibrary.org/obo/MONDO_0018954,Loeys-Dietz syndrome,http://identifiers.org/hgnc/11773,TGFBR2
+http://purl.obolibrary.org/obo/MONDO_0013897,Loeys-Dietz syndrome 4,http://purl.obolibrary.org/obo/MONDO_0018954,Loeys-Dietz syndrome,http://identifiers.org/hgnc/11768,TGFB2
+http://purl.obolibrary.org/obo/MONDO_0100000,MED12-related intellectual disability syndrome,http://purl.obolibrary.org/obo/MONDO_0020119,X-linked syndromic intellectual disability,http://identifiers.org/hgnc/11957,MED12
+http://purl.obolibrary.org/obo/MONDO_0009571,"Meckel syndrome, type 1",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/7121,MKS1
+http://purl.obolibrary.org/obo/MONDO_0013609,"Meckel syndrome, type 10",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/28636,B9D2
+http://purl.obolibrary.org/obo/MONDO_0014164,"Meckel syndrome, type 11",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/37234,TMEM231
+http://purl.obolibrary.org/obo/MONDO_0011296,"Meckel syndrome, type 2",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/25018,TMEM216
+http://purl.obolibrary.org/obo/MONDO_0011821,"Meckel syndrome, type 3",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/28396,TMEM67
+http://purl.obolibrary.org/obo/MONDO_0012626,"Meckel syndrome, type 4",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/29021,CEP290
+http://purl.obolibrary.org/obo/MONDO_0012695,"Meckel syndrome, type 5",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/29168,RPGRIP1L
+http://purl.obolibrary.org/obo/MONDO_0012848,"Meckel syndrome, type 6",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/29253,CC2D2A
+http://purl.obolibrary.org/obo/MONDO_0013482,"Meckel syndrome, type 8",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/25774,TCTN2
+http://purl.obolibrary.org/obo/MONDO_0013630,"Meckel syndrome, type 9",http://purl.obolibrary.org/obo/MONDO_0018921,Meckel syndrome,http://identifiers.org/hgnc/24123,B9D1
+http://purl.obolibrary.org/obo/MONDO_0009143,Meier-Gorlin syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/8487,ORC1
+http://purl.obolibrary.org/obo/MONDO_0013428,Meier-Gorlin syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/8490,ORC4
+http://purl.obolibrary.org/obo/MONDO_0013430,Meier-Gorlin syndrome 3,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/17151,ORC6
+http://purl.obolibrary.org/obo/MONDO_0013431,Meier-Gorlin syndrome 4,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/24576,CDT1
+http://purl.obolibrary.org/obo/MONDO_0013432,Meier-Gorlin syndrome 5,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/1744,CDC6
+http://purl.obolibrary.org/obo/MONDO_0014794,Meier-Gorlin syndrome 6,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/17493,GMNN
+http://purl.obolibrary.org/obo/MONDO_0014894,Meier-Gorlin syndrome 7; MGORS7,http://purl.obolibrary.org/obo/MONDO_0016817,Meier-Gorlin syndrome,http://identifiers.org/hgnc/1739,CDC45
+http://purl.obolibrary.org/obo/MONDO_0024545,Miyoshi muscular dystrophy 1,http://purl.obolibrary.org/obo/MONDO_0009685,Miyoshi myopathy,http://identifiers.org/hgnc/3097,DYSF
+http://purl.obolibrary.org/obo/MONDO_0011784,Moyamoya disease 2,http://purl.obolibrary.org/obo/MONDO_0016820,Moyamoya disease,http://identifiers.org/hgnc/14539,RNF213
+http://purl.obolibrary.org/obo/MONDO_0013542,Moyamoya disease 5,http://purl.obolibrary.org/obo/MONDO_0016820,Moyamoya disease,http://identifiers.org/hgnc/130,ACTA2
+http://purl.obolibrary.org/obo/MONDO_0018642,NIK deficiency,http://purl.obolibrary.org/obo/MONDO_0018814,non-severe combined immunodeficiency,http://identifiers.org/hgnc/6853,MAP3K14
+http://purl.obolibrary.org/obo/MONDO_0009736,Neu-Laxova syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000179,Neu-Laxova syndrome,http://identifiers.org/hgnc/8923,PHGDH
+http://purl.obolibrary.org/obo/MONDO_0014466,Neu-Laxova syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000179,Neu-Laxova syndrome,http://identifiers.org/hgnc/19129,PSAT1
+http://purl.obolibrary.org/obo/MONDO_0011839,Newfoundland cone-rod dystrophy,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/10024,RLBP1
+http://purl.obolibrary.org/obo/MONDO_0014693,Noonan syndrome 10,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/6742,LZTR1
+http://purl.obolibrary.org/obo/MONDO_0012371,Noonan syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/6407,KRAS
+http://purl.obolibrary.org/obo/MONDO_0012547,Noonan syndrome 4,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/11187,SOS1
+http://purl.obolibrary.org/obo/MONDO_0012690,Noonan syndrome 5,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/9829,RAF1
+http://purl.obolibrary.org/obo/MONDO_0013186,Noonan syndrome 6,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/7989,NRAS
+http://purl.obolibrary.org/obo/MONDO_0013379,Noonan syndrome 7,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/1097,BRAF
+http://purl.obolibrary.org/obo/MONDO_0014143,Noonan syndrome 8,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/10023,RIT1
+http://purl.obolibrary.org/obo/MONDO_0014691,Noonan syndrome 9,http://purl.obolibrary.org/obo/MONDO_0018997,Noonan syndrome,http://identifiers.org/hgnc/11188,SOS2
+http://purl.obolibrary.org/obo/MONDO_0009775,Oguchi disease-1,http://purl.obolibrary.org/obo/MONDO_0019152,Oguchi disease,http://identifiers.org/hgnc/10521,SAG
+http://purl.obolibrary.org/obo/MONDO_0013259,Oguchi disease-2,http://purl.obolibrary.org/obo/MONDO_0019152,Oguchi disease,http://identifiers.org/hgnc/10013,GRK1
+http://purl.obolibrary.org/obo/MONDO_0017998,PLA2G6-associated neurodegeneration,http://purl.obolibrary.org/obo/MONDO_0018307,neurodegeneration with brain iron accumulation,http://identifiers.org/hgnc/9039,PLA2G6
+http://purl.obolibrary.org/obo/MONDO_0013755,PYCR1-related de Barsy syndrome,http://purl.obolibrary.org/obo/MONDO_0017569,de Barsy syndrome,http://identifiers.org/hgnc/9721,PYCR1
+http://purl.obolibrary.org/obo/MONDO_0011896,"Parkinson disease 11, autosomal dominant, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0018466,hereditary late onset Parkinson disease,http://identifiers.org/hgnc/11960,GIGYF2
+http://purl.obolibrary.org/obo/MONDO_0012466,"Parkinson disease 13, autosomal dominant, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0017279,young-onset Parkinson disease,http://identifiers.org/hgnc/14348,HTRA2
+http://purl.obolibrary.org/obo/MONDO_0013625,Parkinson disease 17,http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/13487,VPS35
+http://purl.obolibrary.org/obo/MONDO_0013653,"Parkinson disease 18, autosomal dominant, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0018466,hereditary late onset Parkinson disease,http://identifiers.org/hgnc/3296,EIF4G1
+http://purl.obolibrary.org/obo/MONDO_0014604,Parkinson disease 21,http://purl.obolibrary.org/obo/MONDO_0018466,hereditary late onset Parkinson disease,http://identifiers.org/hgnc/30343,DNAJC13
+http://purl.obolibrary.org/obo/MONDO_0014742,"Parkinson disease 22, autosomal dominant; PARK22",http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/21645,CHCHD2
+http://purl.obolibrary.org/obo/MONDO_0013340,"Parkinson disease 5, autosomal dominant, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0017279,young-onset Parkinson disease,http://identifiers.org/hgnc/12513,UCHL1
+http://purl.obolibrary.org/obo/MONDO_0009300,Perrault syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017312,Perrault syndrome,http://identifiers.org/hgnc/5213,HSD17B4
+http://purl.obolibrary.org/obo/MONDO_0013972,Perrault syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017312,Perrault syndrome,http://identifiers.org/hgnc/4817,HARS2
+http://purl.obolibrary.org/obo/MONDO_0013588,Perrault syndrome 3,http://purl.obolibrary.org/obo/MONDO_0017312,Perrault syndrome,http://identifiers.org/hgnc/2084,CLPP
+http://purl.obolibrary.org/obo/MONDO_0014126,Perrault syndrome 4,http://purl.obolibrary.org/obo/MONDO_0017312,Perrault syndrome,http://identifiers.org/hgnc/17095,LARS2
+http://purl.obolibrary.org/obo/MONDO_0014504,Perrault syndrome 5,http://purl.obolibrary.org/obo/MONDO_0017312,Perrault syndrome,http://identifiers.org/hgnc/1160,TWNK
+http://purl.obolibrary.org/obo/MONDO_0013690,Pitt-Hopkins-like syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016377,Pitt-Hopkins-like syndrome,http://identifiers.org/hgnc/8008,NRXN1
+http://purl.obolibrary.org/obo/MONDO_0009073,Ritscher-Schinzel syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019078,Ritscher-Schinzel syndrome,http://identifiers.org/hgnc/28984,WASHC5
+http://purl.obolibrary.org/obo/MONDO_0010499,Ritscher-Schinzel syndrome 2,http://purl.obolibrary.org/obo/MONDO_0019078,Ritscher-Schinzel syndrome,http://identifiers.org/hgnc/28909,CCDC22
+http://purl.obolibrary.org/obo/MONDO_0008869,Seckel syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/882,ATR
+http://purl.obolibrary.org/obo/MONDO_0014991,Seckel syndrome 10,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/26513,NSMCE2
+http://purl.obolibrary.org/obo/MONDO_0011715,Seckel syndrome 2,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/9891,RBBP8
+http://purl.obolibrary.org/obo/MONDO_0013358,Seckel syndrome 4,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/17272,CENPJ
+http://purl.obolibrary.org/obo/MONDO_0013443,Seckel syndrome 5,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/29298,CEP152
+http://purl.obolibrary.org/obo/MONDO_0013871,Seckel syndrome 6,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/25815,CEP63
+http://purl.obolibrary.org/obo/MONDO_0013922,Seckel syndrome 7,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/14906,NIN
+http://purl.obolibrary.org/obo/MONDO_0014350,Seckel syndrome 8,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/2939,DNA2
+http://purl.obolibrary.org/obo/MONDO_0014767,Seckel syndrome 9,http://purl.obolibrary.org/obo/MONDO_0019342,Seckel syndrome,http://identifiers.org/hgnc/30764,TRAIP
+http://purl.obolibrary.org/obo/MONDO_0009962,Senior-Loken syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/7905,NPHP1
+http://purl.obolibrary.org/obo/MONDO_0011756,Senior-Loken syndrome 4,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/19104,NPHP4
+http://purl.obolibrary.org/obo/MONDO_0012225,Senior-Loken syndrome 5,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/28949,IQCB1
+http://purl.obolibrary.org/obo/MONDO_0012433,Senior-Loken syndrome 6,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/29021,CEP290
+http://purl.obolibrary.org/obo/MONDO_0013326,Senior-Loken syndrome 7,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/10671,SDCCAG8
+http://purl.obolibrary.org/obo/MONDO_0014579,Senior-Loken syndrome 8,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/18340,WDR19
+http://purl.obolibrary.org/obo/MONDO_0014712,Senior-Loken syndrome 9; SLSN9,http://purl.obolibrary.org/obo/MONDO_0017842,Senior-Loken syndrome,http://identifiers.org/hgnc/17861,TRAF3IP1
+http://purl.obolibrary.org/obo/MONDO_0010265,Simpson-Golabi-Behmel syndrome type 2,http://purl.obolibrary.org/obo/MONDO_0010731,Simpson-Golabi-Behmel syndrome,http://identifiers.org/hgnc/2567,OFD1
+http://purl.obolibrary.org/obo/MONDO_0024535,Singleton-Merten syndrome 1,http://purl.obolibrary.org/obo/MONDO_0008429,singleton-Merten dysplasia,http://identifiers.org/hgnc/18873,IFIH1
+http://purl.obolibrary.org/obo/MONDO_0014575,Singleton-Merten syndrome 2,http://purl.obolibrary.org/obo/MONDO_0008429,singleton-Merten dysplasia,http://identifiers.org/hgnc/19102,DDX58
+http://purl.obolibrary.org/obo/MONDO_0011814,Smith-McCort dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0015799,Smith-McCort dysplasia,http://identifiers.org/hgnc/21317,DYM
+http://purl.obolibrary.org/obo/MONDO_0014087,Smith-McCort dysplasia 2,http://purl.obolibrary.org/obo/MONDO_0015799,Smith-McCort dysplasia,http://identifiers.org/hgnc/16075,RAB33B
+http://purl.obolibrary.org/obo/MONDO_0007299,Sotos syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019349,Sotos syndrome,http://identifiers.org/hgnc/14234,NSD1
+http://purl.obolibrary.org/obo/MONDO_0014951,Sotos syndrome 3,http://purl.obolibrary.org/obo/MONDO_0019349,Sotos syndrome,http://identifiers.org/hgnc/24036,APC2
+http://purl.obolibrary.org/obo/MONDO_0011370,Stargardt disease 4,http://purl.obolibrary.org/obo/MONDO_0019353,Stargardt disease,http://identifiers.org/hgnc/9454,PROM1
+http://purl.obolibrary.org/obo/MONDO_0011493,Stickler syndrome type 2,http://purl.obolibrary.org/obo/MONDO_0019354,Stickler syndrome,http://identifiers.org/hgnc/2186,COL11A1
+http://purl.obolibrary.org/obo/MONDO_0008490,Stickler syndrome type 3,http://purl.obolibrary.org/obo/MONDO_0019354,Stickler syndrome,http://identifiers.org/hgnc/2187,COL11A2
+http://purl.obolibrary.org/obo/MONDO_0013590,"Stickler syndrome, type 4",http://purl.obolibrary.org/obo/MONDO_0016647,autosomal recessive Stickler syndrome,http://identifiers.org/hgnc/2217,COL9A1
+http://purl.obolibrary.org/obo/MONDO_0013666,"Stickler syndrome, type 5",http://purl.obolibrary.org/obo/MONDO_0016647,autosomal recessive Stickler syndrome,http://identifiers.org/hgnc/2218,COL9A2
+http://purl.obolibrary.org/obo/MONDO_0013385,Treacher Collins syndrome 2,http://purl.obolibrary.org/obo/MONDO_0002457,Treacher-Collins syndrome,http://identifiers.org/hgnc/20422,POLR1D
+http://purl.obolibrary.org/obo/MONDO_0009558,Treacher Collins syndrome 3,http://purl.obolibrary.org/obo/MONDO_0002457,Treacher-Collins syndrome,http://identifiers.org/hgnc/20194,POLR1C
+http://purl.obolibrary.org/obo/MONDO_0007944,Treacher-Collins syndrome 1,http://purl.obolibrary.org/obo/MONDO_0002457,Treacher-Collins syndrome,http://identifiers.org/hgnc/11654,TCOF1
+http://purl.obolibrary.org/obo/MONDO_0010909,UV-sensitive syndrome 1,http://purl.obolibrary.org/obo/MONDO_0015797,UV-sensitive syndrome,http://identifiers.org/hgnc/3438,ERCC6
+http://purl.obolibrary.org/obo/MONDO_0013829,UV-sensitive syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015797,UV-sensitive syndrome,http://identifiers.org/hgnc/3439,ERCC8
+http://purl.obolibrary.org/obo/MONDO_0013834,UV-sensitive syndrome 3,http://purl.obolibrary.org/obo/MONDO_0015797,UV-sensitive syndrome,http://identifiers.org/hgnc/29304,UVSSA
+http://purl.obolibrary.org/obo/MONDO_0014654,Ullrich congenital muscular dystrophy 2,http://purl.obolibrary.org/obo/MONDO_0000355,Ullrich congenital muscular dystrophy,http://identifiers.org/hgnc/2188,COL12A1
+http://purl.obolibrary.org/obo/MONDO_0011748,Usher syndrome type 1G,http://purl.obolibrary.org/obo/MONDO_0019501,Usher syndrome,http://identifiers.org/hgnc/16356,USH1G
+http://purl.obolibrary.org/obo/MONDO_0013935,Usher syndrome type 1J,http://purl.obolibrary.org/obo/MONDO_0019501,Usher syndrome,http://identifiers.org/hgnc/24579,CIB2
+http://purl.obolibrary.org/obo/MONDO_0010169,Usher syndrome type 2A,http://purl.obolibrary.org/obo/MONDO_0019501,Usher syndrome,http://identifiers.org/hgnc/12601,USH2A
+http://purl.obolibrary.org/obo/MONDO_0012662,Usher syndrome type 2D,http://purl.obolibrary.org/obo/MONDO_0019501,Usher syndrome,http://identifiers.org/hgnc/16361,WHRN
+http://purl.obolibrary.org/obo/MONDO_0010170,Usher syndrome type 3A,http://purl.obolibrary.org/obo/MONDO_0019501,Usher syndrome,http://identifiers.org/hgnc/12605,CLRN1
+http://purl.obolibrary.org/obo/MONDO_0013788,Usher syndrome type 3B,http://purl.obolibrary.org/obo/MONDO_0019501,Usher syndrome,http://identifiers.org/hgnc/4816,HARS
+http://purl.obolibrary.org/obo/MONDO_0008671,Waardenburg syndrome type 2A,http://purl.obolibrary.org/obo/MONDO_0019517,Waardenburg syndrome type 2,http://identifiers.org/hgnc/7105,MITF
+http://purl.obolibrary.org/obo/MONDO_0012144,Waardenburg syndrome type 2D,http://purl.obolibrary.org/obo/MONDO_0019517,Waardenburg syndrome type 2,http://identifiers.org/hgnc/11094,SNAI2
+http://purl.obolibrary.org/obo/MONDO_0012698,Waardenburg syndrome type 2E,http://purl.obolibrary.org/obo/MONDO_0019517,Waardenburg syndrome type 2,http://identifiers.org/hgnc/11190,SOX10
+http://purl.obolibrary.org/obo/MONDO_0010192,Waardenburg syndrome type 4A,http://purl.obolibrary.org/obo/MONDO_0018094,Waardenburg syndrome,http://identifiers.org/hgnc/3180,EDNRB
+http://purl.obolibrary.org/obo/MONDO_0013201,Waardenburg syndrome type 4B,http://purl.obolibrary.org/obo/MONDO_0018094,Waardenburg syndrome,http://identifiers.org/hgnc/3178,EDN3
+http://purl.obolibrary.org/obo/MONDO_0010822,Warburg micro syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016649,Warburg micro syndrome,http://identifiers.org/hgnc/17063,RAB3GAP1
+http://purl.obolibrary.org/obo/MONDO_0013641,Warburg micro syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016649,Warburg micro syndrome,http://identifiers.org/hgnc/17168,RAB3GAP2
+http://purl.obolibrary.org/obo/MONDO_0013638,Warburg micro syndrome 3,http://purl.obolibrary.org/obo/MONDO_0016649,Warburg micro syndrome,http://identifiers.org/hgnc/14244,RAB18
+http://purl.obolibrary.org/obo/MONDO_0014296,Warburg micro syndrome 4,http://purl.obolibrary.org/obo/MONDO_0016649,Warburg micro syndrome,http://identifiers.org/hgnc/16133,TBC1D20
+http://purl.obolibrary.org/obo/MONDO_0010194,Weill-Marchesani syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018096,Weill-Marchesani syndrome,http://identifiers.org/hgnc/13201,ADAMTS10
+http://purl.obolibrary.org/obo/MONDO_0013899,Weill-Marchesani syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018096,Weill-Marchesani syndrome,http://identifiers.org/hgnc/6715,LTBP2
+http://purl.obolibrary.org/obo/MONDO_0013779,Wiskott-Aldrich syndrome 2,http://purl.obolibrary.org/obo/MONDO_0010518,Wiskott-Aldrich syndrome,http://identifiers.org/hgnc/12736,WIPF1
+http://purl.obolibrary.org/obo/MONDO_0009101,Wolfram syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018105,Wolfram syndrome,http://identifiers.org/hgnc/12762,WFS1
+http://purl.obolibrary.org/obo/MONDO_0011502,Wolfram syndrome 2,http://purl.obolibrary.org/obo/MONDO_0018105,Wolfram syndrome,http://identifiers.org/hgnc/24212,CISD2
+http://purl.obolibrary.org/obo/MONDO_0010555,X-linked chondrodysplasia punctata 1,http://purl.obolibrary.org/obo/MONDO_0010556,X-linked chondrodysplasia punctata,http://identifiers.org/hgnc/719,ARSE
+http://purl.obolibrary.org/obo/MONDO_0010338,X-linked distal spinal muscular atrophy type 3,http://purl.obolibrary.org/obo/MONDO_0001516,spinal muscular atrophy,http://identifiers.org/hgnc/869,ATP7A
+http://purl.obolibrary.org/obo/MONDO_0024526,Zimmermann-Laband syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000200,Zimmermann-Laband syndrome,http://identifiers.org/hgnc/6250,KCNH1
+http://purl.obolibrary.org/obo/MONDO_0014646,Zimmermann-Laband syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000200,Zimmermann-Laband syndrome,http://identifiers.org/hgnc/854,ATP6V1B2
+http://purl.obolibrary.org/obo/MONDO_0014352,abdominal obesity-metabolic syndrome 3,http://purl.obolibrary.org/obo/MONDO_0004955,metabolic syndrome,http://identifiers.org/hgnc/3092,DYRK1B
+http://purl.obolibrary.org/obo/MONDO_0009003,achromatopsia 2,http://purl.obolibrary.org/obo/MONDO_0018852,achromatopsia,http://identifiers.org/hgnc/2150,CNGA3
+http://purl.obolibrary.org/obo/MONDO_0009875,achromatopsia 3,http://purl.obolibrary.org/obo/MONDO_0018852,achromatopsia,http://identifiers.org/hgnc/2153,CNGB3
+http://purl.obolibrary.org/obo/MONDO_0013465,achromatopsia 4,http://purl.obolibrary.org/obo/MONDO_0018852,achromatopsia,http://identifiers.org/hgnc/4394,GNAT2
+http://purl.obolibrary.org/obo/MONDO_0014677,achromatopsia 7,http://purl.obolibrary.org/obo/MONDO_0018852,achromatopsia,http://identifiers.org/hgnc/791,ATF6
+http://purl.obolibrary.org/obo/MONDO_0007728,"acne inversa, familial, 1",http://purl.obolibrary.org/obo/MONDO_0024516,familial acne inversa,http://identifiers.org/hgnc/17091,NCSTN
+http://purl.obolibrary.org/obo/MONDO_0013397,"acne inversa, familial, 2",http://purl.obolibrary.org/obo/MONDO_0024516,familial acne inversa,http://identifiers.org/hgnc/30100,PSENEN
+http://purl.obolibrary.org/obo/MONDO_0013398,"acne inversa, familial, 3",http://purl.obolibrary.org/obo/MONDO_0024516,familial acne inversa,http://identifiers.org/hgnc/9508,PSEN1
+http://purl.obolibrary.org/obo/MONDO_0013822,acrodysostosis 2 with or without hormone resistance,http://purl.obolibrary.org/obo/MONDO_0019797,acrodysostosis,http://identifiers.org/hgnc/8783,PDE4D
+http://purl.obolibrary.org/obo/MONDO_0014651,acrofacial dysostosis Cincinnati type,http://purl.obolibrary.org/obo/MONDO_0018237,acrofacial dysostosis,http://identifiers.org/hgnc/17264,POLR1A
+http://purl.obolibrary.org/obo/MONDO_0013111,acute infantile liver failure due to synthesis defect of mtDNA-encoded proteins,http://purl.obolibrary.org/obo/MONDO_0000023,infantile liver failure,http://identifiers.org/hgnc/25481,TRMU
+http://purl.obolibrary.org/obo/MONDO_0011442,advanced sleep phase syndrome 1,http://purl.obolibrary.org/obo/MONDO_0015609,advanced sleep phase syndrome,http://identifiers.org/hgnc/8846,PER2
+http://purl.obolibrary.org/obo/MONDO_0014088,advanced sleep phase syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015609,advanced sleep phase syndrome,http://identifiers.org/hgnc/2452,CSNK1D
+http://purl.obolibrary.org/obo/MONDO_0014814,advanced sleep phase syndrome 3,http://purl.obolibrary.org/obo/MONDO_0015609,advanced sleep phase syndrome,http://identifiers.org/hgnc/8847,PER3
+http://purl.obolibrary.org/obo/MONDO_0013287,"agammaglobulinemia 2, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/5870,IGLL1
+http://purl.obolibrary.org/obo/MONDO_0013288,"agammaglobulinemia 3, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/1698,CD79A
+http://purl.obolibrary.org/obo/MONDO_0013289,"agammaglobulinemia 4, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/14211,BLNK
+http://purl.obolibrary.org/obo/MONDO_0013290,"agammaglobulinemia 5, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/19027,LRRC8A
+http://purl.obolibrary.org/obo/MONDO_0012987,"agammaglobulinemia 6, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/1699,CD79B
+http://purl.obolibrary.org/obo/MONDO_0014083,"agammaglobulinemia 7, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/8979,PIK3R1
+http://purl.obolibrary.org/obo/MONDO_0014840,"agammaglobulinemia 8, autosomal dominant; AGM8",http://purl.obolibrary.org/obo/MONDO_0011096,autosomal agammaglobulinemia,http://identifiers.org/hgnc/11633,TCF3
+http://purl.obolibrary.org/obo/MONDO_0012674,age related macular degeneration 10,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/11850,TLR4
+http://purl.obolibrary.org/obo/MONDO_0012767,age related macular degeneration 11,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/2475,CST3
+http://purl.obolibrary.org/obo/MONDO_0013420,age related macular degeneration 12,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/2558,CX3CR1
+http://purl.obolibrary.org/obo/MONDO_0014189,age related macular degeneration 13,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/5394,CFI
+http://purl.obolibrary.org/obo/MONDO_0014266,age related macular degeneration 15,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/1358,C9
+http://purl.obolibrary.org/obo/MONDO_0012540,age related macular degeneration 4,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/4883,CFH
+http://purl.obolibrary.org/obo/MONDO_0013409,age related macular degeneration 5,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/3438,ERCC6
+http://purl.obolibrary.org/obo/MONDO_0013406,age related macular degeneration 6,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/18286,RAX2
+http://purl.obolibrary.org/obo/MONDO_0012419,age related macular degeneration 7,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/9476,HTRA1
+http://purl.obolibrary.org/obo/MONDO_0013416,age related macular degeneration 8,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/32685,ARMS2
+http://purl.obolibrary.org/obo/MONDO_0012659,age related macular degeneration 9,http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/1318,C3
+http://purl.obolibrary.org/obo/MONDO_0007087,alternating hemiplegia of childhood 1,http://purl.obolibrary.org/obo/MONDO_0016241,alternating hemiplegia of childhood,http://identifiers.org/hgnc/800,ATP1A2
+http://purl.obolibrary.org/obo/MONDO_0013900,alternating hemiplegia of childhood 2,http://purl.obolibrary.org/obo/MONDO_0016241,alternating hemiplegia of childhood,http://identifiers.org/hgnc/801,ATP1A3
+http://purl.obolibrary.org/obo/MONDO_0012926,amelogenesis imperfecta hypomaturation type 2A2,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/7167,MMP20
+http://purl.obolibrary.org/obo/MONDO_0013181,amelogenesis imperfecta hypomaturation type 2A3,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/26790,WDR72
+http://purl.obolibrary.org/obo/MONDO_0013906,amelogenesis imperfecta hypomaturation type 2A4,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/26300,ODAPH
+http://purl.obolibrary.org/obo/MONDO_0014385,amelogenesis imperfecta hypomaturation type 2A5,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/10978,SLC24A4
+http://purl.obolibrary.org/obo/MONDO_0007094,amelogenesis imperfecta type 1A,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/6490,LAMB3
+http://purl.obolibrary.org/obo/MONDO_0007092,amelogenesis imperfecta type 1B,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/3344,ENAM
+http://purl.obolibrary.org/obo/MONDO_0010521,amelogenesis imperfecta type 1E,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/461,AMELX
+http://purl.obolibrary.org/obo/MONDO_0014560,amelogenesis imperfecta type 1F,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/452,AMBN
+http://purl.obolibrary.org/obo/MONDO_0008771,amelogenesis imperfecta type 1G,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/23015,FAM20A
+http://purl.obolibrary.org/obo/MONDO_0014540,amelogenesis imperfecta type 1H,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/6161,ITGB6
+http://purl.obolibrary.org/obo/MONDO_0008772,amelogenesis imperfecta type 2A1,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/6365,KLK4
+http://purl.obolibrary.org/obo/MONDO_0024522,"amyloidosis, primary localized cutaneous, 1",http://purl.obolibrary.org/obo/MONDO_0015301,primary cutaneous amyloidosis,http://identifiers.org/hgnc/8507,OSMR
+http://purl.obolibrary.org/obo/MONDO_0014531,amyotrohpic lateral sclerosis type 22,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/12407,TUBA4A
+http://purl.obolibrary.org/obo/MONDO_0012790,amyotrophic lateral sclerosis type 10,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/11571,TARDBP
+http://purl.obolibrary.org/obo/MONDO_0012945,amyotrophic lateral sclerosis type 11,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/16873,FIG4
+http://purl.obolibrary.org/obo/MONDO_0013264,amyotrophic lateral sclerosis type 12,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/17142,OPTN
+http://purl.obolibrary.org/obo/MONDO_0013501,amyotrophic lateral sclerosis type 14,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/12666,VCP
+http://purl.obolibrary.org/obo/MONDO_0010459,amyotrophic lateral sclerosis type 15,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/12509,UBQLN2
+http://purl.obolibrary.org/obo/MONDO_0013715,amyotrophic lateral sclerosis type 16,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/8157,SIGMAR1
+http://purl.obolibrary.org/obo/MONDO_0013861,amyotrophic lateral sclerosis type 17,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/24537,CHMP2B
+http://purl.obolibrary.org/obo/MONDO_0013891,amyotrophic lateral sclerosis type 18,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/8881,PFN1
+http://purl.obolibrary.org/obo/MONDO_0014223,amyotrophic lateral sclerosis type 19,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/3432,ERBB4
+http://purl.obolibrary.org/obo/MONDO_0008780,amyotrophic lateral sclerosis type 2,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/443,ALS2
+http://purl.obolibrary.org/obo/MONDO_0014181,amyotrophic lateral sclerosis type 20,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/5031,HNRNPA1
+http://purl.obolibrary.org/obo/MONDO_0011632,amyotrophic lateral sclerosis type 21,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/6912,MATR3
+http://purl.obolibrary.org/obo/MONDO_0011223,amyotrophic lateral sclerosis type 4,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/445,SETX
+http://purl.obolibrary.org/obo/MONDO_0011196,amyotrophic lateral sclerosis type 5,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/11226,SPG11
+http://purl.obolibrary.org/obo/MONDO_0011951,amyotrophic lateral sclerosis type 6,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/4010,FUS
+http://purl.obolibrary.org/obo/MONDO_0012077,amyotrophic lateral sclerosis type 8,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/12649,VAPB
+http://purl.obolibrary.org/obo/MONDO_0012753,amyotrophic lateral sclerosis type 9,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis,http://identifiers.org/hgnc/483,ANG
+http://purl.obolibrary.org/obo/MONDO_0014938,aniridia 3; AN3,http://purl.obolibrary.org/obo/MONDO_0007119,isolated aniridia,http://identifiers.org/hgnc/19016,TRIM44
+http://purl.obolibrary.org/obo/MONDO_0024456,anterior segment dysgenesis 3,http://purl.obolibrary.org/obo/MONDO_0011119,iridogoniodysgenesis,http://identifiers.org/hgnc/3800,FOXC1
+http://purl.obolibrary.org/obo/MONDO_0007662,anterior segment dysgenesis 4,http://purl.obolibrary.org/obo/MONDO_0011119,iridogoniodysgenesis,http://identifiers.org/hgnc/9005,PITX2
+http://purl.obolibrary.org/obo/MONDO_0010015,anterior segment dysgenesis 7,http://purl.obolibrary.org/obo/MONDO_0019503,anterior segment dysgenesis,http://identifiers.org/hgnc/14966,PXDN
+http://purl.obolibrary.org/obo/MONDO_0015017,anterior segment dysgenesis 8,http://purl.obolibrary.org/obo/MONDO_0019503,anterior segment dysgenesis,http://identifiers.org/hgnc/23228,CPAMD8
+http://purl.obolibrary.org/obo/MONDO_0014950,"aortic aneurysm, familial thoracic 10",http://purl.obolibrary.org/obo/MONDO_0019625,familial thoracic aortic aneurysm and aortic dissection,http://identifiers.org/hgnc/6664,LOX
+http://purl.obolibrary.org/obo/MONDO_0007568,"aortic aneurysm, familial thoracic 4",http://purl.obolibrary.org/obo/MONDO_0019625,familial thoracic aortic aneurysm and aortic dissection,http://identifiers.org/hgnc/7569,MYH11
+http://purl.obolibrary.org/obo/MONDO_0012730,"aortic aneurysm, familial thoracic 6",http://purl.obolibrary.org/obo/MONDO_0019625,familial thoracic aortic aneurysm and aortic dissection,http://identifiers.org/hgnc/130,ACTA2
+http://purl.obolibrary.org/obo/MONDO_0014187,"aortic aneurysm, familial thoracic 8",http://purl.obolibrary.org/obo/MONDO_0019625,familial thoracic aortic aneurysm and aortic dissection,http://identifiers.org/hgnc/9414,PRKG1
+http://purl.obolibrary.org/obo/MONDO_0014514,"aortic aneurysm, familial thoracic 9",http://purl.obolibrary.org/obo/MONDO_0019625,familial thoracic aortic aneurysm and aortic dissection,http://identifiers.org/hgnc/29673,MFAP5
+http://purl.obolibrary.org/obo/MONDO_0024523,aortic valve disease 1,http://purl.obolibrary.org/obo/MONDO_0003803,aortic valve disease,http://identifiers.org/hgnc/7881,NOTCH1
+http://purl.obolibrary.org/obo/MONDO_0013902,aortic valve disease 2,http://purl.obolibrary.org/obo/MONDO_0003803,aortic valve disease,http://identifiers.org/hgnc/6772,SMAD6
+http://purl.obolibrary.org/obo/MONDO_0007152,arrhythmogenic right ventricular dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0016587,arrhythmogenic right ventricular cardiomyopathy,http://identifiers.org/hgnc/11769,TGFB3
+http://purl.obolibrary.org/obo/MONDO_0012434,arrhythmogenic right ventricular dysplasia 10,http://purl.obolibrary.org/obo/MONDO_0016587,arrhythmogenic right ventricular cardiomyopathy,http://identifiers.org/hgnc/3049,DSG2
+http://purl.obolibrary.org/obo/MONDO_0012506,arrhythmogenic right ventricular dysplasia 11,http://purl.obolibrary.org/obo/MONDO_0016342,familial isolated arrhythmogenic right ventricular dysplasia,http://identifiers.org/hgnc/3036,DSC2
+http://purl.obolibrary.org/obo/MONDO_0012684,arrhythmogenic right ventricular dysplasia 12,http://purl.obolibrary.org/obo/MONDO_0016342,familial isolated arrhythmogenic right ventricular dysplasia,http://identifiers.org/hgnc/6207,JUP
+http://purl.obolibrary.org/obo/MONDO_0000908,arrhythmogenic right ventricular dysplasia 13,http://purl.obolibrary.org/obo/MONDO_0016587,arrhythmogenic right ventricular cardiomyopathy,http://identifiers.org/hgnc/2511,CTNNA3
+http://purl.obolibrary.org/obo/MONDO_0010975,arrhythmogenic right ventricular dysplasia 2,http://purl.obolibrary.org/obo/MONDO_0016342,familial isolated arrhythmogenic right ventricular dysplasia,http://identifiers.org/hgnc/10484,RYR2
+http://purl.obolibrary.org/obo/MONDO_0011459,arrhythmogenic right ventricular dysplasia 5,http://purl.obolibrary.org/obo/MONDO_0016587,arrhythmogenic right ventricular cardiomyopathy,http://identifiers.org/hgnc/28472,TMEM43
+http://purl.obolibrary.org/obo/MONDO_0011831,arrhythmogenic right ventricular dysplasia 8,http://purl.obolibrary.org/obo/MONDO_0016587,arrhythmogenic right ventricular cardiomyopathy,http://identifiers.org/hgnc/3052,DSP
+http://purl.obolibrary.org/obo/MONDO_0012180,arrhythmogenic right ventricular dysplasia 9,http://purl.obolibrary.org/obo/MONDO_0016342,familial isolated arrhythmogenic right ventricular dysplasia,http://identifiers.org/hgnc/9024,PKP2
+http://purl.obolibrary.org/obo/MONDO_0008817,"arterial calcification, generalized, of infancy, 1",http://purl.obolibrary.org/obo/MONDO_0018870,arterial calcification of infancy,http://identifiers.org/hgnc/3356,ENPP1
+http://purl.obolibrary.org/obo/MONDO_0013768,"arterial calcification, generalized, of infancy, 2",http://purl.obolibrary.org/obo/MONDO_0018870,arterial calcification of infancy,http://identifiers.org/hgnc/57,ABCC6
+http://purl.obolibrary.org/obo/MONDO_0008822,"arthrogryposis, renal dysfunction, and cholestasis 1",http://purl.obolibrary.org/obo/MONDO_0017123,arthrogryposis-renal dysfunction-cholestasis syndrome,http://identifiers.org/hgnc/12712,VPS33B
+http://purl.obolibrary.org/obo/MONDO_0013255,"arthrogryposis, renal dysfunction, and cholestasis 2",http://purl.obolibrary.org/obo/MONDO_0017123,arthrogryposis-renal dysfunction-cholestasis syndrome,http://identifiers.org/hgnc/20347,VIPAS39
+http://purl.obolibrary.org/obo/MONDO_0012644,asphyxiating thoracic dystrophy 2,http://purl.obolibrary.org/obo/MONDO_0018770,Jeune syndrome,http://identifiers.org/hgnc/29262,IFT80
+http://purl.obolibrary.org/obo/MONDO_0013717,asphyxiating thoracic dystrophy 5,http://purl.obolibrary.org/obo/MONDO_0018770,Jeune syndrome,http://identifiers.org/hgnc/18340,WDR19
+http://purl.obolibrary.org/obo/MONDO_0011805,"asthma-related traits, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0010940,inherited susceptibility to asthma,http://identifiers.org/hgnc/9591,PTGDR
+http://purl.obolibrary.org/obo/MONDO_0012067,"asthma-related traits, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0010940,inherited susceptibility to asthma,http://identifiers.org/hgnc/23631,NPSR1
+http://purl.obolibrary.org/obo/MONDO_0012607,"asthma-related traits, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0010940,inherited susceptibility to asthma,http://identifiers.org/hgnc/17020,IRAK3
+http://purl.obolibrary.org/obo/MONDO_0012771,"asthma-related traits, susceptibility to, 7",http://purl.obolibrary.org/obo/MONDO_0010940,inherited susceptibility to asthma,http://identifiers.org/hgnc/1932,CHI3L1
+http://purl.obolibrary.org/obo/MONDO_0008842,ataxia with oculomotor apraxia type 1,http://purl.obolibrary.org/obo/MONDO_0020258,oculomotor apraxia or related oculomotor disease,http://identifiers.org/hgnc/15984,APTX
+http://purl.obolibrary.org/obo/MONDO_0014557,ataxia-oculomotor apraxia type 4,http://purl.obolibrary.org/obo/MONDO_0020258,oculomotor apraxia or related oculomotor disease,http://identifiers.org/hgnc/9154,PNKP
+http://purl.obolibrary.org/obo/MONDO_0024557,ataxia-telangiectasia-like disorder 1,http://purl.obolibrary.org/obo/MONDO_0011457,ataxia-telangiectasia-like disorder,http://identifiers.org/hgnc/7230,MRE11
+http://purl.obolibrary.org/obo/MONDO_0011596,atopic dermatitis 2,http://purl.obolibrary.org/obo/MONDO_0004980,atopic eczema,http://identifiers.org/hgnc/3748,FLG
+http://purl.obolibrary.org/obo/MONDO_0013530,"atrial fibrillation, familial, 10",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/10593,SCN5A
+http://purl.obolibrary.org/obo/MONDO_0013544,"atrial fibrillation, familial, 11",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/4279,GJA5
+http://purl.obolibrary.org/obo/MONDO_0013545,"atrial fibrillation, familial, 12",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/60,ABCC9
+http://purl.obolibrary.org/obo/MONDO_0014155,"atrial fibrillation, familial, 13",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/10586,SCN1B
+http://purl.obolibrary.org/obo/MONDO_0014156,"atrial fibrillation, familial, 14",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/10589,SCN2B
+http://purl.obolibrary.org/obo/MONDO_0014340,"atrial fibrillation, familial, 15",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/8063,NUP155
+http://purl.obolibrary.org/obo/MONDO_0015001,"atrial fibrillation, familial, 18; ATFB18",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/7585,MYL4
+http://purl.obolibrary.org/obo/MONDO_0011857,"atrial fibrillation, familial, 3",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/6294,KCNQ1
+http://purl.obolibrary.org/obo/MONDO_0012677,"atrial fibrillation, familial, 4",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/6242,KCNE2
+http://purl.obolibrary.org/obo/MONDO_0012816,"atrial fibrillation, familial, 6",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/7939,NPPA
+http://purl.obolibrary.org/obo/MONDO_0012828,"atrial fibrillation, familial, 7",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/6224,KCNA5
+http://purl.obolibrary.org/obo/MONDO_0013513,"atrial fibrillation, familial, 9",http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://identifiers.org/hgnc/6263,KCNJ2
+http://purl.obolibrary.org/obo/MONDO_0011938,atrial heart septal defect 2,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/4173,GATA4
+http://purl.obolibrary.org/obo/MONDO_0013567,atrial heart septal defect 3,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/7576,MYH6
+http://purl.obolibrary.org/obo/MONDO_0012654,atrial heart septal defect 4,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/11598,TBX20
+http://purl.obolibrary.org/obo/MONDO_0013011,atrial heart septal defect 5,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/143,ACTC1
+http://purl.obolibrary.org/obo/MONDO_0013123,atrial heart septal defect 6,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/11843,TLL1
+http://purl.obolibrary.org/obo/MONDO_0007173,atrial heart septal defect 7,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/2488,NKX2-5
+http://purl.obolibrary.org/obo/MONDO_0013750,atrial heart septal defect 8,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/1987,CITED2
+http://purl.obolibrary.org/obo/MONDO_0013770,atrial heart septal defect 9,http://purl.obolibrary.org/obo/MONDO_0006664,atrial heart septal defect,http://identifiers.org/hgnc/4174,GATA6
+http://purl.obolibrary.org/obo/MONDO_0007171,atrial standstill 1,http://purl.obolibrary.org/obo/MONDO_0015281,atrial standstill,http://identifiers.org/hgnc/4279,GJA5
+http://purl.obolibrary.org/obo/MONDO_0014329,atrial standstill 2,http://purl.obolibrary.org/obo/MONDO_0015281,atrial standstill,http://identifiers.org/hgnc/7939,NPPA
+http://purl.obolibrary.org/obo/MONDO_0010859,atrioventricular septal defect 3,http://purl.obolibrary.org/obo/MONDO_0020290,atrioventricular septal defect,http://identifiers.org/hgnc/4274,GJA1
+http://purl.obolibrary.org/obo/MONDO_0013747,atrioventricular septal defect 4,http://purl.obolibrary.org/obo/MONDO_0020290,atrioventricular septal defect,http://identifiers.org/hgnc/4173,GATA4
+http://purl.obolibrary.org/obo/MONDO_0013769,atrioventricular septal defect 5,http://purl.obolibrary.org/obo/MONDO_0020290,atrioventricular septal defect,http://identifiers.org/hgnc/4174,GATA6
+http://purl.obolibrary.org/obo/MONDO_0011650,"atrioventricular septal defect, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0020290,atrioventricular septal defect,http://identifiers.org/hgnc/14630,CRELD1
+http://purl.obolibrary.org/obo/MONDO_0012517,atypical Gaucher disease due to saposin C deficiency,http://purl.obolibrary.org/obo/MONDO_0018150,Gaucher disease,http://identifiers.org/hgnc/9498,PSAP
+http://purl.obolibrary.org/obo/MONDO_0011234,auriculocondylar syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000107,auriculocondylar syndrome,http://identifiers.org/hgnc/4387,GNAI3
+http://purl.obolibrary.org/obo/MONDO_0013845,auriculocondylar syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000107,auriculocondylar syndrome,http://identifiers.org/hgnc/9059,PLCB4
+http://purl.obolibrary.org/obo/MONDO_0014861,"autoimmune disease, multisystem, infantile-onset, 2; ADMIO2",http://purl.obolibrary.org/obo/MONDO_0000213,"autoimmune disease, multisystem, infantile-onset",http://identifiers.org/hgnc/12858,ZAP70
+http://purl.obolibrary.org/obo/MONDO_0011919,"autoimmune disease, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://identifiers.org/hgnc/3804,FOXD3
+http://purl.obolibrary.org/obo/MONDO_0013303,"autoimmune disease, susceptibility to, 6",http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://identifiers.org/hgnc/18187,SIAE
+http://purl.obolibrary.org/obo/MONDO_0011383,autoimmune lymphoproliferative syndrome type 2A,http://purl.obolibrary.org/obo/MONDO_0017979,autoimmune lymphoproliferative syndrome,http://identifiers.org/hgnc/1500,CASP10
+http://purl.obolibrary.org/obo/MONDO_0011804,autoimmune lymphoproliferative syndrome type 2B,http://purl.obolibrary.org/obo/MONDO_0017979,autoimmune lymphoproliferative syndrome,http://identifiers.org/hgnc/1509,CASP8
+http://purl.obolibrary.org/obo/MONDO_0014253,autoimmune lymphoproliferative syndrome type 3,http://purl.obolibrary.org/obo/MONDO_0017979,autoimmune lymphoproliferative syndrome,http://identifiers.org/hgnc/9399,PRKCD
+http://purl.obolibrary.org/obo/MONDO_0013767,autoimmune lymphoproliferative syndrome type 4,http://purl.obolibrary.org/obo/MONDO_0017979,autoimmune lymphoproliferative syndrome,http://identifiers.org/hgnc/7989,NRAS
+http://purl.obolibrary.org/obo/MONDO_0009411,autoimmune polyendocrine syndrome type 1,http://purl.obolibrary.org/obo/MONDO_0017278,autoimmune polyendocrinopathy,http://identifiers.org/hgnc/360,AIRE
+http://purl.obolibrary.org/obo/MONDO_0014711,autosomal dominant Charcot-Marie-Tooth disease type 2W,http://purl.obolibrary.org/obo/MONDO_0018993,Charcot-Marie-tooth disease type 2,http://identifiers.org/hgnc/4816,HARS
+http://purl.obolibrary.org/obo/MONDO_0011764,autosomal dominant Parkinson disease 8,http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/18618,LRRK2
+http://purl.obolibrary.org/obo/MONDO_0024455,autosomal dominant Robinow syndrome 1,http://purl.obolibrary.org/obo/MONDO_0008389,autosomal dominant Robinow syndrome,http://identifiers.org/hgnc/12784,WNT5A
+http://purl.obolibrary.org/obo/MONDO_0014591,autosomal dominant Robinow syndrome 2,http://purl.obolibrary.org/obo/MONDO_0008389,autosomal dominant Robinow syndrome,http://identifiers.org/hgnc/3084,DVL1
+http://purl.obolibrary.org/obo/MONDO_0014819,autosomal dominant Robinow syndrome 3,http://purl.obolibrary.org/obo/MONDO_0019978,Robinow syndrome,http://identifiers.org/hgnc/3087,DVL3
+http://purl.obolibrary.org/obo/MONDO_0012196,autosomal dominant auditory neuropathy 1,http://purl.obolibrary.org/obo/MONDO_0021944,auditory neuropathy,http://identifiers.org/hgnc/15480,DIAPH3
+http://purl.obolibrary.org/obo/MONDO_0011013,autosomal dominant hypocalcemia 1,http://purl.obolibrary.org/obo/MONDO_0018543,autosomal dominant hypocalcemia,http://identifiers.org/hgnc/1514,CASR
+http://purl.obolibrary.org/obo/MONDO_0008032,autosomal dominant limb-girdle muscular dystrophy type 1A,http://purl.obolibrary.org/obo/MONDO_0015151,autosomal dominant limb-girdle muscular dystrophy,http://identifiers.org/hgnc/12399,MYOT
+http://purl.obolibrary.org/obo/MONDO_0008033,autosomal dominant limb-girdle muscular dystrophy type 1B,http://purl.obolibrary.org/obo/MONDO_0015151,autosomal dominant limb-girdle muscular dystrophy,http://identifiers.org/hgnc/6636,LMNA
+http://purl.obolibrary.org/obo/MONDO_0011910,autosomal dominant limb-girdle muscular dystrophy type 1C,http://purl.obolibrary.org/obo/MONDO_0015151,autosomal dominant limb-girdle muscular dystrophy,http://identifiers.org/hgnc/1529,CAV3
+http://purl.obolibrary.org/obo/MONDO_0021018,autosomal dominant limb-girdle muscular dystrophy type 1D (DNAJB6),http://purl.obolibrary.org/obo/MONDO_0015151,autosomal dominant limb-girdle muscular dystrophy,http://identifiers.org/hgnc/14888,DNAJB6
+http://purl.obolibrary.org/obo/MONDO_0012193,autosomal dominant limb-girdle muscular dystrophy type 1G,http://purl.obolibrary.org/obo/MONDO_0015151,autosomal dominant limb-girdle muscular dystrophy,http://identifiers.org/hgnc/5037,HNRNPDL
+http://purl.obolibrary.org/obo/MONDO_0013141,autosomal dominant macrothrombocytopenia TUBB1-related,http://purl.obolibrary.org/obo/MONDO_0015372,autosomal dominant macrothrombocytopenia,http://identifiers.org/hgnc/16257,TUBB1
+http://purl.obolibrary.org/obo/MONDO_0010899,autosomal dominant nocturnal frontal lobe epilepsy 1,http://purl.obolibrary.org/obo/MONDO_0020300,autosomal dominant nocturnal frontal lobe epilepsy,http://identifiers.org/hgnc/1958,CHRNA4
+http://purl.obolibrary.org/obo/MONDO_0011545,autosomal dominant nocturnal frontal lobe epilepsy 3,http://purl.obolibrary.org/obo/MONDO_0020300,autosomal dominant nocturnal frontal lobe epilepsy,http://identifiers.org/hgnc/1962,CHRNB2
+http://purl.obolibrary.org/obo/MONDO_0012474,autosomal dominant nocturnal frontal lobe epilepsy 4,http://purl.obolibrary.org/obo/MONDO_0020300,autosomal dominant nocturnal frontal lobe epilepsy,http://identifiers.org/hgnc/1956,CHRNA2
+http://purl.obolibrary.org/obo/MONDO_0014002,autosomal dominant nocturnal frontal lobe epilepsy 5,http://purl.obolibrary.org/obo/MONDO_0020300,autosomal dominant nocturnal frontal lobe epilepsy,http://identifiers.org/hgnc/18865,KCNT1
+http://purl.obolibrary.org/obo/MONDO_0007424,autosomal dominant nonsyndromic deafness 1,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/2876,DIAPH1
+http://purl.obolibrary.org/obo/MONDO_0011031,autosomal dominant nonsyndromic deafness 10,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/3522,EYA4
+http://purl.obolibrary.org/obo/MONDO_0011032,autosomal dominant nonsyndromic deafness 11,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/7606,MYO7A
+http://purl.obolibrary.org/obo/MONDO_0011102,autosomal dominant nonsyndromic deafness 12,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/11720,TECTA
+http://purl.obolibrary.org/obo/MONDO_0011159,autosomal dominant nonsyndromic deafness 13,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/2187,COL11A2
+http://purl.obolibrary.org/obo/MONDO_0011226,autosomal dominant nonsyndromic deafness 15,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/9220,POU4F3
+http://purl.obolibrary.org/obo/MONDO_0011350,autosomal dominant nonsyndromic deafness 17,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/7579,MYH9
+http://purl.obolibrary.org/obo/MONDO_0011480,autosomal dominant nonsyndromic deafness 20,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/144,ACTG1
+http://purl.obolibrary.org/obo/MONDO_0011660,autosomal dominant nonsyndromic deafness 22,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/7605,MYO6
+http://purl.obolibrary.org/obo/MONDO_0011519,autosomal dominant nonsyndromic deafness 23,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/10887,SIX1
+http://purl.obolibrary.org/obo/MONDO_0011568,autosomal dominant nonsyndromic deafness 25,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/20151,SLC17A8
+http://purl.obolibrary.org/obo/MONDO_0012083,autosomal dominant nonsyndromic deafness 28,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/2799,GRHL2
+http://purl.obolibrary.org/obo/MONDO_0010817,autosomal dominant nonsyndromic deafness 2A,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/6298,KCNQ4
+http://purl.obolibrary.org/obo/MONDO_0012976,autosomal dominant nonsyndromic deafness 2B,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/4285,GJB3
+http://purl.obolibrary.org/obo/MONDO_0011708,autosomal dominant nonsyndromic deafness 36,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/16513,TMC1
+http://purl.obolibrary.org/obo/MONDO_0011103,autosomal dominant nonsyndromic deafness 3A,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/4284,GJB2
+http://purl.obolibrary.org/obo/MONDO_0012975,autosomal dominant nonsyndromic deafness 3B,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/4288,GJB6
+http://purl.obolibrary.org/obo/MONDO_0014603,autosomal dominant nonsyndromic deafness 40,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/2418,CRYM
+http://purl.obolibrary.org/obo/MONDO_0011994,autosomal dominant nonsyndromic deafness 41,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/15459,P2RX2
+http://purl.obolibrary.org/obo/MONDO_0011832,autosomal dominant nonsyndromic deafness 44,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/18111,CCDC50
+http://purl.obolibrary.org/obo/MONDO_0011920,autosomal dominant nonsyndromic deafness 48,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/7595,MYO1A
+http://purl.obolibrary.org/obo/MONDO_0010915,autosomal dominant nonsyndromic deafness 4A,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/23212,MYH14
+http://purl.obolibrary.org/obo/MONDO_0013823,autosomal dominant nonsyndromic deafness 4B,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/31948,CEACAM16
+http://purl.obolibrary.org/obo/MONDO_0010973,autosomal dominant nonsyndromic deafness 5,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/2810,GSDME
+http://purl.obolibrary.org/obo/MONDO_0014283,autosomal dominant nonsyndromic deafness 56,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/5318,TNC
+http://purl.obolibrary.org/obo/MONDO_0010963,autosomal dominant nonsyndromic deafness 6,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/12762,WFS1
+http://purl.obolibrary.org/obo/MONDO_0013593,autosomal dominant nonsyndromic deafness 64,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/21528,DIABLO
+http://purl.obolibrary.org/obo/MONDO_0014470,autosomal dominant nonsyndromic deafness 65,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/29203,TBC1D24
+http://purl.obolibrary.org/obo/MONDO_0014854,autosomal dominant nonsyndromic deafness 66,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/1632,CD164
+http://purl.obolibrary.org/obo/MONDO_0014594,autosomal dominant nonsyndromic deafness 67,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/15761,OSBPL2
+http://purl.obolibrary.org/obo/MONDO_0014740,autosomal dominant nonsyndromic deafness 68,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/17513,HOMER2
+http://purl.obolibrary.org/obo/MONDO_0014738,autosomal dominant nonsyndromic deafness 69,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/6343,KITLG
+http://purl.obolibrary.org/obo/MONDO_0014853,autosomal dominant nonsyndromic deafness 70,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/6944,MCM2
+http://purl.obolibrary.org/obo/MONDO_0011058,autosomal dominant nonsyndromic deafness 9,http://purl.obolibrary.org/obo/MONDO_0019587,autosomal dominant nonsyndromic deafness,http://identifiers.org/hgnc/2180,COCH
+http://purl.obolibrary.org/obo/MONDO_0011877,autosomal dominant osteopetrosis 1,http://purl.obolibrary.org/obo/MONDO_0017198,osteopetrosis (disease),http://identifiers.org/hgnc/6697,LRP5
+http://purl.obolibrary.org/obo/MONDO_0012166,autosomal dominant sensory ataxia 1,http://purl.obolibrary.org/obo/MONDO_0000557,hereditary ataxia,http://identifiers.org/hgnc/25358,RNF170
+http://purl.obolibrary.org/obo/MONDO_0015091,autosomal dominant spastic paraplegia type 9,http://purl.obolibrary.org/obo/MONDO_0015087,autosomal dominant complex spastic paraplegia,http://identifiers.org/hgnc/9722,ALDH18A1
+http://purl.obolibrary.org/obo/MONDO_0012205,autosomal dominant striatal neurodegeneration type 1,http://purl.obolibrary.org/obo/MONDO_0000211,"striatal degeneration, autosomal dominant",http://identifiers.org/hgnc/8794,PDE8B
+http://purl.obolibrary.org/obo/MONDO_0013060,autosomal recessive Parkinson disease 14,http://purl.obolibrary.org/obo/MONDO_0018466,hereditary late onset Parkinson disease,http://identifiers.org/hgnc/9039,PLA2G6
+http://purl.obolibrary.org/obo/MONDO_0014702,autosomal recessive complex spastic paraplegia type 9B,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/9722,ALDH18A1
+http://purl.obolibrary.org/obo/MONDO_0013051,autosomal recessive cutis laxa type 2B,http://purl.obolibrary.org/obo/MONDO_0019573,autosomal recessive cutis laxa type 2,http://identifiers.org/hgnc/9721,PYCR1
+http://purl.obolibrary.org/obo/MONDO_0011436,autosomal recessive distal spinal muscular atrophy 1,http://purl.obolibrary.org/obo/MONDO_0001516,spinal muscular atrophy,http://identifiers.org/hgnc/5542,IGHMBP2
+http://purl.obolibrary.org/obo/MONDO_0011613,autosomal recessive early-onset Parkinson disease 6,http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/14581,PINK1
+http://purl.obolibrary.org/obo/MONDO_0011658,autosomal recessive early-onset Parkinson disease 7,http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/16369,PARK7
+http://purl.obolibrary.org/obo/MONDO_0014796,autosomal recessive early-onset Parksinson disease 23,http://purl.obolibrary.org/obo/MONDO_0017279,young-onset Parkinson disease,http://identifiers.org/hgnc/23594,VPS13C
+http://purl.obolibrary.org/obo/MONDO_0010820,autosomal recessive juvenile Parkinson disease 2,http://purl.obolibrary.org/obo/MONDO_0017279,young-onset Parkinson disease,http://identifiers.org/hgnc/8607,PRKN
+http://purl.obolibrary.org/obo/MONDO_0009675,autosomal recessive limb-girdle muscular dystrophy type 2A,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/1480,CAPN3
+http://purl.obolibrary.org/obo/MONDO_0009676,autosomal recessive limb-girdle muscular dystrophy type 2B,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/3097,DYSF
+http://purl.obolibrary.org/obo/MONDO_0009677,autosomal recessive limb-girdle muscular dystrophy type 2C,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/10809,SGCG
+http://purl.obolibrary.org/obo/MONDO_0011968,autosomal recessive limb-girdle muscular dystrophy type 2D,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/10805,SGCA
+http://purl.obolibrary.org/obo/MONDO_0011423,autosomal recessive limb-girdle muscular dystrophy type 2E,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/10806,SGCB
+http://purl.obolibrary.org/obo/MONDO_0011028,autosomal recessive limb-girdle muscular dystrophy type 2F,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/10807,SGCD
+http://purl.obolibrary.org/obo/MONDO_0011170,autosomal recessive limb-girdle muscular dystrophy type 2G,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/11610,TCAP
+http://purl.obolibrary.org/obo/MONDO_0009683,autosomal recessive limb-girdle muscular dystrophy type 2H,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/16380,TRIM32
+http://purl.obolibrary.org/obo/MONDO_0011787,autosomal recessive limb-girdle muscular dystrophy type 2I,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/17997,FKRP
+http://purl.obolibrary.org/obo/MONDO_0012127,autosomal recessive limb-girdle muscular dystrophy type 2J,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/12403,TTN
+http://purl.obolibrary.org/obo/MONDO_0012248,autosomal recessive limb-girdle muscular dystrophy type 2K,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/9202,POMT1
+http://purl.obolibrary.org/obo/MONDO_0012652,autosomal recessive limb-girdle muscular dystrophy type 2L,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/27337,ANO5
+http://purl.obolibrary.org/obo/MONDO_0012699,autosomal recessive limb-girdle muscular dystrophy type 2M,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/3622,FKTN
+http://purl.obolibrary.org/obo/MONDO_0013162,autosomal recessive limb-girdle muscular dystrophy type 2N,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/19743,POMT2
+http://purl.obolibrary.org/obo/MONDO_0013161,autosomal recessive limb-girdle muscular dystrophy type 2O,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/19139,POMGNT1
+http://purl.obolibrary.org/obo/MONDO_0013440,autosomal recessive limb-girdle muscular dystrophy type 2P,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/2666,DAG1
+http://purl.obolibrary.org/obo/MONDO_0014129,autosomal recessive limb-girdle muscular dystrophy type 2R,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/2770,DES
+http://purl.obolibrary.org/obo/MONDO_0014144,autosomal recessive limb-girdle muscular dystrophy type 2S,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/25751,TRAPPC11
+http://purl.obolibrary.org/obo/MONDO_0014142,autosomal recessive limb-girdle muscular dystrophy type 2T,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/22932,GMPPB
+http://purl.obolibrary.org/obo/MONDO_0014474,autosomal recessive limb-girdle muscular dystrophy type 2U,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/37276,ISPD
+http://purl.obolibrary.org/obo/MONDO_0014788,autosomal recessive limb-girdle muscular dystrophy type 2W,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/16084,LIMS2
+http://purl.obolibrary.org/obo/MONDO_0014782,autosomal recessive limb-girdle muscular dystrophy type 2X,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/1152,BVES
+http://purl.obolibrary.org/obo/MONDO_0014900,autosomal recessive limb-girdle muscular dystrophy type 2Y,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/29456,TOR1AIP1
+http://purl.obolibrary.org/obo/MONDO_0014977,autosomal recessive limb-girdle muscular dystrophy type 2Z,http://purl.obolibrary.org/obo/MONDO_0015152,autosomal recessive limb-girdle muscular dystrophy,http://identifiers.org/hgnc/22954,POGLUT1
+http://purl.obolibrary.org/obo/MONDO_0014363,autosomal recessive nonsyndromic deafness 101,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/33862,GRXCR2
+http://purl.obolibrary.org/obo/MONDO_0014428,autosomal recessive nonsyndromic deafness 102,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/3420,EPS8
+http://purl.obolibrary.org/obo/MONDO_0014469,autosomal recessive nonsyndromic deafness 103,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/13517,CLIC5
+http://purl.obolibrary.org/obo/MONDO_0014675,autosomal recessive nonsyndromic deafness 104,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/13872,RIPOR2
+http://purl.obolibrary.org/obo/MONDO_0014849,autosomal recessive nonsyndromic deafness 105,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/1718,CDC14A
+http://purl.obolibrary.org/obo/MONDO_0011160,autosomal recessive nonsyndromic deafness 15,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/18183,GIPC3
+http://purl.obolibrary.org/obo/MONDO_0011364,autosomal recessive nonsyndromic deafness 16,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/16035,STRC
+http://purl.obolibrary.org/obo/MONDO_0011192,autosomal recessive nonsyndromic deafness 18A,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/12597,USH1C
+http://purl.obolibrary.org/obo/MONDO_0013985,autosomal recessive nonsyndromic deafness 18B,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/8516,OTOG
+http://purl.obolibrary.org/obo/MONDO_0012977,autosomal recessive nonsyndromic deafness 1B,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/4288,GJB6
+http://purl.obolibrary.org/obo/MONDO_0010807,autosomal recessive nonsyndromic deafness 2,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/7606,MYO7A
+http://purl.obolibrary.org/obo/MONDO_0011351,autosomal recessive nonsyndromic deafness 21,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/11720,TECTA
+http://purl.obolibrary.org/obo/MONDO_0011762,autosomal recessive nonsyndromic deafness 22,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/16378,OTOA
+http://purl.obolibrary.org/obo/MONDO_0012293,autosomal recessive nonsyndromic deafness 23,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/14674,PCDH15
+http://purl.obolibrary.org/obo/MONDO_0012602,autosomal recessive nonsyndromic deafness 24,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/9944,RDX
+http://purl.obolibrary.org/obo/MONDO_0013210,autosomal recessive nonsyndromic deafness 25,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/31673,GRXCR1
+http://purl.obolibrary.org/obo/MONDO_0012355,autosomal recessive nonsyndromic deafness 28,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/17009,TRIOBP
+http://purl.obolibrary.org/obo/MONDO_0013537,autosomal recessive nonsyndromic deafness 29,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/2035,CLDN14
+http://purl.obolibrary.org/obo/MONDO_0010860,autosomal recessive nonsyndromic deafness 3,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/7594,MYO15A
+http://purl.obolibrary.org/obo/MONDO_0011774,autosomal recessive nonsyndromic deafness 30,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/7601,MYO3A
+http://purl.obolibrary.org/obo/MONDO_0011767,autosomal recessive nonsyndromic deafness 31,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/16361,WHRN
+http://purl.obolibrary.org/obo/MONDO_0012060,autosomal recessive nonsyndromic deafness 35,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/3473,ESRRB
+http://purl.obolibrary.org/obo/MONDO_0012170,autosomal recessive nonsyndromic deafness 36,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/13281,ESPN
+http://purl.obolibrary.org/obo/MONDO_0011912,autosomal recessive nonsyndromic deafness 37,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/7605,MYO6
+http://purl.obolibrary.org/obo/MONDO_0012003,autosomal recessive nonsyndromic deafness 39,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/4893,HGF
+http://purl.obolibrary.org/obo/MONDO_0012326,autosomal recessive nonsyndromic deafness 42,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/28741,ILDR1
+http://purl.obolibrary.org/obo/MONDO_0012421,autosomal recessive nonsyndromic deafness 44,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/232,ADCY1
+http://purl.obolibrary.org/obo/MONDO_0012273,autosomal recessive nonsyndromic deafness 48,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/24579,CIB2
+http://purl.obolibrary.org/obo/MONDO_0012420,autosomal recessive nonsyndromic deafness 49,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/26401,MARVELD2
+http://purl.obolibrary.org/obo/MONDO_0012333,autosomal recessive nonsyndromic deafness 53,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/2187,COL11A2
+http://purl.obolibrary.org/obo/MONDO_0012445,autosomal recessive nonsyndromic deafness 59,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/29502,PJVK
+http://purl.obolibrary.org/obo/MONDO_0010965,autosomal recessive nonsyndromic deafness 6,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/30800,TMIE
+http://purl.obolibrary.org/obo/MONDO_0013471,autosomal recessive nonsyndromic deafness 61,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/9359,SLC26A5
+http://purl.obolibrary.org/obo/MONDO_0012670,autosomal recessive nonsyndromic deafness 63,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/25033,LRTOMT
+http://purl.obolibrary.org/obo/MONDO_0012442,autosomal recessive nonsyndromic deafness 66,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/18141,DCDC2
+http://purl.obolibrary.org/obo/MONDO_0012460,autosomal recessive nonsyndromic deafness 67,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/21253,LHFPL5
+http://purl.obolibrary.org/obo/MONDO_0012485,autosomal recessive nonsyndromic deafness 68,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/3169,S1PR2
+http://purl.obolibrary.org/obo/MONDO_0010967,autosomal recessive nonsyndromic deafness 7,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/16513,TMC1
+http://purl.obolibrary.org/obo/MONDO_0013978,autosomal recessive nonsyndromic deafness 70,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/23166,PNPT1
+http://purl.obolibrary.org/obo/MONDO_0013386,autosomal recessive nonsyndromic deafness 74,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/27375,MSRB3
+http://purl.obolibrary.org/obo/MONDO_0014237,autosomal recessive nonsyndromic deafness 76,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/26703,SYNE4
+http://purl.obolibrary.org/obo/MONDO_0013119,autosomal recessive nonsyndromic deafness 77,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/26521,LOXHD1
+http://purl.obolibrary.org/obo/MONDO_0013215,autosomal recessive nonsyndromic deafness 79,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/26894,TPRN
+http://purl.obolibrary.org/obo/MONDO_0013249,autosomal recessive nonsyndromic deafness 84A,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/9679,PTPRQ
+http://purl.obolibrary.org/obo/MONDO_0013984,autosomal recessive nonsyndromic deafness 84B,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/26901,OTOGL
+http://purl.obolibrary.org/obo/MONDO_0013826,autosomal recessive nonsyndromic deafness 86,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/29203,TBC1D24
+http://purl.obolibrary.org/obo/MONDO_0014182,autosomal recessive nonsyndromic deafness 88,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/26158,ELMOD3
+http://purl.obolibrary.org/obo/MONDO_0013489,autosomal recessive nonsyndromic deafness 89,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/6215,KARS
+http://purl.obolibrary.org/obo/MONDO_0010986,autosomal recessive nonsyndromic deafness 9,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/8515,OTOF
+http://purl.obolibrary.org/obo/MONDO_0013269,autosomal recessive nonsyndromic deafness 91,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/8950,SERPINB6
+http://purl.obolibrary.org/obo/MONDO_0013963,autosomal recessive nonsyndromic deafness 93,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/1385,CABP2
+http://purl.obolibrary.org/obo/MONDO_0014739,autosomal recessive nonsyndromic deafness 97,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/7029,MET
+http://purl.obolibrary.org/obo/MONDO_0013929,autosomal recessive nonsyndromic deafness 98,http://purl.obolibrary.org/obo/MONDO_0019588,autosomal recessive nonsyndromic deafness,http://identifiers.org/hgnc/1268,TSPEAR
+http://purl.obolibrary.org/obo/MONDO_0009815,autosomal recessive osteopetrosis 1,http://purl.obolibrary.org/obo/MONDO_0019026,autosomal recessive osteopetrosis,http://identifiers.org/hgnc/11647,TCIRG1
+http://purl.obolibrary.org/obo/MONDO_0009816,autosomal recessive osteopetrosis 2,http://purl.obolibrary.org/obo/MONDO_0019026,autosomal recessive osteopetrosis,http://identifiers.org/hgnc/11926,TNFSF11
+http://purl.obolibrary.org/obo/MONDO_0009818,autosomal recessive osteopetrosis 3,http://purl.obolibrary.org/obo/MONDO_0017198,osteopetrosis (disease),http://identifiers.org/hgnc/1373,CA2
+http://purl.obolibrary.org/obo/MONDO_0012676,autosomal recessive osteopetrosis 4,http://purl.obolibrary.org/obo/MONDO_0019026,autosomal recessive osteopetrosis,http://identifiers.org/hgnc/2025,CLCN7
+http://purl.obolibrary.org/obo/MONDO_0009817,autosomal recessive osteopetrosis 5,http://purl.obolibrary.org/obo/MONDO_0017198,osteopetrosis (disease),http://identifiers.org/hgnc/21652,OSTM1
+http://purl.obolibrary.org/obo/MONDO_0012679,autosomal recessive osteopetrosis 6,http://purl.obolibrary.org/obo/MONDO_0017198,osteopetrosis (disease),http://identifiers.org/hgnc/29017,PLEKHM1
+http://purl.obolibrary.org/obo/MONDO_0012859,autosomal recessive osteopetrosis 7,http://purl.obolibrary.org/obo/MONDO_0017198,osteopetrosis (disease),http://identifiers.org/hgnc/11908,TNFRSF11A
+http://purl.obolibrary.org/obo/MONDO_0014040,autosomal recessive osteopetrosis 8,http://purl.obolibrary.org/obo/MONDO_0019026,autosomal recessive osteopetrosis,http://identifiers.org/hgnc/14974,SNX10
+http://purl.obolibrary.org/obo/MONDO_0014827,autosomal recessive spastic paraplegia type 76,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/1476,CAPN1
+http://purl.obolibrary.org/obo/MONDO_0013392,autosomal recessive spinocerebellar ataxia 10,http://purl.obolibrary.org/obo/MONDO_0015244,autosomal recessive cerebellar ataxia,http://identifiers.org/hgnc/25519,ANO10
+http://purl.obolibrary.org/obo/MONDO_0013645,autosomal recessive spinocerebellar ataxia 11,http://purl.obolibrary.org/obo/MONDO_0020047,autosomal recessive syndromic cerebellar ataxia,http://identifiers.org/hgnc/23143,SYT14
+http://purl.obolibrary.org/obo/MONDO_0013687,autosomal recessive spinocerebellar ataxia 12,http://purl.obolibrary.org/obo/MONDO_0018446,autosomal recessive cerebellar ataxia-epilepsy-intellectual disability syndrome,http://identifiers.org/hgnc/12799,WWOX
+http://purl.obolibrary.org/obo/MONDO_0013905,autosomal recessive spinocerebellar ataxia 13,http://purl.obolibrary.org/obo/MONDO_0018189,autosomal recessive cerebellar ataxia-pyramidal signs-nystagmus-oculomotor apraxia syndrome,http://identifiers.org/hgnc/4593,GRM1
+http://purl.obolibrary.org/obo/MONDO_0014159,autosomal recessive spinocerebellar ataxia 14,http://purl.obolibrary.org/obo/MONDO_0015244,autosomal recessive cerebellar ataxia,http://identifiers.org/hgnc/11276,SPTBN2
+http://purl.obolibrary.org/obo/MONDO_0014311,autosomal recessive spinocerebellar ataxia 15,http://purl.obolibrary.org/obo/MONDO_0018446,autosomal recessive cerebellar ataxia-epilepsy-intellectual disability syndrome,http://identifiers.org/hgnc/28991,RUBCN
+http://purl.obolibrary.org/obo/MONDO_0014339,autosomal recessive spinocerebellar ataxia 16,http://purl.obolibrary.org/obo/MONDO_0015244,autosomal recessive cerebellar ataxia,http://identifiers.org/hgnc/11427,STUB1
+http://purl.obolibrary.org/obo/MONDO_0014503,autosomal recessive spinocerebellar ataxia 17,http://purl.obolibrary.org/obo/MONDO_0020043,autosomal recessive congenital cerebellar ataxia,http://identifiers.org/hgnc/25613,CWF19L1
+http://purl.obolibrary.org/obo/MONDO_0014530,autosomal recessive spinocerebellar ataxia 18,http://purl.obolibrary.org/obo/MONDO_0018189,autosomal recessive cerebellar ataxia-pyramidal signs-nystagmus-oculomotor apraxia syndrome,http://identifiers.org/hgnc/4576,GRID2
+http://purl.obolibrary.org/obo/MONDO_0008943,autosomal recessive spinocerebellar ataxia 2,http://purl.obolibrary.org/obo/MONDO_0020043,autosomal recessive congenital cerebellar ataxia,http://identifiers.org/hgnc/18667,PMPCA
+http://purl.obolibrary.org/obo/MONDO_0014601,autosomal recessive spinocerebellar ataxia 20,http://purl.obolibrary.org/obo/MONDO_0015244,autosomal recessive cerebellar ataxia,http://identifiers.org/hgnc/14977,SNX14
+http://purl.obolibrary.org/obo/MONDO_0013223,"autosomal recessive spondylometaphyseal dysplasia, Megarbane type",http://purl.obolibrary.org/obo/MONDO_0019694,spondylodysplastic dysplasia,http://identifiers.org/hgnc/29679,PAM16
+http://purl.obolibrary.org/obo/MONDO_0013723,"bacteremia, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0000108,"bacteremia, susceptibility",http://identifiers.org/hgnc/17192,TIRAP
+http://purl.obolibrary.org/obo/MONDO_0013724,"bacteremia, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0000108,"bacteremia, susceptibility",http://identifiers.org/hgnc/1984,CISH
+http://purl.obolibrary.org/obo/MONDO_0013876,"basal cell carcinoma, susceptibility to, 7",http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://identifiers.org/hgnc/11998,TP53
+http://purl.obolibrary.org/obo/MONDO_0014628,"basal ganglia calcification, idiopathic, 6",http://purl.obolibrary.org/obo/MONDO_0008947,bilateral striopallidodentate calcinosis,http://identifiers.org/hgnc/12827,XPR1
+http://purl.obolibrary.org/obo/MONDO_0009469,benign recurrent intrahepatic cholestasis type 1,http://purl.obolibrary.org/obo/MONDO_0019008,benign recurrent intrahepatic cholestasis,http://identifiers.org/hgnc/3706,ATP8B1
+http://purl.obolibrary.org/obo/MONDO_0014887,bone marrow failure syndrome 3; BMFS3,http://purl.obolibrary.org/obo/MONDO_0000159,bone marrow failure syndrome,http://identifiers.org/hgnc/27030,DNAJC21
+http://purl.obolibrary.org/obo/MONDO_0014032,brachydactyly type A1C,http://purl.obolibrary.org/obo/MONDO_0007215,brachydactyly type A1,http://identifiers.org/hgnc/4220,GDF5
+http://purl.obolibrary.org/obo/MONDO_0014798,brachydactyly type A1D,http://purl.obolibrary.org/obo/MONDO_0007215,brachydactyly type A1,http://identifiers.org/hgnc/1077,BMPR1B
+http://purl.obolibrary.org/obo/MONDO_0007220,brachydactyly type B1,http://purl.obolibrary.org/obo/MONDO_0019676,brachydactyly type B,http://identifiers.org/hgnc/10257,ROR2
+http://purl.obolibrary.org/obo/MONDO_0007223,brachydactyly type E1,http://purl.obolibrary.org/obo/MONDO_0019677,brachydactyly type E,http://identifiers.org/hgnc/5136,HOXD13
+http://purl.obolibrary.org/obo/MONDO_0013244,brachydactyly type E2,http://purl.obolibrary.org/obo/MONDO_0019677,brachydactyly type E,http://identifiers.org/hgnc/9607,PTHLH
+http://purl.obolibrary.org/obo/MONDO_0011258,branchiootic syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018878,branchiootic syndrome,http://identifiers.org/hgnc/3519,EYA1
+http://purl.obolibrary.org/obo/MONDO_0012025,branchiootic syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018878,branchiootic syndrome,http://identifiers.org/hgnc/10887,SIX1
+http://purl.obolibrary.org/obo/MONDO_0012575,branchiootorenal syndrome 2,http://purl.obolibrary.org/obo/MONDO_0007029,branchio-oto-renal syndrome,http://identifiers.org/hgnc/10891,SIX5
+http://purl.obolibrary.org/obo/MONDO_0011450,"breast-ovarian cancer, familial, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0003582,hereditary breast ovarian cancer syndrome,http://identifiers.org/hgnc/1100,BRCA1
+http://purl.obolibrary.org/obo/MONDO_0012933,"breast-ovarian cancer, familial, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0003582,hereditary breast ovarian cancer syndrome,http://identifiers.org/hgnc/1101,BRCA2
+http://purl.obolibrary.org/obo/MONDO_0013253,"breast-ovarian cancer, familial, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0003582,hereditary breast ovarian cancer syndrome,http://identifiers.org/hgnc/9820,RAD51C
+http://purl.obolibrary.org/obo/MONDO_0013669,"breast-ovarian cancer, familial, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0003582,hereditary breast ovarian cancer syndrome,http://identifiers.org/hgnc/9823,RAD51D
+http://purl.obolibrary.org/obo/MONDO_0014450,"breasts and/or nipples, aplasia or hypoplasia of, 2",http://purl.obolibrary.org/obo/MONDO_0015855,isolated congenital breast hypoplasia/aplasia,http://identifiers.org/hgnc/9670,PTPRF
+http://purl.obolibrary.org/obo/MONDO_0024543,brittle cornea syndrome 1,http://purl.obolibrary.org/obo/MONDO_0009242,brittle cornea syndrome,http://identifiers.org/hgnc/23216,ZNF469
+http://purl.obolibrary.org/obo/MONDO_0013605,brittle cornea syndrome 2,http://purl.obolibrary.org/obo/MONDO_0009242,brittle cornea syndrome,http://identifiers.org/hgnc/9349,PRDM5
+http://purl.obolibrary.org/obo/MONDO_0013087,bronchiectasis with or without elevated sweat chloride 2,http://purl.obolibrary.org/obo/MONDO_0004822,bronchiectasis,http://identifiers.org/hgnc/10599,SCNN1A
+http://purl.obolibrary.org/obo/MONDO_0013112,bronchiectasis with or without elevated sweat chloride 3,http://purl.obolibrary.org/obo/MONDO_0004822,bronchiectasis,http://identifiers.org/hgnc/10602,SCNN1G
+http://purl.obolibrary.org/obo/MONDO_0013867,brown-Vialetto-van Laere syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000406,Brown-Vialetto-van Laere syndrome,http://identifiers.org/hgnc/30224,SLC52A2
+http://purl.obolibrary.org/obo/MONDO_0013140,"candidiasis, familial, 4",http://purl.obolibrary.org/obo/MONDO_0024486,familial chronic mucocutaneous candidiasis,http://identifiers.org/hgnc/14558,CLEC7A
+http://purl.obolibrary.org/obo/MONDO_0013503,"candidiasis, familial, 6",http://purl.obolibrary.org/obo/MONDO_0024486,familial chronic mucocutaneous candidiasis,http://identifiers.org/hgnc/16404,IL17F
+http://purl.obolibrary.org/obo/MONDO_0014230,"candidiasis, familial, 8",http://purl.obolibrary.org/obo/MONDO_0015279,chronic mucocutaneous candidiasis (disease),http://identifiers.org/hgnc/1343,TRAF3IP2
+http://purl.obolibrary.org/obo/MONDO_0014642,"candidiasis, familial, 9",http://purl.obolibrary.org/obo/MONDO_0015279,chronic mucocutaneous candidiasis (disease),http://identifiers.org/hgnc/18358,IL17RC
+http://purl.obolibrary.org/obo/MONDO_0011451,"cardioencephalomyopathy, fatal infantile, due to cytochrome c oxidase deficiency 1",http://purl.obolibrary.org/obo/MONDO_0015487,fatal infantile encephalocardiomyopathy,http://identifiers.org/hgnc/10604,SCO2
+http://purl.obolibrary.org/obo/MONDO_0014051,"cardioencephalomyopathy, fatal infantile, due to cytochrome c oxidase deficiency 2",http://purl.obolibrary.org/obo/MONDO_0015487,fatal infantile encephalocardiomyopathy,http://identifiers.org/hgnc/2263,COX15
+http://purl.obolibrary.org/obo/MONDO_0014667,"cardioencephalomyopathy, fatal infantile, due to cytochrome c oxidase deficiency 3",http://purl.obolibrary.org/obo/MONDO_0015487,fatal infantile encephalocardiomyopathy,http://identifiers.org/hgnc/33848,COA5
+http://purl.obolibrary.org/obo/MONDO_0014668,"cardioencephalomyopathy, fatal infantile, due to cytochrome c oxidase deficiency 4",http://purl.obolibrary.org/obo/MONDO_0015487,fatal infantile encephalocardiomyopathy,http://identifiers.org/hgnc/18025,COA6
+http://purl.obolibrary.org/obo/MONDO_0007265,cardiofaciocutaneous syndrome 1,http://purl.obolibrary.org/obo/MONDO_0015280,cardiofaciocutaneous syndrome,http://identifiers.org/hgnc/1097,BRAF
+http://purl.obolibrary.org/obo/MONDO_0014112,cardiofaciocutaneous syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015280,cardiofaciocutaneous syndrome,http://identifiers.org/hgnc/6407,KRAS
+http://purl.obolibrary.org/obo/MONDO_0014113,cardiofaciocutaneous syndrome 3,http://purl.obolibrary.org/obo/MONDO_0015280,cardiofaciocutaneous syndrome,http://identifiers.org/hgnc/6840,MAP2K1
+http://purl.obolibrary.org/obo/MONDO_0014114,cardiofaciocutaneous syndrome 4,http://purl.obolibrary.org/obo/MONDO_0015280,cardiofaciocutaneous syndrome,http://identifiers.org/hgnc/6842,MAP2K2
+http://purl.obolibrary.org/obo/MONDO_0007270,"cardiomyopathy, familial restrictive, 1",http://purl.obolibrary.org/obo/MONDO_0019150,familial isolated restrictive cardiomyopathy,http://identifiers.org/hgnc/11947,TNNI3
+http://purl.obolibrary.org/obo/MONDO_0012900,"cardiomyopathy, familial restrictive, 3",http://purl.obolibrary.org/obo/MONDO_0019150,familial isolated restrictive cardiomyopathy,http://identifiers.org/hgnc/11949,TNNT2
+http://purl.obolibrary.org/obo/MONDO_0009705,carnitine palmitoyl transferase 1A deficiency,http://purl.obolibrary.org/obo/MONDO_0017716,disorder of carnitine cycle and carnitine transport,http://identifiers.org/hgnc/2328,CPT1A
+http://purl.obolibrary.org/obo/MONDO_0007285,cataract 1 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/4281,GJA8
+http://purl.obolibrary.org/obo/MONDO_0010948,cataract 10 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2394,CRYBA1
+http://purl.obolibrary.org/obo/MONDO_0012527,cataract 11 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/9006,PITX3
+http://purl.obolibrary.org/obo/MONDO_0011162,cataract 14 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/4277,GJA3
+http://purl.obolibrary.org/obo/MONDO_0014110,cataract 15 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/7103,MIP
+http://purl.obolibrary.org/obo/MONDO_0013411,cataract 16 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2389,CRYAB
+http://purl.obolibrary.org/obo/MONDO_0012688,cataract 17 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2397,CRYBB1
+http://purl.obolibrary.org/obo/MONDO_0012395,cataract 18,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/14673,FYCO1
+http://purl.obolibrary.org/obo/MONDO_0014111,cataract 19 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/6610,LIM2
+http://purl.obolibrary.org/obo/MONDO_0007284,cataract 20 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/2417,CRYGS
+http://purl.obolibrary.org/obo/MONDO_0012437,cataract 21 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/6776,MAF
+http://purl.obolibrary.org/obo/MONDO_0012336,cataract 22 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2400,CRYBB3
+http://purl.obolibrary.org/obo/MONDO_0012489,cataract 23,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2396,CRYBA4
+http://purl.obolibrary.org/obo/MONDO_0011104,cataract 3 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/2398,CRYBB2
+http://purl.obolibrary.org/obo/MONDO_0011547,cataract 31 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/16171,CHMP4B
+http://purl.obolibrary.org/obo/MONDO_0012665,cataract 33,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/1040,BFSP1
+http://purl.obolibrary.org/obo/MONDO_0013067,cataract 34 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/3808,FOXE3
+http://purl.obolibrary.org/obo/MONDO_0013484,cataract 36,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/30831,TDRD7
+http://purl.obolibrary.org/obo/MONDO_0013859,cataract 38,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/21869,AGK
+http://purl.obolibrary.org/obo/MONDO_0014075,cataract 39 multiple types,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2409,CRYGB
+http://purl.obolibrary.org/obo/MONDO_0007281,cataract 4 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/2411,CRYGD
+http://purl.obolibrary.org/obo/MONDO_0010544,cataract 40,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/7820,NHS
+http://purl.obolibrary.org/obo/MONDO_0007287,cataract 41,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/12762,WFS1
+http://purl.obolibrary.org/obo/MONDO_0007283,cataract 42,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/2395,CRYBA2
+http://purl.obolibrary.org/obo/MONDO_0014565,cataract 43,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/14304,UNC45B
+http://purl.obolibrary.org/obo/MONDO_0014673,cataract 44,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/6708,LSS
+http://purl.obolibrary.org/obo/MONDO_0014799,cataract 45,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/23801,SIPA1L3
+http://purl.obolibrary.org/obo/MONDO_0008925,cataract 46 juvenile-onset,http://purl.obolibrary.org/obo/MONDO_0011060,early-onset non-syndromic cataract,http://identifiers.org/hgnc/21244,LEMD2
+http://purl.obolibrary.org/obo/MONDO_0007290,cataract 5 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/5227,HSF4
+http://purl.obolibrary.org/obo/MONDO_0007288,cataract 6 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/3386,EPHA2
+http://purl.obolibrary.org/obo/MONDO_0011413,cataract 9 multiple types,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://identifiers.org/hgnc/2388,CRYAA
+http://purl.obolibrary.org/obo/MONDO_0012762,catecholaminergic polymorphic ventricular tachycardia 2,http://purl.obolibrary.org/obo/MONDO_0017990,catecholaminergic polymorphic ventricular tachycardia,http://identifiers.org/hgnc/1513,CASQ2
+http://purl.obolibrary.org/obo/MONDO_0013529,catecholaminergic polymorphic ventricular tachycardia 3,http://purl.obolibrary.org/obo/MONDO_0017990,catecholaminergic polymorphic ventricular tachycardia,http://identifiers.org/hgnc/27365,TECRL
+http://purl.obolibrary.org/obo/MONDO_0013966,catecholaminergic polymorphic ventricular tachycardia 4,http://purl.obolibrary.org/obo/MONDO_0017990,catecholaminergic polymorphic ventricular tachycardia,http://identifiers.org/hgnc/1442,CALM1
+http://purl.obolibrary.org/obo/MONDO_0014191,catecholaminergic polymorphic ventricular tachycardia 5,http://purl.obolibrary.org/obo/MONDO_0017990,catecholaminergic polymorphic ventricular tachycardia,http://identifiers.org/hgnc/12261,TRDN
+http://purl.obolibrary.org/obo/MONDO_0012341,"celiac disease, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0005130,celiac disease,http://identifiers.org/hgnc/2505,CTLA4
+http://purl.obolibrary.org/obo/MONDO_0012339,"celiac disease, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0005130,celiac disease,http://identifiers.org/hgnc/7609,MYO9B
+http://purl.obolibrary.org/obo/MONDO_0024542,"cerebellar ataxia, mental retardation, and dysequilibrium syndrome 1",http://purl.obolibrary.org/obo/MONDO_0009133,dysequilibrium syndrome,http://identifiers.org/hgnc/12698,VLDLR
+http://purl.obolibrary.org/obo/MONDO_0012430,"cerebellar ataxia, mental retardation, and dysequilibrium syndrome 2",http://purl.obolibrary.org/obo/MONDO_0009133,dysequilibrium syndrome,http://identifiers.org/hgnc/26600,WDR81
+http://purl.obolibrary.org/obo/MONDO_0013188,"cerebellar ataxia, mental retardation, and dysequilibrium syndrome 3",http://purl.obolibrary.org/obo/MONDO_0009133,dysequilibrium syndrome,http://identifiers.org/hgnc/1382,CA8
+http://purl.obolibrary.org/obo/MONDO_0014104,"cerebellar ataxia, mental retardation, and dysequilibrium syndrome 4",http://purl.obolibrary.org/obo/MONDO_0009133,dysequilibrium syndrome,http://identifiers.org/hgnc/13533,ATP8A2
+http://purl.obolibrary.org/obo/MONDO_0014768,"cerebral arteriopathy, autosomal dominant, with subcortical infarcts and leukoencephalopathy, type 2",http://purl.obolibrary.org/obo/MONDO_0007432,CADASIL,http://identifiers.org/hgnc/9476,HTRA1
+http://purl.obolibrary.org/obo/MONDO_0011304,cerebral cavernous malformation 2,http://purl.obolibrary.org/obo/MONDO_0007291,familial cerebral cavernous malformation,http://identifiers.org/hgnc/21708,CCM2
+http://purl.obolibrary.org/obo/MONDO_0011305,cerebral cavernous malformation 3,http://purl.obolibrary.org/obo/MONDO_0007291,familial cerebral cavernous malformation,http://identifiers.org/hgnc/8761,PDCD10
+http://purl.obolibrary.org/obo/MONDO_0011329,"cerebral palsy, spastic quadriplegic, 1",http://purl.obolibrary.org/obo/MONDO_0016215,spastic quadriplegia,http://identifiers.org/hgnc/4092,GAD1
+http://purl.obolibrary.org/obo/MONDO_0013033,"cerebral palsy, spastic quadriplegic, 2",http://purl.obolibrary.org/obo/MONDO_0016215,spastic quadriplegia,http://identifiers.org/hgnc/19309,KANK1
+http://purl.obolibrary.org/obo/MONDO_0014862,"cerebral palsy, spastic quadriplegic, 3; CPSQ3",http://purl.obolibrary.org/obo/MONDO_0016215,spastic quadriplegia,http://identifiers.org/hgnc/245,ADD3
+http://purl.obolibrary.org/obo/MONDO_0008955,cerebrooculofacioskeletal syndrome 1,http://purl.obolibrary.org/obo/MONDO_0008926,COFS syndrome,http://identifiers.org/hgnc/3438,ERCC6
+http://purl.obolibrary.org/obo/MONDO_0012553,cerebrooculofacioskeletal syndrome 2,http://purl.obolibrary.org/obo/MONDO_0008926,COFS syndrome,http://identifiers.org/hgnc/3434,ERCC2
+http://purl.obolibrary.org/obo/MONDO_0012554,cerebrooculofacioskeletal syndrome 4,http://purl.obolibrary.org/obo/MONDO_0008926,COFS syndrome,http://identifiers.org/hgnc/3433,ERCC1
+http://purl.obolibrary.org/obo/MONDO_0024564,cerebroretinal microangiopathy with calcifications and cysts 1,http://purl.obolibrary.org/obo/MONDO_0012815,Coats plus syndrome,http://identifiers.org/hgnc/26169,CTC1
+http://purl.obolibrary.org/obo/MONDO_0015026,cerebroretinal microangiopathy with calcifications and cysts 2;,http://purl.obolibrary.org/obo/MONDO_0012815,Coats plus syndrome,http://identifiers.org/hgnc/26200,STN1
+http://purl.obolibrary.org/obo/MONDO_0012500,chilblain lupus 1,http://purl.obolibrary.org/obo/MONDO_0019557,chilblain lupus,http://identifiers.org/hgnc/12269,TREX1
+http://purl.obolibrary.org/obo/MONDO_0013739,chilblain lupus 2,http://purl.obolibrary.org/obo/MONDO_0019557,chilblain lupus,http://identifiers.org/hgnc/15925,SAMHD1
+http://purl.obolibrary.org/obo/MONDO_0014381,"cholestasis, progressive familial intrahepatic, 4",http://purl.obolibrary.org/obo/MONDO_0015762,progressive familial intrahepatic cholestasis,http://identifiers.org/hgnc/11828,TJP2
+http://purl.obolibrary.org/obo/MONDO_0014884,"cholestasis, progressive familial intrahepatic, 5; PFIC5",http://purl.obolibrary.org/obo/MONDO_0015762,progressive familial intrahepatic cholestasis,http://identifiers.org/hgnc/7967,NR1H4
+http://purl.obolibrary.org/obo/MONDO_0013137,"choroidal dystrophy, central areolar 2",http://purl.obolibrary.org/obo/MONDO_0008982,central areolar choroidal dystrophy,http://identifiers.org/hgnc/9942,PRPH2
+http://purl.obolibrary.org/obo/MONDO_0024539,"choroidal dystrophy, central areolar, 1",http://purl.obolibrary.org/obo/MONDO_0008982,central areolar choroidal dystrophy,http://identifiers.org/hgnc/4689,GUCY2D
+http://purl.obolibrary.org/obo/MONDO_0010517,"ciliary dyskinesia, primary, 36, X-linked; CILD36",http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/28570,PIH1D3
+http://purl.obolibrary.org/obo/MONDO_0011829,"coenzyme Q10 deficiency, primary, 1",http://purl.obolibrary.org/obo/MONDO_0018151,coenzyme Q10 deficiency,http://identifiers.org/hgnc/25223,COQ2
+http://purl.obolibrary.org/obo/MONDO_0013838,"coenzyme Q10 deficiency, primary, 3",http://purl.obolibrary.org/obo/MONDO_0018151,coenzyme Q10 deficiency,http://identifiers.org/hgnc/23041,PDSS2
+http://purl.obolibrary.org/obo/MONDO_0012467,cold-induced sweating syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015526,cold-induced sweating syndrome,http://identifiers.org/hgnc/17412,CLCF1
+http://purl.obolibrary.org/obo/MONDO_0014890,cold-induced sweating syndrome 3,http://purl.obolibrary.org/obo/MONDO_0015526,cold-induced sweating syndrome,http://identifiers.org/hgnc/15646,KLHL7
+http://purl.obolibrary.org/obo/MONDO_0022800,collagenopathy type 2 alpha 1,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://identifiers.org/hgnc/2200,COL2A1
+http://purl.obolibrary.org/obo/MONDO_0013699,"colorectal cancer, hereditary nonpolyposis, type 4",http://purl.obolibrary.org/obo/MONDO_0018630,hereditary nonpolyposis colon cancer,http://identifiers.org/hgnc/9122,PMS2
+http://purl.obolibrary.org/obo/MONDO_0013710,"colorectal cancer, hereditary nonpolyposis, type 5",http://purl.obolibrary.org/obo/MONDO_0018630,hereditary nonpolyposis colon cancer,http://identifiers.org/hgnc/7329,MSH6
+http://purl.obolibrary.org/obo/MONDO_0013695,"colorectal cancer, hereditary nonpolyposis, type 6",http://purl.obolibrary.org/obo/MONDO_0018630,hereditary nonpolyposis colon cancer,http://identifiers.org/hgnc/11773,TGFBR2
+http://purl.obolibrary.org/obo/MONDO_0013725,"colorectal cancer, hereditary nonpolyposis, type 7",http://purl.obolibrary.org/obo/MONDO_0018630,hereditary nonpolyposis colon cancer,http://identifiers.org/hgnc/7128,MLH3
+http://purl.obolibrary.org/obo/MONDO_0013196,"colorectal cancer, hereditary nonpolyposis, type 8",http://purl.obolibrary.org/obo/MONDO_0018630,hereditary nonpolyposis colon cancer,http://identifiers.org/hgnc/11529,EPCAM
+http://purl.obolibrary.org/obo/MONDO_0012132,"colorectal cancer, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0005575,colorectal cancer,http://identifiers.org/hgnc/19877,GALNT12
+http://purl.obolibrary.org/obo/MONDO_0012953,"colorectal cancer, susceptibility to, 10",http://purl.obolibrary.org/obo/MONDO_0005575,colorectal cancer,http://identifiers.org/hgnc/9175,POLD1
+http://purl.obolibrary.org/obo/MONDO_0014038,"colorectal cancer, susceptibility to, 12",http://purl.obolibrary.org/obo/MONDO_0005575,colorectal cancer,http://identifiers.org/hgnc/9177,POLE
+http://purl.obolibrary.org/obo/MONDO_0012820,"colorectal cancer, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0005575,colorectal cancer,http://identifiers.org/hgnc/6773,SMAD7
+http://purl.obolibrary.org/obo/MONDO_0013969,combined oxidative phosphorylation defect type 11,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/21176,RMND1
+http://purl.obolibrary.org/obo/MONDO_0013977,combined oxidative phosphorylation defect type 13,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/23166,PNPT1
+http://purl.obolibrary.org/obo/MONDO_0013986,combined oxidative phosphorylation defect type 14,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/21062,FARS2
+http://purl.obolibrary.org/obo/MONDO_0013987,combined oxidative phosphorylation defect type 15,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/29666,MTFMT
+http://purl.obolibrary.org/obo/MONDO_0014190,combined oxidative phosphorylation defect type 17,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/14198,ELAC2
+http://purl.obolibrary.org/obo/MONDO_0012510,combined oxidative phosphorylation defect type 2,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/14048,MRPS16
+http://purl.obolibrary.org/obo/MONDO_0014397,combined oxidative phosphorylation defect type 20,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/21642,VARS2
+http://purl.obolibrary.org/obo/MONDO_0014398,combined oxidative phosphorylation defect type 21,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/30740,TARS2
+http://purl.obolibrary.org/obo/MONDO_0014525,combined oxidative phosphorylation defect type 23,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/14880,GTPBP3
+http://purl.obolibrary.org/obo/MONDO_0014547,combined oxidative phosphorylation defect type 24,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/26274,NARS2
+http://purl.obolibrary.org/obo/MONDO_0014636,combined oxidative phosphorylation defect type 25,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/25133,MARS2
+http://purl.obolibrary.org/obo/MONDO_0014684,combined oxidative phosphorylation defect type 26,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/23141,TRMT5
+http://purl.obolibrary.org/obo/MONDO_0014728,combined oxidative phosphorylation defect type 27,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/25695,CARS2
+http://purl.obolibrary.org/obo/MONDO_0014856,combined oxidative phosphorylation defect type 30,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/26022,TRMT10C
+http://purl.obolibrary.org/obo/MONDO_0012534,combined oxidative phosphorylation defect type 4,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/12420,TUFM
+http://purl.obolibrary.org/obo/MONDO_0013306,combined oxidative phosphorylation defect type 7,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/26784,C12orf65
+http://purl.obolibrary.org/obo/MONDO_0013570,combined oxidative phosphorylation defect type 8,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/21022,AARS2
+http://purl.obolibrary.org/obo/MONDO_0013811,combined oxidative phosphorylation defect type 9,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/10379,MRPL3
+http://purl.obolibrary.org/obo/MONDO_0014269,combined oxidative phosphorylation deficiency 19,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/21365,LYRM4
+http://purl.obolibrary.org/obo/MONDO_0014781,combined oxidative phosphorylation deficiency 29; COXPD29,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/17772,TXN2
+http://purl.obolibrary.org/obo/MONDO_0009006,complement component 2 deficiency,http://purl.obolibrary.org/obo/MONDO_0003832,complement deficiency,http://identifiers.org/hgnc/1248,C2
+http://purl.obolibrary.org/obo/MONDO_0013417,complement component 3 deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1318,C3
+http://purl.obolibrary.org/obo/MONDO_0013721,complement component 4a deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1323,C4A
+http://purl.obolibrary.org/obo/MONDO_0013720,complement component 4b deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1324,C4B
+http://purl.obolibrary.org/obo/MONDO_0012295,complement component 5 deficiency,http://purl.obolibrary.org/obo/MONDO_0003832,complement deficiency,http://identifiers.org/hgnc/1331,C5
+http://purl.obolibrary.org/obo/MONDO_0012908,complement component 6 deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1339,C6
+http://purl.obolibrary.org/obo/MONDO_0012412,complement component 7 deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1346,C7
+http://purl.obolibrary.org/obo/MONDO_0013445,complement component 9 deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1358,C9
+http://purl.obolibrary.org/obo/MONDO_0013541,complex cortical dysplasia with other brain malformations 1,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/20772,TUBB3
+http://purl.obolibrary.org/obo/MONDO_0014116,complex cortical dysplasia with other brain malformations 2,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/6325,KIF5C
+http://purl.obolibrary.org/obo/MONDO_0014170,complex cortical dysplasia with other brain malformations 3,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/6318,KIF2A
+http://purl.obolibrary.org/obo/MONDO_0014171,complex cortical dysplasia with other brain malformations 4,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/12417,TUBG1
+http://purl.obolibrary.org/obo/MONDO_0014337,complex cortical dysplasia with other brain malformations 5,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/12412,TUBB2A
+http://purl.obolibrary.org/obo/MONDO_0014341,complex cortical dysplasia with other brain malformations 6,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/20778,TUBB
+http://purl.obolibrary.org/obo/MONDO_0012399,complex cortical dysplasia with other brain malformations 7,http://purl.obolibrary.org/obo/MONDO_0000904,complex cortical dysplasia with other brain malformations,http://identifiers.org/hgnc/30829,TUBB2B
+http://purl.obolibrary.org/obo/MONDO_0011193,cone dystrophy 3,http://purl.obolibrary.org/obo/MONDO_0000455,cone dystrophy,http://identifiers.org/hgnc/4678,GUCA1A
+http://purl.obolibrary.org/obo/MONDO_0013129,cone dystrophy 4,http://purl.obolibrary.org/obo/MONDO_0000455,cone dystrophy,http://identifiers.org/hgnc/8787,PDE6C
+http://purl.obolibrary.org/obo/MONDO_0012464,cone-rod dystrophy 10,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/10729,SEMA4A
+http://purl.obolibrary.org/obo/MONDO_0012483,cone-rod dystrophy 11,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/18286,RAX2
+http://purl.obolibrary.org/obo/MONDO_0012983,cone-rod dystrophy 12,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/9454,PROM1
+http://purl.obolibrary.org/obo/MONDO_0011987,cone-rod dystrophy 13,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/13436,RPGRIP1
+http://purl.obolibrary.org/obo/MONDO_0013348,cone-rod dystrophy 15,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/14550,CDHR1
+http://purl.obolibrary.org/obo/MONDO_0013786,cone-rod dystrophy 16,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/27232,C8orf37
+http://purl.obolibrary.org/obo/MONDO_0014153,cone-rod dystrophy 18,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/9768,RAB28
+http://purl.obolibrary.org/obo/MONDO_0014372,cone-rod dystrophy 19,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/19963,TTLL5
+http://purl.obolibrary.org/obo/MONDO_0007362,cone-rod dystrophy 2,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/2383,CRX
+http://purl.obolibrary.org/obo/MONDO_0014427,cone-rod dystrophy 20,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/30836,POC1B
+http://purl.obolibrary.org/obo/MONDO_0014669,cone-rod dystrophy 21,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/28769,DRAM2
+http://purl.obolibrary.org/obo/MONDO_0011395,cone-rod dystrophy 3,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/34,ABCA4
+http://purl.obolibrary.org/obo/MONDO_0010969,cone-rod dystrophy 5,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/21043,PITPNM3
+http://purl.obolibrary.org/obo/MONDO_0011143,cone-rod dystrophy 6,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/4689,GUCY2D
+http://purl.obolibrary.org/obo/MONDO_0011355,cone-rod dystrophy 7,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/17282,RIMS1
+http://purl.obolibrary.org/obo/MONDO_0013002,cone-rod dystrophy 9,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy,http://identifiers.org/hgnc/216,ADAM9
+http://purl.obolibrary.org/obo/MONDO_0012561,"congenital anomalies of kidney and urinary tract 1, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0019719,congenital anomaly of kidney and urinary tract,http://identifiers.org/hgnc/29043,DSTYK
+http://purl.obolibrary.org/obo/MONDO_0027676,congenital anomalies of kidney and urinary tract type 2,http://purl.obolibrary.org/obo/MONDO_0019719,congenital anomaly of kidney and urinary tract,http://identifiers.org/hgnc/11595,TBX18
+http://purl.obolibrary.org/obo/MONDO_0011906,congenital bile acid synthesis defect 1,http://purl.obolibrary.org/obo/MONDO_0018841,congenital bile acid synthesis defect,http://identifiers.org/hgnc/18324,HSD3B7
+http://purl.obolibrary.org/obo/MONDO_0009339,congenital bile acid synthesis defect 2,http://purl.obolibrary.org/obo/MONDO_0018841,congenital bile acid synthesis defect,http://identifiers.org/hgnc/388,AKR1D1
+http://purl.obolibrary.org/obo/MONDO_0013439,congenital bile acid synthesis defect 3,http://purl.obolibrary.org/obo/MONDO_0018841,congenital bile acid synthesis defect,http://identifiers.org/hgnc/2652,CYP7B1
+http://purl.obolibrary.org/obo/MONDO_0014564,congenital bile acid synthesis defect 5,http://purl.obolibrary.org/obo/MONDO_0018841,congenital bile acid synthesis defect,http://identifiers.org/hgnc/67,ABCD3
+http://purl.obolibrary.org/obo/MONDO_0015015,congenital bile acid synthesis defect 6,http://purl.obolibrary.org/obo/MONDO_0018841,congenital bile acid synthesis defect,http://identifiers.org/hgnc/120,ACOX2
+http://purl.obolibrary.org/obo/MONDO_0013184,congenital diarrhea 5 with tufting enteropathy,http://purl.obolibrary.org/obo/MONDO_0000249,secretory diarrhea,http://identifiers.org/hgnc/11529,EPCAM
+http://purl.obolibrary.org/obo/MONDO_0013825,congenital diarrhea 6,http://purl.obolibrary.org/obo/MONDO_0000824,congenital diarrhea,http://identifiers.org/hgnc/4688,GUCY2C
+http://purl.obolibrary.org/obo/MONDO_0014375,congenital diarrhea 7 with exudative enteropathy,http://purl.obolibrary.org/obo/MONDO_0000824,congenital diarrhea,http://identifiers.org/hgnc/2843,DGAT1
+http://purl.obolibrary.org/obo/MONDO_0011291,congenital disorder of glycosylation type 1C,http://purl.obolibrary.org/obo/MONDO_0015286,congenital disorder of glycosylation,http://identifiers.org/hgnc/23157,ALG6
+http://purl.obolibrary.org/obo/MONDO_0012123,congenital disorder of glycosylation type 1E,http://purl.obolibrary.org/obo/MONDO_0015286,congenital disorder of glycosylation,http://identifiers.org/hgnc/3005,DPM1
+http://purl.obolibrary.org/obo/MONDO_0021083,congenital fibrosis of extraocular muscles type 1,http://purl.obolibrary.org/obo/MONDO_0007614,congenital fibrosis of extraocular muscles,http://identifiers.org/hgnc/19349,KIF21A
+http://purl.obolibrary.org/obo/MONDO_0012071,congenital generalized lipodystrophy type 1,http://purl.obolibrary.org/obo/MONDO_0006536,congenital generalized lipodystrophy (disease),http://identifiers.org/hgnc/325,AGPAT2
+http://purl.obolibrary.org/obo/MONDO_0010020,congenital generalized lipodystrophy type 2,http://purl.obolibrary.org/obo/MONDO_0006536,congenital generalized lipodystrophy (disease),http://identifiers.org/hgnc/15832,BSCL2
+http://purl.obolibrary.org/obo/MONDO_0012923,congenital generalized lipodystrophy type 3,http://purl.obolibrary.org/obo/MONDO_0006536,congenital generalized lipodystrophy (disease),http://identifiers.org/hgnc/1527,CAV1
+http://purl.obolibrary.org/obo/MONDO_0013225,congenital generalized lipodystrophy type 4,http://purl.obolibrary.org/obo/MONDO_0006536,congenital generalized lipodystrophy (disease),http://identifiers.org/hgnc/9688,CAVIN1
+http://purl.obolibrary.org/obo/MONDO_0014000,"congenital heart defects, multiple types, 2",http://purl.obolibrary.org/obo/MONDO_0019512,congenital heart malformation,http://identifiers.org/hgnc/17075,TAB2
+http://purl.obolibrary.org/obo/MONDO_0014344,"congenital heart defects, multiple types, 4",http://purl.obolibrary.org/obo/MONDO_0000119,"congenital heart defects, multiple types",http://identifiers.org/hgnc/7976,NR2F2
+http://purl.obolibrary.org/obo/MONDO_0012479,congenital malabsorptive diarrhea 4,http://purl.obolibrary.org/obo/MONDO_0000824,congenital diarrhea,http://identifiers.org/hgnc/13806,NEUROG3
+http://purl.obolibrary.org/obo/MONDO_0011925,congenital merosin-deficient muscular dystrophy 1A,http://purl.obolibrary.org/obo/MONDO_0019950,congenital muscular dystrophy,http://identifiers.org/hgnc/6482,LAMA2
+http://purl.obolibrary.org/obo/MONDO_0013178,congenital muscular dystrophy due to LMNA mutation,http://purl.obolibrary.org/obo/MONDO_0019950,congenital muscular dystrophy,http://identifiers.org/hgnc/6636,LMNA
+http://purl.obolibrary.org/obo/MONDO_0013177,congenital muscular dystrophy due to integrin alpha-7 deficiency,http://purl.obolibrary.org/obo/MONDO_0019950,congenital muscular dystrophy,http://identifiers.org/hgnc/6143,ITGA7
+http://purl.obolibrary.org/obo/MONDO_0009690,congenital myasthenic syndrome 10,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/26594,DOK7
+http://purl.obolibrary.org/obo/MONDO_0014588,congenital myasthenic syndrome 11,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/9863,RAPSN
+http://purl.obolibrary.org/obo/MONDO_0012518,congenital myasthenic syndrome 12,http://purl.obolibrary.org/obo/MONDO_0018144,congenital myasthenic syndromes with glycosylation defect,http://identifiers.org/hgnc/4241,GFPT1
+http://purl.obolibrary.org/obo/MONDO_0013883,congenital myasthenic syndrome 13,http://purl.obolibrary.org/obo/MONDO_0018144,congenital myasthenic syndromes with glycosylation defect,http://identifiers.org/hgnc/2995,DPAGT1
+http://purl.obolibrary.org/obo/MONDO_0014543,congenital myasthenic syndrome 14,http://purl.obolibrary.org/obo/MONDO_0018144,congenital myasthenic syndromes with glycosylation defect,http://identifiers.org/hgnc/23159,ALG2
+http://purl.obolibrary.org/obo/MONDO_0014542,congenital myasthenic syndrome 15,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/28287,ALG14
+http://purl.obolibrary.org/obo/MONDO_0013620,congenital myasthenic syndrome 16,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/10591,SCN4A
+http://purl.obolibrary.org/obo/MONDO_0014578,congenital myasthenic syndrome 17,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/6696,LRP4
+http://purl.obolibrary.org/obo/MONDO_0014590,congenital myasthenic syndrome 18,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/11132,SNAP25
+http://purl.obolibrary.org/obo/MONDO_0014745,congenital myasthenic syndrome 19,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/2190,COL13A1
+http://purl.obolibrary.org/obo/MONDO_0011088,congenital myasthenic syndrome 1A,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/1955,CHRNA1
+http://purl.obolibrary.org/obo/MONDO_0014939,congenital myasthenic syndrome 20,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/14025,SLC5A7
+http://purl.obolibrary.org/obo/MONDO_0014983,congenital myasthenic syndrome 21,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/10936,SLC18A3
+http://purl.obolibrary.org/obo/MONDO_0011281,congenital myasthenic syndrome 5,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/2226,COLQ
+http://purl.obolibrary.org/obo/MONDO_0009689,congenital myasthenic syndrome 6,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/1912,CHAT
+http://purl.obolibrary.org/obo/MONDO_0014468,congenital myasthenic syndrome 7,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/11510,SYT2
+http://purl.obolibrary.org/obo/MONDO_0014052,congenital myasthenic syndrome 8,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/329,AGRN
+http://purl.obolibrary.org/obo/MONDO_0014587,congenital myasthenic syndrome 9,http://purl.obolibrary.org/obo/MONDO_0018940,congenital myasthenic syndrome,http://identifiers.org/hgnc/7525,MUSK
+http://purl.obolibrary.org/obo/MONDO_0013757,congenital nongoitrous hypothryoidism 6,http://purl.obolibrary.org/obo/MONDO_0000045,"hypothyroidism, congenital, nongoitrous",http://identifiers.org/hgnc/11796,THRA
+http://purl.obolibrary.org/obo/MONDO_0008964,congenital secretory chloride diarrhea 1,http://purl.obolibrary.org/obo/MONDO_0000249,secretory diarrhea,http://identifiers.org/hgnc/3018,SLC26A3
+http://purl.obolibrary.org/obo/MONDO_0010036,congenital secretory sodium diarrhea 3,http://purl.obolibrary.org/obo/MONDO_0000249,secretory diarrhea,http://identifiers.org/hgnc/11247,SPINT2
+http://purl.obolibrary.org/obo/MONDO_0014808,congenital secretory sodium diarrhea 8,http://purl.obolibrary.org/obo/MONDO_0000249,secretory diarrhea,http://identifiers.org/hgnc/11073,SLC9A3
+http://purl.obolibrary.org/obo/MONDO_0010690,congenital stationary night blindness 1A,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/8082,NYX
+http://purl.obolibrary.org/obo/MONDO_0009758,congenital stationary night blindness 1B,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/4598,GRM6
+http://purl.obolibrary.org/obo/MONDO_0013183,congenital stationary night blindness 1C,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/7146,TRPM1
+http://purl.obolibrary.org/obo/MONDO_0013450,congenital stationary night blindness 1D,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/10975,SLC24A1
+http://purl.obolibrary.org/obo/MONDO_0013807,congenital stationary night blindness 1E,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/31371,GPR179
+http://purl.obolibrary.org/obo/MONDO_0014026,congenital stationary night blindness 1F,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/24783,LRIT3
+http://purl.obolibrary.org/obo/MONDO_0014872,congenital stationary night blindness 1H,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/4400,GNB3
+http://purl.obolibrary.org/obo/MONDO_0010241,congenital stationary night blindness 2A,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/1393,CACNA1F
+http://purl.obolibrary.org/obo/MONDO_0012498,congenital stationary night blindness autosomal dominant 1,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/10012,RHO
+http://purl.obolibrary.org/obo/MONDO_0008099,congenital stationary night blindness autosomal dominant 2,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness,http://identifiers.org/hgnc/8786,PDE6B
+http://purl.obolibrary.org/obo/MONDO_0009014,cornea plana 2,http://purl.obolibrary.org/obo/MONDO_0000733,cornea plana,http://identifiers.org/hgnc/6309,KERA
+http://purl.obolibrary.org/obo/MONDO_0007637,"corneal dystrophy, Fuchs endothelial, 1",http://purl.obolibrary.org/obo/MONDO_0005321,Fuchs' endothelial dystrophy,http://identifiers.org/hgnc/2216,COL8A2
+http://purl.obolibrary.org/obo/MONDO_0013203,"corneal dystrophy, Fuchs endothelial, 3",http://purl.obolibrary.org/obo/MONDO_0005321,Fuchs' endothelial dystrophy,http://identifiers.org/hgnc/11634,TCF4
+http://purl.obolibrary.org/obo/MONDO_0013204,"corneal dystrophy, Fuchs endothelial, 4",http://purl.obolibrary.org/obo/MONDO_0005321,Fuchs' endothelial dystrophy,http://identifiers.org/hgnc/16438,SLC4A11
+http://purl.obolibrary.org/obo/MONDO_0013206,"corneal dystrophy, Fuchs endothelial, 6",http://purl.obolibrary.org/obo/MONDO_0005321,Fuchs' endothelial dystrophy,http://identifiers.org/hgnc/11642,ZEB1
+http://purl.obolibrary.org/obo/MONDO_0014228,"corneal dystrophy, Fuchs endothelial, 8",http://purl.obolibrary.org/obo/MONDO_0005321,Fuchs' endothelial dystrophy,http://identifiers.org/hgnc/26504,AGBL1
+http://purl.obolibrary.org/obo/MONDO_0012586,"coronary artery disease, autosomal dominant 2",http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://identifiers.org/hgnc/6698,LRP6
+http://purl.obolibrary.org/obo/MONDO_0012011,"coronary artery disease, autosomal dominant, 1",http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://identifiers.org/hgnc/6993,MEF2A
+http://purl.obolibrary.org/obo/MONDO_0011817,"coronary heart disease, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://identifiers.org/hgnc/2558,CX3CR1
+http://purl.obolibrary.org/obo/MONDO_0012147,"coronary heart disease, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://identifiers.org/hgnc/4814,KALRN
+http://purl.obolibrary.org/obo/MONDO_0013765,"coronary heart disease, susceptibility to, 6",http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://identifiers.org/hgnc/7173,MMP3
+http://purl.obolibrary.org/obo/MONDO_0012585,"coronary heart disease, susceptibility to, 7",http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://identifiers.org/hgnc/1663,CD36
+http://purl.obolibrary.org/obo/MONDO_0011503,cortisone reductase deficiency 1,http://purl.obolibrary.org/obo/MONDO_0000193,cortisone reductase deficiency,http://identifiers.org/hgnc/4795,H6PD
+http://purl.obolibrary.org/obo/MONDO_0013842,cortisone reductase deficiency 2,http://purl.obolibrary.org/obo/MONDO_0000193,cortisone reductase deficiency,http://identifiers.org/hgnc/5208,HSD11B1
+http://purl.obolibrary.org/obo/MONDO_0021093,cranioectodermal dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0009032,cranioectodermal dysplasia,http://identifiers.org/hgnc/13556,IFT122
+http://purl.obolibrary.org/obo/MONDO_0013323,cranioectodermal dysplasia 2,http://purl.obolibrary.org/obo/MONDO_0009032,cranioectodermal dysplasia,http://identifiers.org/hgnc/29250,WDR35
+http://purl.obolibrary.org/obo/MONDO_0013573,cranioectodermal dysplasia 3,http://purl.obolibrary.org/obo/MONDO_0009032,cranioectodermal dysplasia,http://identifiers.org/hgnc/29669,IFT43
+http://purl.obolibrary.org/obo/MONDO_0013719,cranioectodermal dysplasia 4,http://purl.obolibrary.org/obo/MONDO_0009035,"craniometaphyseal dysplasia, autosomal recessive",http://identifiers.org/hgnc/18340,WDR19
+http://purl.obolibrary.org/obo/MONDO_0014128,craniosynostosis 3,http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis,http://identifiers.org/hgnc/11623,TCF12
+http://purl.obolibrary.org/obo/MONDO_0010929,craniosynostosis 4,http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis,http://identifiers.org/hgnc/3444,ERF
+http://purl.obolibrary.org/obo/MONDO_0014232,"craniosynostosis 5, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis,http://identifiers.org/hgnc/450,ALX4
+http://purl.obolibrary.org/obo/MONDO_0014705,craniosynostosis 6,http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis,http://identifiers.org/hgnc/12872,ZIC1
+http://purl.obolibrary.org/obo/MONDO_0007411,"cutis laxa, autosomal dominant 1",http://purl.obolibrary.org/obo/MONDO_0019571,autosomal dominant cutis laxa,http://identifiers.org/hgnc/3327,ELN
+http://purl.obolibrary.org/obo/MONDO_0013751,"cutis laxa, autosomal dominant 2",http://purl.obolibrary.org/obo/MONDO_0019571,autosomal dominant cutis laxa,http://identifiers.org/hgnc/3602,FBLN5
+http://purl.obolibrary.org/obo/MONDO_0013345,d-2-hydroxyglutaric aciduria 2,http://purl.obolibrary.org/obo/MONDO_0010924,D-2-hydroxyglutaric aciduria,http://identifiers.org/hgnc/5383,IDH2
+http://purl.obolibrary.org/obo/MONDO_0010238,"deafness, X-linked 4",http://purl.obolibrary.org/obo/MONDO_0019586,X-linked nonsyndromic deafness,http://identifiers.org/hgnc/11122,SMPX
+http://purl.obolibrary.org/obo/MONDO_0010484,"deafness, X-linked 6",http://purl.obolibrary.org/obo/MONDO_0019586,X-linked nonsyndromic deafness,http://identifiers.org/hgnc/2208,COL4A6
+http://purl.obolibrary.org/obo/MONDO_0014737,dehydrated hereditary stomatocytosis 2; DHS2,http://purl.obolibrary.org/obo/MONDO_0017910,dehydrated hereditary stomatocytosis,http://identifiers.org/hgnc/6293,KCNN4
+http://purl.obolibrary.org/obo/MONDO_0012128,dextro-looped transposition of the great arteries 1,http://purl.obolibrary.org/obo/MONDO_0019443,dextro-looped transposition of the great arteries,http://identifiers.org/hgnc/22962,MED13L
+http://purl.obolibrary.org/obo/MONDO_0013463,dextro-looped transposition of the great arteries 3,http://purl.obolibrary.org/obo/MONDO_0019443,dextro-looped transposition of the great arteries,http://identifiers.org/hgnc/4214,GDF1
+http://purl.obolibrary.org/obo/MONDO_0014488,"diabetes mellitus, noninsulin-dependent, 5",http://purl.obolibrary.org/obo/MONDO_0005148,type 2 diabetes mellitus,http://identifiers.org/hgnc/19165,TBC1D4
+http://purl.obolibrary.org/obo/MONDO_0012480,"diabetes mellitus, transient neonatal, 2",http://purl.obolibrary.org/obo/MONDO_0020525,transient neonatal diabetes mellitus (disease),http://identifiers.org/hgnc/59,ABCC8
+http://purl.obolibrary.org/obo/MONDO_0012522,"diabetes mellitus, transient neonatal, 3",http://purl.obolibrary.org/obo/MONDO_0020525,transient neonatal diabetes mellitus (disease),http://identifiers.org/hgnc/6257,KCNJ11
+http://purl.obolibrary.org/obo/MONDO_0012431,diaphragmatic hernia 3,http://purl.obolibrary.org/obo/MONDO_0005711,congenital diaphragmatic hernia,http://identifiers.org/hgnc/16700,ZFPM2
+http://purl.obolibrary.org/obo/MONDO_0007269,dilated cardiomyopathy 1A,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/6636,LMNA
+http://purl.obolibrary.org/obo/MONDO_0012808,dilated cardiomyopathy 1AA,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/164,ACTN2
+http://purl.obolibrary.org/obo/MONDO_0013030,dilated cardiomyopathy 1BB,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/3049,DSG2
+http://purl.obolibrary.org/obo/MONDO_0013147,dilated cardiomyopathy 1CC,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/29557,NEXN
+http://purl.obolibrary.org/obo/MONDO_0011095,dilated cardiomyopathy 1D,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/11949,TNNT2
+http://purl.obolibrary.org/obo/MONDO_0013168,dilated cardiomyopathy 1DD,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/27424,RBM20
+http://purl.obolibrary.org/obo/MONDO_0011003,dilated cardiomyopathy 1E,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/10593,SCN5A
+http://purl.obolibrary.org/obo/MONDO_0013198,dilated cardiomyopathy 1EE,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/7576,MYH6
+http://purl.obolibrary.org/obo/MONDO_0011400,dilated cardiomyopathy 1G,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/12403,TTN
+http://purl.obolibrary.org/obo/MONDO_0013339,dilated cardiomyopathy 1GG,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/10680,SDHA
+http://purl.obolibrary.org/obo/MONDO_0013479,dilated cardiomyopathy 1HH,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/939,BAG3
+http://purl.obolibrary.org/obo/MONDO_0011482,dilated cardiomyopathy 1I,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/2770,DES
+http://purl.obolibrary.org/obo/MONDO_0014073,dilated cardiomyopathy 1II,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/2389,CRYAB
+http://purl.obolibrary.org/obo/MONDO_0011541,dilated cardiomyopathy 1J,http://purl.obolibrary.org/obo/MONDO_0016333,familial dilated cardiomyopathy,http://identifiers.org/hgnc/3522,EYA4
+http://purl.obolibrary.org/obo/MONDO_0014095,dilated cardiomyopathy 1JJ,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/6484,LAMA4
+http://purl.obolibrary.org/obo/MONDO_0014100,dilated cardiomyopathy 1KK,http://purl.obolibrary.org/obo/MONDO_0005021,dilated cardiomyopathy,http://identifiers.org/hgnc/23246,MYPN
+http://purl.obolibrary.org/obo/MONDO_0011702,dilated cardiomyopathy 1L,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/10807,SGCD
+http://purl.obolibrary.org/obo/MONDO_0011840,dilated cardiomyopathy 1M,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/2472,CSRP3
+http://purl.obolibrary.org/obo/MONDO_0014396,dilated cardiomyopathy 1NN,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/9829,RAF1
+http://purl.obolibrary.org/obo/MONDO_0012062,dilated cardiomyopathy 1O,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/60,ABCC9
+http://purl.obolibrary.org/obo/MONDO_0012362,dilated cardiomyopathy 1P,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/9080,PLN
+http://purl.obolibrary.org/obo/MONDO_0013261,dilated cardiomyopathy 1R,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/143,ACTC1
+http://purl.obolibrary.org/obo/MONDO_0013262,dilated cardiomyopathy 1S,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/7577,MYH7
+http://purl.obolibrary.org/obo/MONDO_0000911,dilated cardiomyopathy 1T,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/11875,TMPO
+http://purl.obolibrary.org/obo/MONDO_0013371,dilated cardiomyopathy 1U,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/9508,PSEN1
+http://purl.obolibrary.org/obo/MONDO_0013373,dilated cardiomyopathy 1V,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/9509,PSEN2
+http://purl.obolibrary.org/obo/MONDO_0012667,dilated cardiomyopathy 1W,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/12665,VCL
+http://purl.obolibrary.org/obo/MONDO_0012704,dilated cardiomyopathy 1X,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/3622,FKTN
+http://purl.obolibrary.org/obo/MONDO_0012744,dilated cardiomyopathy 1Y,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/12010,TPM1
+http://purl.obolibrary.org/obo/MONDO_0012745,dilated cardiomyopathy 1Z,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/11943,TNNC1
+http://purl.obolibrary.org/obo/MONDO_0013848,dilated cardiomyopathy 2B,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/29941,GATAD1
+http://purl.obolibrary.org/obo/MONDO_0010542,dilated cardiomyopathy 3B,http://purl.obolibrary.org/obo/MONDO_0005021,dilated cardiomyopathy,http://identifiers.org/hgnc/2928,DMD
+http://purl.obolibrary.org/obo/MONDO_0014028,distal arthrogryposis type 5D,http://purl.obolibrary.org/obo/MONDO_0019942,distal arthrogryposis,http://identifiers.org/hgnc/3147,ECEL1
+http://purl.obolibrary.org/obo/MONDO_0014169,dyschromatosis universalis hereditaria 3,http://purl.obolibrary.org/obo/MONDO_0000736,dyschromatosis universalis hereditaria,http://identifiers.org/hgnc/47,ABCB6
+http://purl.obolibrary.org/obo/MONDO_0014600,"dyskeratosis congenita, autosomal recessive 6",http://purl.obolibrary.org/obo/MONDO_0015780,dyskeratosis congenita,http://identifiers.org/hgnc/8609,PARN
+http://purl.obolibrary.org/obo/MONDO_0007496,dystonia 12,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/801,ATP1A3
+http://purl.obolibrary.org/obo/MONDO_0012789,dystonia 16,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/9438,PRKRA
+http://purl.obolibrary.org/obo/MONDO_0013928,dystonia 23,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/1389,CACNA1B
+http://purl.obolibrary.org/obo/MONDO_0014019,dystonia 24,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/14004,ANO3
+http://purl.obolibrary.org/obo/MONDO_0014033,dystonia 25,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/4388,GNAL
+http://purl.obolibrary.org/obo/MONDO_0014627,dystonia 27,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/2213,COL6A3
+http://purl.obolibrary.org/obo/MONDO_0015004,"dystonia 28, childhood-onset; DYT28",http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/15840,KMT2B
+http://purl.obolibrary.org/obo/MONDO_0010246,early infantile epileptic encephalopathy 9,http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/14270,PCDH19
+http://purl.obolibrary.org/obo/MONDO_0014233,early-onset Parkinson disease 20,http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/11503,SYNJ1
+http://purl.obolibrary.org/obo/MONDO_0015024,"ectodermal dysplasia 12, hypohidrotic/hair/tooth/nail type; ECTD12",http://purl.obolibrary.org/obo/MONDO_0019287,ectodermal dysplasia syndrome,http://identifiers.org/hgnc/26624,KDF1
+http://purl.obolibrary.org/obo/MONDO_0011177,"ectodermal dysplasia 4, hair/nail type",http://purl.obolibrary.org/obo/MONDO_0019071,pure hair and nail ectodermal dysplasia,http://identifiers.org/hgnc/6462,KRT85
+http://purl.obolibrary.org/obo/MONDO_0013975,"ectodermal dysplasia 7, hair/nail type",http://purl.obolibrary.org/obo/MONDO_0019071,pure hair and nail ectodermal dysplasia,http://identifiers.org/hgnc/28929,KRT74
+http://purl.obolibrary.org/obo/MONDO_0013976,"ectodermal dysplasia 9, hair/nail type",http://purl.obolibrary.org/obo/MONDO_0019071,pure hair and nail ectodermal dysplasia,http://identifiers.org/hgnc/5125,HOXC13
+http://purl.obolibrary.org/obo/MONDO_0024565,ectodermal dysplasia-syndactyly syndrome 1,http://purl.obolibrary.org/obo/MONDO_0013311,ectodermal dysplasia-syndactyly syndrome,http://identifiers.org/hgnc/19688,NECTIN4
+http://purl.obolibrary.org/obo/MONDO_0007514,"ectopia lentis 1, isolated, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0015998,isolated ectopia lentis,http://identifiers.org/hgnc/3603,FBN1
+http://purl.obolibrary.org/obo/MONDO_0011428,"ectrodactyly, ectodermal dysplasia, and cleft lip-palate syndrome 3",http://purl.obolibrary.org/obo/MONDO_0010004,EEC syndrome,http://identifiers.org/hgnc/15979,TP63
+http://purl.obolibrary.org/obo/MONDO_0012731,elliptocytosis 1,http://purl.obolibrary.org/obo/MONDO_0017319,hereditary elliptocytosis,http://identifiers.org/hgnc/3377,EPB41
+http://purl.obolibrary.org/obo/MONDO_0007533,elliptocytosis 2,http://purl.obolibrary.org/obo/MONDO_0017319,hereditary elliptocytosis,http://identifiers.org/hgnc/11272,SPTA1
+http://purl.obolibrary.org/obo/MONDO_0013633,"encephalopathy, acute, infection-induced, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0000166,"encephalopathy, acute, infection-induced",http://identifiers.org/hgnc/2330,CPT2
+http://purl.obolibrary.org/obo/MONDO_0011891,"epilepsy, childhood absence, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0010826,childhood absence epilepsy,http://identifiers.org/hgnc/4087,GABRG2
+http://purl.obolibrary.org/obo/MONDO_0012843,"epilepsy, childhood absence, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0010826,childhood absence epilepsy,http://identifiers.org/hgnc/4083,GABRB3
+http://purl.obolibrary.org/obo/MONDO_0012763,"epilepsy, childhood absence, susceptibility to, 6",http://purl.obolibrary.org/obo/MONDO_0010826,childhood absence epilepsy,http://identifiers.org/hgnc/1395,CACNA1H
+http://purl.obolibrary.org/obo/MONDO_0011930,"epilepsy, familial adult myoclonic, 2",http://purl.obolibrary.org/obo/MONDO_0000160,"epilepsy, familial adult myoclonic",http://identifiers.org/hgnc/282,ADRA2B
+http://purl.obolibrary.org/obo/MONDO_0014167,"epilepsy, familial adult myoclonic, 5",http://purl.obolibrary.org/obo/MONDO_0000160,"epilepsy, familial adult myoclonic",http://identifiers.org/hgnc/2172,CNTN2
+http://purl.obolibrary.org/obo/MONDO_0024556,"epilepsy, familial focal, with variable foci 1",http://purl.obolibrary.org/obo/MONDO_0000215,"epilepsy, familial focal, with variable foci",http://identifiers.org/hgnc/18423,DEPDC5
+http://purl.obolibrary.org/obo/MONDO_0014924,"epilepsy, familial focal, with variable foci 2; FFEVF2",http://purl.obolibrary.org/obo/MONDO_0000215,"epilepsy, familial focal, with variable foci",http://identifiers.org/hgnc/24969,NPRL2
+http://purl.obolibrary.org/obo/MONDO_0014925,"epilepsy, familial focal, with variable foci 3; FFEVF3",http://purl.obolibrary.org/obo/MONDO_0000215,"epilepsy, familial focal, with variable foci",http://identifiers.org/hgnc/14124,NPRL3
+http://purl.obolibrary.org/obo/MONDO_0013103,"epilepsy, idiopathic generalized, susceptibility to, 10",http://purl.obolibrary.org/obo/MONDO_0009696,juvenile myoclonic epilepsy,http://identifiers.org/hgnc/4084,GABRD
+http://purl.obolibrary.org/obo/MONDO_0011875,"epilepsy, idiopathic generalized, susceptibility to, 11",http://purl.obolibrary.org/obo/MONDO_0005579,generalised epilepsy,http://identifiers.org/hgnc/2020,CLCN2
+http://purl.obolibrary.org/obo/MONDO_0012627,"epilepsy, idiopathic generalized, susceptibility to, 13",http://purl.obolibrary.org/obo/MONDO_0009696,juvenile myoclonic epilepsy,http://identifiers.org/hgnc/4075,GABRA1
+http://purl.obolibrary.org/obo/MONDO_0013032,"epilepsy, idiopathic generalized, susceptibility to, 8",http://purl.obolibrary.org/obo/MONDO_0005579,generalised epilepsy,http://identifiers.org/hgnc/1514,CASR
+http://purl.obolibrary.org/obo/MONDO_0011892,"epilepsy, idiopathic generalized, susceptibility to, 9",http://purl.obolibrary.org/obo/MONDO_0005579,generalised epilepsy,http://identifiers.org/hgnc/1404,CACNB4
+http://purl.obolibrary.org/obo/MONDO_0012904,"epilepsy, progressive myoclonic, 1B",http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/17019,PRICKLE1
+http://purl.obolibrary.org/obo/MONDO_0010632,"epileptic encephalopathy, early infantile, 1",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/18060,ARX
+http://purl.obolibrary.org/obo/MONDO_0013388,"epileptic encephalopathy, early infantile, 11",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/10588,SCN2A
+http://purl.obolibrary.org/obo/MONDO_0013389,"epileptic encephalopathy, early infantile, 12",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/15917,PLCB1
+http://purl.obolibrary.org/obo/MONDO_0013801,"epileptic encephalopathy, early infantile, 13",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/10596,SCN8A
+http://purl.obolibrary.org/obo/MONDO_0013989,"epileptic encephalopathy, early infantile, 14",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/18865,KCNT1
+http://purl.obolibrary.org/obo/MONDO_0014199,"epileptic encephalopathy, early infantile, 17",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4389,GNAO1
+http://purl.obolibrary.org/obo/MONDO_0014328,"epileptic encephalopathy, early infantile, 19",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4075,GABRA1
+http://purl.obolibrary.org/obo/MONDO_0010396,"epileptic encephalopathy, early infantile, 2",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/11411,CDKL5
+http://purl.obolibrary.org/obo/MONDO_0014360,"epileptic encephalopathy, early infantile, 21",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/24539,NECAP1
+http://purl.obolibrary.org/obo/MONDO_0014377,"epileptic encephalopathy, early infantile, 24",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4845,HCN1
+http://purl.obolibrary.org/obo/MONDO_0014392,"epileptic encephalopathy, early infantile, 25",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/23089,SLC13A5
+http://purl.obolibrary.org/obo/MONDO_0014477,"epileptic encephalopathy, early infantile, 26",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/6231,KCNB1
+http://purl.obolibrary.org/obo/MONDO_0014505,"epileptic encephalopathy, early infantile, 27",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4586,GRIN2B
+http://purl.obolibrary.org/obo/MONDO_0014533,"epileptic encephalopathy, early infantile, 28",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/12799,WWOX
+http://purl.obolibrary.org/obo/MONDO_0014593,"epileptic encephalopathy, early infantile, 29",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/20,AARS
+http://purl.obolibrary.org/obo/MONDO_0012245,"epileptic encephalopathy, early infantile, 3",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/19954,SLC25A22
+http://purl.obolibrary.org/obo/MONDO_0014595,"epileptic encephalopathy, early infantile, 30",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/11142,SIK1
+http://purl.obolibrary.org/obo/MONDO_0014598,"epileptic encephalopathy, early infantile, 31",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/2972,DNM1
+http://purl.obolibrary.org/obo/MONDO_0014607,"epileptic encephalopathy, early infantile, 32",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/6220,KCNA2
+http://purl.obolibrary.org/obo/MONDO_0014625,"epileptic encephalopathy, early infantile, 33",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/3192,EEF1A2
+http://purl.obolibrary.org/obo/MONDO_0014718,"epileptic encephalopathy, early infantile, 34; EIEE34",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/13818,SLC12A5
+http://purl.obolibrary.org/obo/MONDO_0014859,"epileptic encephalopathy, early infantile, 37; EIEE37",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/1362,FRRS1L
+http://purl.obolibrary.org/obo/MONDO_0014868,"epileptic encephalopathy, early infantile, 38; EIEE38",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/29561,ARV1
+http://purl.obolibrary.org/obo/MONDO_0012812,"epileptic encephalopathy, early infantile, 4",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/11444,STXBP1
+http://purl.obolibrary.org/obo/MONDO_0014895,"epileptic encephalopathy, early infantile, 40; EIEE40",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/25799,GUF1
+http://purl.obolibrary.org/obo/MONDO_0014916,"epileptic encephalopathy, early infantile, 41; EIEE41",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/10940,SLC1A2
+http://purl.obolibrary.org/obo/MONDO_0014917,"epileptic encephalopathy, early infantile, 42; EIEE42",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/1388,CACNA1A
+http://purl.obolibrary.org/obo/MONDO_0014921,"epileptic encephalopathy, early infantile, 43; EIEE43",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4083,GABRB3
+http://purl.obolibrary.org/obo/MONDO_0014933,"epileptic encephalopathy, early infantile, 44; EIEE44",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/23230,UBA5
+http://purl.obolibrary.org/obo/MONDO_0014942,"epileptic encephalopathy, early infantile, 45; EIEE45",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4081,GABRB1
+http://purl.obolibrary.org/obo/MONDO_0014947,"epileptic encephalopathy, early infantile, 46; EIEE46",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/4588,GRIN2D
+http://purl.obolibrary.org/obo/MONDO_0014949,"epileptic encephalopathy, early infantile, 47; EIEE47",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/3668,FGF12
+http://purl.obolibrary.org/obo/MONDO_0015000,"epileptic encephalopathy, early infantile, 48; EIEE48",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/567,AP3B2
+http://purl.obolibrary.org/obo/MONDO_0015002,"epileptic encephalopathy, early infantile, 49; EIEE49",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/19344,DENND5A
+http://purl.obolibrary.org/obo/MONDO_0013277,"epileptic encephalopathy, early infantile, 5",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/11273,SPTAN1
+http://purl.obolibrary.org/obo/MONDO_0015025,"epileptic encephalopathy, early infantile, 51; EIEE51",http://purl.obolibrary.org/obo/MONDO_0016021,early infantile epileptic encephalopathy,http://identifiers.org/hgnc/6971,MDH2
+http://purl.obolibrary.org/obo/MONDO_0010844,"epiphyseal dysplasia, multiple, 2",http://purl.obolibrary.org/obo/MONDO_0016648,multiple epiphyseal dysplasia (disease),http://identifiers.org/hgnc/2218,COL9A2
+http://purl.obolibrary.org/obo/MONDO_0010964,"epiphyseal dysplasia, multiple, 3",http://purl.obolibrary.org/obo/MONDO_0016648,multiple epiphyseal dysplasia (disease),http://identifiers.org/hgnc/2219,COL9A3
+http://purl.obolibrary.org/obo/MONDO_0013591,"epiphyseal dysplasia, multiple, 6",http://purl.obolibrary.org/obo/MONDO_0016648,multiple epiphyseal dysplasia (disease),http://identifiers.org/hgnc/2217,COL9A1
+http://purl.obolibrary.org/obo/MONDO_0008047,episodic ataxia type 1,http://purl.obolibrary.org/obo/MONDO_0016227,hereditary episodic ataxia,http://identifiers.org/hgnc/6218,KCNA1
+http://purl.obolibrary.org/obo/MONDO_0007163,episodic ataxia type 2,http://purl.obolibrary.org/obo/MONDO_0016227,hereditary episodic ataxia,http://identifiers.org/hgnc/1388,CACNA1A
+http://purl.obolibrary.org/obo/MONDO_0013464,episodic ataxia type 5,http://purl.obolibrary.org/obo/MONDO_0016227,hereditary episodic ataxia,http://identifiers.org/hgnc/1404,CACNB4
+http://purl.obolibrary.org/obo/MONDO_0012982,episodic ataxia type 6,http://purl.obolibrary.org/obo/MONDO_0016227,hereditary episodic ataxia,http://identifiers.org/hgnc/10941,SLC1A3
+http://purl.obolibrary.org/obo/MONDO_0007494,episodic kinesigenic dyskinesia 1,http://purl.obolibrary.org/obo/MONDO_0044202,episodic kinesigenic dyskinesia,http://identifiers.org/hgnc/30500,PRRT2
+http://purl.obolibrary.org/obo/MONDO_0014246,"episodic pain syndrome, familial, 2",http://purl.obolibrary.org/obo/MONDO_0018319,familial episodic pain syndrome,http://identifiers.org/hgnc/10582,SCN10A
+http://purl.obolibrary.org/obo/MONDO_0000764,epithelial-stromal TGFBI dystrophy,http://purl.obolibrary.org/obo/MONDO_0018102,corneal dystrophy (disease),http://identifiers.org/hgnc/7045,MGAT2
+http://purl.obolibrary.org/obo/MONDO_0012353,"erythrocytosis, familial, 3",http://purl.obolibrary.org/obo/MONDO_0001115,familial polycythemia,http://identifiers.org/hgnc/1232,EGLN1
+http://purl.obolibrary.org/obo/MONDO_0012729,"erythrocytosis, familial, 4",http://purl.obolibrary.org/obo/MONDO_0001115,familial polycythemia,http://identifiers.org/hgnc/3374,EPAS1
+http://purl.obolibrary.org/obo/MONDO_0033483,"erythrocytosis, familial, 5",http://purl.obolibrary.org/obo/MONDO_0001115,familial polycythemia,http://identifiers.org/hgnc/3415,EPO
+http://purl.obolibrary.org/obo/MONDO_0007585,"exostoses, multiple, type 1",http://purl.obolibrary.org/obo/MONDO_0000024,"exostoses, multiple",http://identifiers.org/hgnc/3512,EXT1
+http://purl.obolibrary.org/obo/MONDO_0007586,"exostoses, multiple, type 2",http://purl.obolibrary.org/obo/MONDO_0000024,"exostoses, multiple",http://identifiers.org/hgnc/3513,EXT2
+http://purl.obolibrary.org/obo/MONDO_0010588,"exudative vitreoretinopathy 2, X-linked",http://purl.obolibrary.org/obo/MONDO_0019516,exudative vitreoretinopathy,http://identifiers.org/hgnc/7678,NDP
+http://purl.obolibrary.org/obo/MONDO_0013218,exudative vitreoretinopathy 5,http://purl.obolibrary.org/obo/MONDO_0019516,exudative vitreoretinopathy,http://identifiers.org/hgnc/21641,TSPAN12
+http://purl.obolibrary.org/obo/MONDO_0014652,exudative vitreoretinopathy 6,http://purl.obolibrary.org/obo/MONDO_0019516,exudative vitreoretinopathy,http://identifiers.org/hgnc/20041,ZNF408
+http://purl.obolibrary.org/obo/MONDO_0013880,"facial paresis, hereditary congenital, 3",http://purl.obolibrary.org/obo/MONDO_0017627,congenital hereditary facial paralysis-variable hearing loss syndrome,http://identifiers.org/hgnc/5111,HOXB1
+http://purl.obolibrary.org/obo/MONDO_0008030,facioscapulohumeral muscular dystrophy 1,http://purl.obolibrary.org/obo/MONDO_0001347,facioscapulohumeral muscular dystrophy,http://identifiers.org/hgnc/3954,FRG1
+http://purl.obolibrary.org/obo/MONDO_0008031,facioscapulohumeral muscular dystrophy 2,http://purl.obolibrary.org/obo/MONDO_0001347,facioscapulohumeral muscular dystrophy,http://identifiers.org/hgnc/29090,SMCHD1
+http://purl.obolibrary.org/obo/MONDO_0013331,"factor 5 and Factor VIII, combined deficiency of, 2",http://purl.obolibrary.org/obo/MONDO_0018175,combined deficiency of factor V and factor VIII,http://identifiers.org/hgnc/18451,MCFD2
+http://purl.obolibrary.org/obo/MONDO_0009206,"factor V and factor VIII, combined deficiency of, type 1",http://purl.obolibrary.org/obo/MONDO_0018175,combined deficiency of factor V and factor VIII,http://identifiers.org/hgnc/6631,LMAN1
+http://purl.obolibrary.org/obo/MONDO_0021056,familial adenomatous polyposis 1,http://purl.obolibrary.org/obo/MONDO_0016362,attenuated familial adenomatous polyposis,http://identifiers.org/hgnc/583,APC
+http://purl.obolibrary.org/obo/MONDO_0007349,familial cold autoinflammatory syndrome 1,http://purl.obolibrary.org/obo/MONDO_0018768,familial cold autoinflammatory syndrome,http://identifiers.org/hgnc/16400,NLRP3
+http://purl.obolibrary.org/obo/MONDO_0012724,familial cold autoinflammatory syndrome 2,http://purl.obolibrary.org/obo/MONDO_0018768,familial cold autoinflammatory syndrome,http://identifiers.org/hgnc/22938,NLRP12
+http://purl.obolibrary.org/obo/MONDO_0013766,familial cold autoinflammatory syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018768,familial cold autoinflammatory syndrome,http://identifiers.org/hgnc/9066,PLCG2
+http://purl.obolibrary.org/obo/MONDO_0014498,familial cold autoinflammatory syndrome 4,http://purl.obolibrary.org/obo/MONDO_0018768,familial cold autoinflammatory syndrome,http://identifiers.org/hgnc/16412,NLRC4
+http://purl.obolibrary.org/obo/MONDO_0011337,familial hemophagocytic lymphohistiocytosis 2,http://purl.obolibrary.org/obo/MONDO_0015541,genetic hemophagocytic lymphohistiocytosis,http://identifiers.org/hgnc/9360,PRF1
+http://purl.obolibrary.org/obo/MONDO_0012146,familial hemophagocytic lymphohistiocytosis 3,http://purl.obolibrary.org/obo/MONDO_0015541,genetic hemophagocytic lymphohistiocytosis,http://identifiers.org/hgnc/23147,UNC13D
+http://purl.obolibrary.org/obo/MONDO_0011336,familial hemophagocytic lymphohistiocytosis 4,http://purl.obolibrary.org/obo/MONDO_0015541,genetic hemophagocytic lymphohistiocytosis,http://identifiers.org/hgnc/11429,STX11
+http://purl.obolibrary.org/obo/MONDO_0013135,familial hemophagocytic lymphohistiocytosis 5,http://purl.obolibrary.org/obo/MONDO_0015541,genetic hemophagocytic lymphohistiocytosis,http://identifiers.org/hgnc/11445,STXBP2
+http://purl.obolibrary.org/obo/MONDO_0014252,familial hypobetalipoproteinemia 1,http://purl.obolibrary.org/obo/MONDO_0017774,hypobetalipoproteinemia,http://identifiers.org/hgnc/603,APOB
+http://purl.obolibrary.org/obo/MONDO_0011505,familial hypobetalipoproteinemia 2,http://purl.obolibrary.org/obo/MONDO_0017774,hypobetalipoproteinemia,http://identifiers.org/hgnc/491,ANGPTL3
+http://purl.obolibrary.org/obo/MONDO_0007791,familial hypocalciuric hypercalcemia 1,http://purl.obolibrary.org/obo/MONDO_0018458,familial hypocalciuric hypercalcemia,http://identifiers.org/hgnc/1514,CASR
+http://purl.obolibrary.org/obo/MONDO_0010926,familial hypocalciuric hypercalcemia 3,http://purl.obolibrary.org/obo/MONDO_0018458,familial hypocalciuric hypercalcemia,http://identifiers.org/hgnc/565,AP2S1
+http://purl.obolibrary.org/obo/MONDO_0008073,familial juvenile hyperuricemic nephropathy type 1,http://purl.obolibrary.org/obo/MONDO_0000608,familial juvenile hyperuricemic nephropathy,http://identifiers.org/hgnc/12559,UMOD
+http://purl.obolibrary.org/obo/MONDO_0013128,familial juvenile hyperuricemic nephropathy type 2,http://purl.obolibrary.org/obo/MONDO_0000608,familial juvenile hyperuricemic nephropathy,http://identifiers.org/hgnc/9958,REN
+http://purl.obolibrary.org/obo/MONDO_0012512,fatal mitochondrial disease due to combined oxidative phosphorylation defect type 3,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/12367,TSFM
+http://purl.obolibrary.org/obo/MONDO_0011443,"febrile seizures, familial, 4",http://purl.obolibrary.org/obo/MONDO_0000032,"febrile seizures, familial",http://identifiers.org/hgnc/17416,ADGRV1
+http://purl.obolibrary.org/obo/MONDO_0014659,fever-associated acute infantile liver failure syndrome,http://purl.obolibrary.org/obo/MONDO_0000023,infantile liver failure,http://identifiers.org/hgnc/15625,NBAS
+http://purl.obolibrary.org/obo/MONDO_0009226,fibrochondrogenesis 1,http://purl.obolibrary.org/obo/MONDO_0016068,fibrochondrogenesis,http://identifiers.org/hgnc/2186,COL11A1
+http://purl.obolibrary.org/obo/MONDO_0013795,fibrochondrogenesis 2,http://purl.obolibrary.org/obo/MONDO_0016068,fibrochondrogenesis,http://identifiers.org/hgnc/2187,COL11A2
+http://purl.obolibrary.org/obo/MONDO_0007609,"fibromatosis, gingival, 1",http://purl.obolibrary.org/obo/MONDO_0016070,hereditary gingival fibromatosis,http://identifiers.org/hgnc/11187,SOS1
+http://purl.obolibrary.org/obo/MONDO_0011181,"fibrosis of extraocular muscles, congenital, 2",http://purl.obolibrary.org/obo/MONDO_0007614,congenital fibrosis of extraocular muscles,http://identifiers.org/hgnc/691,PHOX2A
+http://purl.obolibrary.org/obo/MONDO_0010912,"fibrosis of extraocular muscles, congenital, 3A, with or without extraocular involvement",http://purl.obolibrary.org/obo/MONDO_0007614,congenital fibrosis of extraocular muscles,http://identifiers.org/hgnc/20772,TUBB3
+http://purl.obolibrary.org/obo/MONDO_0014538,"fibrosis of extraocular muscles, congenital, 5",http://purl.obolibrary.org/obo/MONDO_0007614,congenital fibrosis of extraocular muscles,http://identifiers.org/hgnc/18603,COL25A1
+http://purl.obolibrary.org/obo/MONDO_0011303,focal segmental glomerulosclerosis 1,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/166,ACTN4
+http://purl.obolibrary.org/obo/MONDO_0011390,focal segmental glomerulosclerosis 2,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/12338,TRPC6
+http://purl.obolibrary.org/obo/MONDO_0011917,"focal segmental glomerulosclerosis 3, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/14258,CD2AP
+http://purl.obolibrary.org/obo/MONDO_0012931,"focal segmental glomerulosclerosis 4, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/618,APOL1
+http://purl.obolibrary.org/obo/MONDO_0013191,focal segmental glomerulosclerosis 5,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/23791,INF2
+http://purl.obolibrary.org/obo/MONDO_0013589,focal segmental glomerulosclerosis 6,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/7599,MYO1E
+http://purl.obolibrary.org/obo/MONDO_0014451,focal segmental glomerulosclerosis 7,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/8616,PAX2
+http://purl.obolibrary.org/obo/MONDO_0014462,focal segmental glomerulosclerosis 8,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/14082,ANLN
+http://purl.obolibrary.org/obo/MONDO_0014539,focal segmental glomerulosclerosis 9,http://purl.obolibrary.org/obo/MONDO_0005363,focal segmental glomerulosclerosis,http://identifiers.org/hgnc/18688,CRB2
+http://purl.obolibrary.org/obo/MONDO_0007628,foveal hypoplasia 1,http://purl.obolibrary.org/obo/MONDO_0044203,foveal hypoplasia,http://identifiers.org/hgnc/8620,PAX6
+http://purl.obolibrary.org/obo/MONDO_0024550,frontometaphyseal dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0015942,frontometaphyseal dysplasia,http://identifiers.org/hgnc/3754,FLNA
+http://purl.obolibrary.org/obo/MONDO_0014935,frontometaphyseal dysplasia 2; FMD2,http://purl.obolibrary.org/obo/MONDO_0015942,frontometaphyseal dysplasia,http://identifiers.org/hgnc/6859,MAP3K7
+http://purl.obolibrary.org/obo/MONDO_0007105,frontotemporal dementia with motor neuron disease 1,http://purl.obolibrary.org/obo/MONDO_0017161,frontotemporal dementia with motor neuron disease,http://identifiers.org/hgnc/28337,C9orf72
+http://purl.obolibrary.org/obo/MONDO_0009269,geleophysic dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0000127,geleophysic dysplasia,http://identifiers.org/hgnc/14631,ADAMTSL2
+http://purl.obolibrary.org/obo/MONDO_0011461,"generalized epilepsy with febrile seizures plus, type 2",http://purl.obolibrary.org/obo/MONDO_0000032,"febrile seizures, familial",http://identifiers.org/hgnc/10585,SCN1A
+http://purl.obolibrary.org/obo/MONDO_0012647,"generalized epilepsy with febrile seizures plus, type 3",http://purl.obolibrary.org/obo/MONDO_0018214,generalized epilepsy with febrile seizures plus,http://identifiers.org/hgnc/4087,GABRG2
+http://purl.obolibrary.org/obo/MONDO_0013470,"generalized epilepsy with febrile seizures plus, type 7",http://purl.obolibrary.org/obo/MONDO_0018214,generalized epilepsy with febrile seizures plus,http://identifiers.org/hgnc/10597,SCN9A
+http://purl.obolibrary.org/obo/MONDO_0014517,"generalized epilepsy with febrile seizures plus, type 9",http://purl.obolibrary.org/obo/MONDO_0018214,generalized epilepsy with febrile seizures plus,http://identifiers.org/hgnc/18539,STX1B
+http://purl.obolibrary.org/obo/MONDO_0009749,giant axonal neuropathy 1,http://purl.obolibrary.org/obo/MONDO_0000128,giant axonal neuropathy,http://identifiers.org/hgnc/4137,GAN
+http://purl.obolibrary.org/obo/MONDO_0012411,giant axonal neuropathy 2,http://purl.obolibrary.org/obo/MONDO_0000128,giant axonal neuropathy,http://identifiers.org/hgnc/24891,DCAF8
+http://purl.obolibrary.org/obo/MONDO_0007664,"glaucoma 1, open angle, A",http://purl.obolibrary.org/obo/MONDO_0020367,juvenile open angle glaucoma,http://identifiers.org/hgnc/7610,MYOC
+http://purl.obolibrary.org/obo/MONDO_0012357,"glaucoma 1, open angle, G",http://purl.obolibrary.org/obo/MONDO_0005338,open-angle glaucoma,http://identifiers.org/hgnc/30696,WDR36
+http://purl.obolibrary.org/obo/MONDO_0013134,"glaucoma 1, open angle, O",http://purl.obolibrary.org/obo/MONDO_0005338,open-angle glaucoma,http://identifiers.org/hgnc/8024,NTF4
+http://purl.obolibrary.org/obo/MONDO_0013092,glioma susceptibility 2,http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://identifiers.org/hgnc/9588,PTEN
+http://purl.obolibrary.org/obo/MONDO_0013093,glioma susceptibility 3,http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://identifiers.org/hgnc/1101,BRCA2
+http://purl.obolibrary.org/obo/MONDO_0014695,glioma susceptibility 9,http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://identifiers.org/hgnc/17284,POT1
+http://purl.obolibrary.org/obo/MONDO_0011165,glomerulopathy with fibronectin deposits 2,http://purl.obolibrary.org/obo/MONDO_0007671,fibronectin glomerulopathy,http://identifiers.org/hgnc/3778,FN1
+http://purl.obolibrary.org/obo/MONDO_0024536,glucocorticoid deficiency 1,http://purl.obolibrary.org/obo/MONDO_0008733,familial glucocorticoid deficiency,http://identifiers.org/hgnc/6930,MC2R
+http://purl.obolibrary.org/obo/MONDO_0011826,glucocorticoid deficiency 2,http://purl.obolibrary.org/obo/MONDO_0008733,familial glucocorticoid deficiency,http://identifiers.org/hgnc/1304,MRAP
+http://purl.obolibrary.org/obo/MONDO_0013874,glucocorticoid deficiency 4,http://purl.obolibrary.org/obo/MONDO_0008733,familial glucocorticoid deficiency,http://identifiers.org/hgnc/7863,NNT
+http://purl.obolibrary.org/obo/MONDO_0009283,glutaric acidemia type 3,http://purl.obolibrary.org/obo/MONDO_0000129,glutaric aciduria (disease),http://identifiers.org/hgnc/16001,SUGCT
+http://purl.obolibrary.org/obo/MONDO_0009290,glycogen storage disease II,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/4065,GAA
+http://purl.obolibrary.org/obo/MONDO_0009291,glycogen storage disease III,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/321,AGL
+http://purl.obolibrary.org/obo/MONDO_0010598,glycogen storage disease IXa,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8926,PHKA2
+http://purl.obolibrary.org/obo/MONDO_0009868,glycogen storage disease IXb,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8927,PHKB
+http://purl.obolibrary.org/obo/MONDO_0013091,glycogen storage disease IXc,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8931,PHKG2
+http://purl.obolibrary.org/obo/MONDO_0010362,glycogen storage disease IXd,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8925,PHKA1
+http://purl.obolibrary.org/obo/MONDO_0009293,glycogen storage disease V,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/9726,PYGM
+http://purl.obolibrary.org/obo/MONDO_0009294,glycogen storage disease VI,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/9725,PYGL
+http://purl.obolibrary.org/obo/MONDO_0009295,glycogen storage disease VII,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8877,PFKM
+http://purl.obolibrary.org/obo/MONDO_0009287,glycogen storage disease due to glucose-6-phosphatase deficiency type IA,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/4056,G6PC
+http://purl.obolibrary.org/obo/MONDO_0009292,glycogen storage disease due to glycogen branching enzyme deficiency,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/4180,GBE1
+http://purl.obolibrary.org/obo/MONDO_0013047,glycogen storage disease due to lactate dehydrogenase M-subunit deficiency,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/6535,LDHA
+http://purl.obolibrary.org/obo/MONDO_0010392,glycogen storage disease due to phosphoglycerate kinase 1 deficiency,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8896,PGK1
+http://purl.obolibrary.org/obo/MONDO_0009865,glycogen storage disease due to phosphoglycerate mutase deficiency,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/8889,PGAM2
+http://purl.obolibrary.org/obo/MONDO_0023258,glycogen storage disease type 1 due to SLC37A4 mutation,http://purl.obolibrary.org/obo/MONDO_0002413,glycogen storage disease I,http://identifiers.org/hgnc/4061,SLC37A4
+http://purl.obolibrary.org/obo/MONDO_0009309,"granulomatous disease, chronic, autosomal recessive, cytochrome b-positive, type 1",http://purl.obolibrary.org/obo/MONDO_0018305,chronic granulomatous disease,http://identifiers.org/hgnc/7660,NCF1
+http://purl.obolibrary.org/obo/MONDO_0009310,"granulomatous disease, chronic, autosomal recessive, cytochrome b-positive, type 2",http://purl.obolibrary.org/obo/MONDO_0018305,chronic granulomatous disease,http://identifiers.org/hgnc/7661,NCF2
+http://purl.obolibrary.org/obo/MONDO_0014261,growth and developmental delay-hypotonia-vision impairment-lactic acidosis syndrome,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/16088,SFXN4
+http://purl.obolibrary.org/obo/MONDO_0011216,hemochromatosis type 2A,http://purl.obolibrary.org/obo/MONDO_0019257,hemochromatosis type 2,http://identifiers.org/hgnc/4887,HJV
+http://purl.obolibrary.org/obo/MONDO_0013220,hemochromatosis type 2B,http://purl.obolibrary.org/obo/MONDO_0019257,hemochromatosis type 2,http://identifiers.org/hgnc/15598,HAMP
+http://purl.obolibrary.org/obo/MONDO_0011417,hemochromatosis type 3,http://purl.obolibrary.org/obo/MONDO_0006507,hereditary hemochromatosis,http://identifiers.org/hgnc/11762,TFR2
+http://purl.obolibrary.org/obo/MONDO_0011631,hemochromatosis type 4,http://purl.obolibrary.org/obo/MONDO_0006507,hereditary hemochromatosis,http://identifiers.org/hgnc/10909,SLC40A1
+http://purl.obolibrary.org/obo/MONDO_0014225,hemochromatosis type 5,http://purl.obolibrary.org/obo/MONDO_0006507,hereditary hemochromatosis,http://identifiers.org/hgnc/3976,FTH1
+http://purl.obolibrary.org/obo/MONDO_0012191,hepatoencephalopathy due to combined oxidative phosphorylation defect type 1,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/13780,GFM1
+http://purl.obolibrary.org/obo/MONDO_0012526,hereditary angioedema type 3,http://purl.obolibrary.org/obo/MONDO_0019623,hereditary angioedema,http://identifiers.org/hgnc/3530,F12
+http://purl.obolibrary.org/obo/MONDO_0009746,hereditary sensory and autonomic neuropathy type 4,http://purl.obolibrary.org/obo/MONDO_0015364,hereditary sensory and autonomic neuropathy,http://identifiers.org/hgnc/8031,NTRK1
+http://purl.obolibrary.org/obo/MONDO_0012092,hereditary sensory and autonomic neuropathy type 5,http://purl.obolibrary.org/obo/MONDO_0015366,autosomal recessive hereditary sensory and autonomic neuropathy,http://identifiers.org/hgnc/7808,NGF
+http://purl.obolibrary.org/obo/MONDO_0013839,hereditary sensory and autonomic neuropathy type 6,http://purl.obolibrary.org/obo/MONDO_0015364,hereditary sensory and autonomic neuropathy,http://identifiers.org/hgnc/1090,DST
+http://purl.obolibrary.org/obo/MONDO_0014244,hereditary sensory and autonomic neuropathy type 7,http://purl.obolibrary.org/obo/MONDO_0015365,autosomal dominant hereditary sensory and autonomic neuropathy,http://identifiers.org/hgnc/10583,SCN11A
+http://purl.obolibrary.org/obo/MONDO_0011408,hereditary spastic paraplegia 10,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/6323,KIF5A
+http://purl.obolibrary.org/obo/MONDO_0011445,hereditary spastic paraplegia 11,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/11226,SPG11
+http://purl.obolibrary.org/obo/MONDO_0011489,hereditary spastic paraplegia 12,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/10468,RTN2
+http://purl.obolibrary.org/obo/MONDO_0011532,hereditary spastic paraplegia 13,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/5261,HSPD1
+http://purl.obolibrary.org/obo/MONDO_0010044,hereditary spastic paraplegia 15,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/20761,ZFYVE26
+http://purl.obolibrary.org/obo/MONDO_0010043,hereditary spastic paraplegia 17,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/15832,BSCL2
+http://purl.obolibrary.org/obo/MONDO_0012639,hereditary spastic paraplegia 18,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/1356,ERLIN2
+http://purl.obolibrary.org/obo/MONDO_0010733,hereditary spastic paraplegia 2,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/9086,PLP1
+http://purl.obolibrary.org/obo/MONDO_0010046,hereditary spastic paraplegia 23,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/29043,DSTYK
+http://purl.obolibrary.org/obo/MONDO_0012256,hereditary spastic paraplegia 28,http://purl.obolibrary.org/obo/MONDO_0015090,autosomal recessive pure spastic paraplegia,http://identifiers.org/hgnc/19714,DDHD1
+http://purl.obolibrary.org/obo/MONDO_0012476,hereditary spastic paraplegia 30,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/888,KIF1A
+http://purl.obolibrary.org/obo/MONDO_0012453,hereditary spastic paraplegia 31,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/25786,REEP1
+http://purl.obolibrary.org/obo/MONDO_0012448,hereditary spastic paraplegia 33,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/26559,ZFYVE27
+http://purl.obolibrary.org/obo/MONDO_0012866,hereditary spastic paraplegia 35,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/21197,FA2H
+http://purl.obolibrary.org/obo/MONDO_0012787,hereditary spastic paraplegia 39,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/16268,PNPLA6
+http://purl.obolibrary.org/obo/MONDO_0008437,hereditary spastic paraplegia 3A,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/11231,ATL1
+http://purl.obolibrary.org/obo/MONDO_0008438,hereditary spastic paraplegia 4,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/11233,SPAST
+http://purl.obolibrary.org/obo/MONDO_0012928,hereditary spastic paraplegia 42,http://purl.obolibrary.org/obo/MONDO_0015088,autosomal dominant pure spastic paraplegia,http://identifiers.org/hgnc/95,SLC33A1
+http://purl.obolibrary.org/obo/MONDO_0014024,hereditary spastic paraplegia 43,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/25443,C19orf12
+http://purl.obolibrary.org/obo/MONDO_0013179,hereditary spastic paraplegia 44,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/17494,GJC2
+http://purl.obolibrary.org/obo/MONDO_0013165,hereditary spastic paraplegia 45,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/8022,NT5C2
+http://purl.obolibrary.org/obo/MONDO_0013737,hereditary spastic paraplegia 46,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/18986,GBA2
+http://purl.obolibrary.org/obo/MONDO_0013551,hereditary spastic paraplegia 47,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/572,AP4B1
+http://purl.obolibrary.org/obo/MONDO_0013342,hereditary spastic paraplegia 48,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/22197,AP5Z1
+http://purl.obolibrary.org/obo/MONDO_0014016,hereditary spastic paraplegia 49,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/19957,TECPR2
+http://purl.obolibrary.org/obo/MONDO_0013048,hereditary spastic paraplegia 50,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/574,AP4M1
+http://purl.obolibrary.org/obo/MONDO_0013401,hereditary spastic paraplegia 51,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/573,AP4E1
+http://purl.obolibrary.org/obo/MONDO_0013552,hereditary spastic paraplegia 52,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/575,AP4S1
+http://purl.obolibrary.org/obo/MONDO_0013962,hereditary spastic paraplegia 53,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/24928,VPS37A
+http://purl.obolibrary.org/obo/MONDO_0014018,hereditary spastic paraplegia 54,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/29106,DDHD2
+http://purl.obolibrary.org/obo/MONDO_0014015,hereditary spastic paraplegia 56,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/20582,CYP2U1
+http://purl.obolibrary.org/obo/MONDO_0014295,hereditary spastic paraplegia 57,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/11758,TFG
+http://purl.obolibrary.org/obo/MONDO_0010047,hereditary spastic paraplegia 5A,http://purl.obolibrary.org/obo/MONDO_0017915,pure or complex autosomal recessive spastic paraplegia,http://identifiers.org/hgnc/2652,CYP7B1
+http://purl.obolibrary.org/obo/MONDO_0010878,hereditary spastic paraplegia 6,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/17043,NIPA1
+http://purl.obolibrary.org/obo/MONDO_0014304,hereditary spastic paraplegia 61,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/697,ARL6IP1
+http://purl.obolibrary.org/obo/MONDO_0014302,hereditary spastic paraplegia 62,http://purl.obolibrary.org/obo/MONDO_0015090,autosomal recessive pure spastic paraplegia,http://identifiers.org/hgnc/16947,ERLIN1
+http://purl.obolibrary.org/obo/MONDO_0014305,hereditary spastic paraplegia 63,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/469,AMPD2
+http://purl.obolibrary.org/obo/MONDO_0014303,hereditary spastic paraplegia 64,http://purl.obolibrary.org/obo/MONDO_0015089,autosomal recessive complex spastic paraplegia,http://identifiers.org/hgnc/3363,ENTPD1
+http://purl.obolibrary.org/obo/MONDO_0011803,hereditary spastic paraplegia 7,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/11237,SPG7
+http://purl.obolibrary.org/obo/MONDO_0014282,hereditary spastic paraplegia 72,http://purl.obolibrary.org/obo/MONDO_0015149,pure hereditary spastic paraplegia,http://identifiers.org/hgnc/17975,REEP2
+http://purl.obolibrary.org/obo/MONDO_0014568,hereditary spastic paraplegia 73,http://purl.obolibrary.org/obo/MONDO_0015088,autosomal dominant pure spastic paraplegia,http://identifiers.org/hgnc/18540,CPT1C
+http://purl.obolibrary.org/obo/MONDO_0014644,hereditary spastic paraplegia 74,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/27302,IBA57
+http://purl.obolibrary.org/obo/MONDO_0014729,hereditary spastic paraplegia 75,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/6783,MAG
+http://purl.obolibrary.org/obo/MONDO_0014882,hereditary spastic paraplegia 77,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/21062,FARS2
+http://purl.obolibrary.org/obo/MONDO_0011339,hereditary spastic paraplegia 8,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/28984,WASHC5
+http://purl.obolibrary.org/obo/MONDO_0008447,hereditary spherocytosis type 1,http://purl.obolibrary.org/obo/MONDO_0019350,hereditary spherocytosis,http://identifiers.org/hgnc/492,ANK1
+http://purl.obolibrary.org/obo/MONDO_0000913,hereditary spherocytosis type 2,http://purl.obolibrary.org/obo/MONDO_0019350,hereditary spherocytosis,http://identifiers.org/hgnc/11274,SPTB
+http://purl.obolibrary.org/obo/MONDO_0010053,hereditary spherocytosis type 3,http://purl.obolibrary.org/obo/MONDO_0019350,hereditary spherocytosis,http://identifiers.org/hgnc/11272,SPTA1
+http://purl.obolibrary.org/obo/MONDO_0012981,hereditary spherocytosis type 4,http://purl.obolibrary.org/obo/MONDO_0019350,hereditary spherocytosis,http://identifiers.org/hgnc/11027,SLC4A1
+http://purl.obolibrary.org/obo/MONDO_0012985,hereditary spherocytosis type 5,http://purl.obolibrary.org/obo/MONDO_0019350,hereditary spherocytosis,http://identifiers.org/hgnc/3381,EPB42
+http://purl.obolibrary.org/obo/MONDO_0024563,"herpes simplex encephalitis, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0012521,herpes simplex encephalitis,http://identifiers.org/hgnc/13481,UNC93B1
+http://purl.obolibrary.org/obo/MONDO_0013920,"herpes simplex encephalitis, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0012521,herpes simplex encephalitis,http://identifiers.org/hgnc/12033,TRAF3
+http://purl.obolibrary.org/obo/MONDO_0013921,"herpes simplex encephalitis, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0012521,herpes simplex encephalitis,http://identifiers.org/hgnc/18348,TICAM1
+http://purl.obolibrary.org/obo/MONDO_0014680,"herpes simplex encephalitis, susceptibility to, 7",http://purl.obolibrary.org/obo/MONDO_0012521,herpes simplex encephalitis,http://identifiers.org/hgnc/6118,IRF3
+http://purl.obolibrary.org/obo/MONDO_0010607,"heterotaxy, visceral, 1, X-linked",http://purl.obolibrary.org/obo/MONDO_0018677,visceral heterotaxy,http://identifiers.org/hgnc/12874,ZIC3
+http://purl.obolibrary.org/obo/MONDO_0013403,"heterotaxy, visceral, 4, autosomal",http://purl.obolibrary.org/obo/MONDO_0018677,visceral heterotaxy,http://identifiers.org/hgnc/174,ACVR2B
+http://purl.obolibrary.org/obo/MONDO_0014762,"heterotaxy, visceral, 7, autosomal; HTX7",http://purl.obolibrary.org/obo/MONDO_0018677,visceral heterotaxy,http://identifiers.org/hgnc/14357,MMP21
+http://purl.obolibrary.org/obo/MONDO_0014967,"heterotaxy, visceral, 8, autosomal; HTX8",http://purl.obolibrary.org/obo/MONDO_0018677,visceral heterotaxy,http://identifiers.org/hgnc/18053,PKD1L1
+http://purl.obolibrary.org/obo/MONDO_0013642,holoprosencephaly 11,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/17104,CDON
+http://purl.obolibrary.org/obo/MONDO_0007999,holoprosencephaly 2,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/10889,SIX3
+http://purl.obolibrary.org/obo/MONDO_0007733,holoprosencephaly 3,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/10848,SHH
+http://purl.obolibrary.org/obo/MONDO_0007734,holoprosencephaly 4,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/11776,TGIF1
+http://purl.obolibrary.org/obo/MONDO_0012322,holoprosencephaly 5,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/12873,ZIC2
+http://purl.obolibrary.org/obo/MONDO_0012562,holoprosencephaly 7,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/9585,PTCH1
+http://purl.obolibrary.org/obo/MONDO_0012563,holoprosencephaly 9,http://purl.obolibrary.org/obo/MONDO_0016296,holoprosencephaly,http://identifiers.org/hgnc/4318,GLI2
+http://purl.obolibrary.org/obo/MONDO_0009273,"hydatidiform mole, recurrent, 1",http://purl.obolibrary.org/obo/MONDO_0016785,complete hydatidiform mole,http://identifiers.org/hgnc/22947,NLRP7
+http://purl.obolibrary.org/obo/MONDO_0013671,"hydatidiform mole, recurrent, 2",http://purl.obolibrary.org/obo/MONDO_0016785,complete hydatidiform mole,http://identifiers.org/hgnc/33699,KHDC3L
+http://purl.obolibrary.org/obo/MONDO_0009360,"hydrocephalus, nonsyndromic, autosomal recessive 1",http://purl.obolibrary.org/obo/MONDO_0016349,congenital hydrocephalus,http://identifiers.org/hgnc/19967,CCDC88C
+http://purl.obolibrary.org/obo/MONDO_0014085,"hydrocephalus, nonsyndromic, autosomal recessive 2",http://purl.obolibrary.org/obo/MONDO_0016349,congenital hydrocephalus,http://identifiers.org/hgnc/7208,MPDZ
+http://purl.obolibrary.org/obo/MONDO_0009365,hydrolethalus syndrome 1,http://purl.obolibrary.org/obo/MONDO_0006037,hydrolethalus syndrome,http://identifiers.org/hgnc/26558,HYLS1
+http://purl.obolibrary.org/obo/MONDO_0013585,hydrolethalus syndrome 2,http://purl.obolibrary.org/obo/MONDO_0006037,hydrolethalus syndrome,http://identifiers.org/hgnc/30497,KIF7
+http://purl.obolibrary.org/obo/MONDO_0011528,hyper-IgM syndrome type 2,http://purl.obolibrary.org/obo/MONDO_0003947,hyper-IgM syndrome,http://identifiers.org/hgnc/13203,AICDA
+http://purl.obolibrary.org/obo/MONDO_0011735,hyper-IgM syndrome type 3,http://purl.obolibrary.org/obo/MONDO_0003947,hyper-IgM syndrome,http://identifiers.org/hgnc/11919,CD40
+http://purl.obolibrary.org/obo/MONDO_0011971,hyper-IgM syndrome type 5,http://purl.obolibrary.org/obo/MONDO_0003947,hyper-IgM syndrome,http://identifiers.org/hgnc/12572,UNG
+http://purl.obolibrary.org/obo/MONDO_0014851,"hypercalcemia, infantile, 2; HCINF2",http://purl.obolibrary.org/obo/MONDO_0007749,autosomal recessive infantile hypercalcemia,http://identifiers.org/hgnc/11019,SLC34A1
+http://purl.obolibrary.org/obo/MONDO_0011369,"hypercholesterolemia, autosomal dominant, 3",http://purl.obolibrary.org/obo/MONDO_0005439,familial hypercholesterolemia,http://identifiers.org/hgnc/20001,PCSK9
+http://purl.obolibrary.org/obo/MONDO_0013828,hyperekplexia 2,http://purl.obolibrary.org/obo/MONDO_0021022,hereditary hyperekplexia,http://identifiers.org/hgnc/4329,GLRB
+http://purl.obolibrary.org/obo/MONDO_0013827,hyperekplexia 3,http://purl.obolibrary.org/obo/MONDO_0021022,hereditary hyperekplexia,http://identifiers.org/hgnc/11051,SLC6A5
+http://purl.obolibrary.org/obo/MONDO_0009734,"hyperinsulinemic hypoglycemia, familial, 1",http://purl.obolibrary.org/obo/MONDO_0005803,hyperinsulinemic hypoglycemia (disease),http://identifiers.org/hgnc/59,ABCC8
+http://purl.obolibrary.org/obo/MONDO_0011153,"hyperinsulinemic hypoglycemia, familial, 2",http://purl.obolibrary.org/obo/MONDO_0005803,hyperinsulinemic hypoglycemia (disease),http://identifiers.org/hgnc/6257,KCNJ11
+http://purl.obolibrary.org/obo/MONDO_0012382,"hyperinsulinemic hypoglycemia, familial, 4",http://purl.obolibrary.org/obo/MONDO_0005803,hyperinsulinemic hypoglycemia (disease),http://identifiers.org/hgnc/4799,HADH
+http://purl.obolibrary.org/obo/MONDO_0011237,"hyperlipidemia, combined, 1",http://purl.obolibrary.org/obo/MONDO_0001807,familial combined hyperlipidemia,http://identifiers.org/hgnc/12593,USF1
+http://purl.obolibrary.org/obo/MONDO_0014412,"hyperlipoproteinemia, type 1D",http://purl.obolibrary.org/obo/MONDO_0001336,familial hyperlipidemia,http://identifiers.org/hgnc/24945,GPIHBP1
+http://purl.obolibrary.org/obo/MONDO_0014864,hypermanganesemia with dystonia 2; HMNDYT2,http://purl.obolibrary.org/obo/MONDO_0000214,hypermanganesemia with dystonia,http://identifiers.org/hgnc/20858,SLC39A14
+http://purl.obolibrary.org/obo/MONDO_0024570,hyperparathyroidism 4,http://purl.obolibrary.org/obo/MONDO_0015027,familial isolated hyperparathyroidism,http://identifiers.org/hgnc/4198,GCM2
+http://purl.obolibrary.org/obo/MONDO_0009398,hyperphosphatasia with intellectual disability syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016596,hyperphosphatasia-intellectual disability syndrome,http://identifiers.org/hgnc/26031,PIGV
+http://purl.obolibrary.org/obo/MONDO_0013882,hyperphosphatasia with intellectual disability syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016596,hyperphosphatasia-intellectual disability syndrome,http://identifiers.org/hgnc/23215,PIGO
+http://purl.obolibrary.org/obo/MONDO_0013628,hyperphosphatasia with intellectual disability syndrome 3,http://purl.obolibrary.org/obo/MONDO_0016596,hyperphosphatasia-intellectual disability syndrome,http://identifiers.org/hgnc/17893,PGAP2
+http://purl.obolibrary.org/obo/MONDO_0014318,hyperphosphatasia with intellectual disability syndrome 4,http://purl.obolibrary.org/obo/MONDO_0016596,hyperphosphatasia-intellectual disability syndrome,http://identifiers.org/hgnc/23719,PGAP3
+http://purl.obolibrary.org/obo/MONDO_0014457,hyperphosphatasia with intellectual disability syndrome 5,http://purl.obolibrary.org/obo/MONDO_0016596,hyperphosphatasia-intellectual disability syndrome,http://identifiers.org/hgnc/23213,PIGW
+http://purl.obolibrary.org/obo/MONDO_0014780,hyperphosphatasia with intellectual disability syndrome 6; HPMRS6,http://purl.obolibrary.org/obo/MONDO_0016596,hyperphosphatasia-intellectual disability syndrome,http://identifiers.org/hgnc/28213,PIGY
+http://purl.obolibrary.org/obo/MONDO_0009400,hyperprolinemia type 1,http://purl.obolibrary.org/obo/MONDO_0023419,hyperprolinemia,http://identifiers.org/hgnc/9453,PRODH
+http://purl.obolibrary.org/obo/MONDO_0009401,hyperprolinemia type 2,http://purl.obolibrary.org/obo/MONDO_0023419,hyperprolinemia,http://identifiers.org/hgnc/406,ALDH4A1
+http://purl.obolibrary.org/obo/MONDO_0008647,hypertrophic cardiomyopathy 1,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/7577,MYH7
+http://purl.obolibrary.org/obo/MONDO_0012112,hypertrophic cardiomyopathy 10,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/7583,MYL2
+http://purl.obolibrary.org/obo/MONDO_0012799,hypertrophic cardiomyopathy 11,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/143,ACTC1
+http://purl.obolibrary.org/obo/MONDO_0012804,hypertrophic cardiomyopathy 12,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/2472,CSRP3
+http://purl.obolibrary.org/obo/MONDO_0013195,hypertrophic cardiomyopathy 13,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/11943,TNNC1
+http://purl.obolibrary.org/obo/MONDO_0013197,hypertrophic cardiomyopathy 14,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/7576,MYH6
+http://purl.obolibrary.org/obo/MONDO_0013200,hypertrophic cardiomyopathy 15,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/12665,VCL
+http://purl.obolibrary.org/obo/MONDO_0013455,hypertrophic cardiomyopathy 16,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/1330,MYOZ2
+http://purl.obolibrary.org/obo/MONDO_0013474,hypertrophic cardiomyopathy 17,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/14202,JPH2
+http://purl.obolibrary.org/obo/MONDO_0013475,hypertrophic cardiomyopathy 18,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/9080,PLN
+http://purl.obolibrary.org/obo/MONDO_0013476,hypertrophic cardiomyopathy 19,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/20407,CALR3
+http://purl.obolibrary.org/obo/MONDO_0007266,hypertrophic cardiomyopathy 2,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/11949,TNNT2
+http://purl.obolibrary.org/obo/MONDO_0013477,hypertrophic cardiomyopathy 20,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/29557,NEXN
+http://purl.obolibrary.org/obo/MONDO_0011843,hypertrophic cardiomyopathy 25,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/11610,TCAP
+http://purl.obolibrary.org/obo/MONDO_0014883,hypertrophic cardiomyopathy 26,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/3756,FLNC
+http://purl.obolibrary.org/obo/MONDO_0007267,hypertrophic cardiomyopathy 3,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/12010,TPM1
+http://purl.obolibrary.org/obo/MONDO_0007268,hypertrophic cardiomyopathy 4,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/7551,MYBPC3
+http://purl.obolibrary.org/obo/MONDO_0010946,hypertrophic cardiomyopathy 6,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/9386,PRKAG2
+http://purl.obolibrary.org/obo/MONDO_0013369,hypertrophic cardiomyopathy 7,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/11947,TNNI3
+http://purl.obolibrary.org/obo/MONDO_0012111,hypertrophic cardiomyopathy 8,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/7584,MYL3
+http://purl.obolibrary.org/obo/MONDO_0013412,hypertrophic cardiomyopathy 9,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy,http://identifiers.org/hgnc/12403,TTN
+http://purl.obolibrary.org/obo/MONDO_0024546,"hypertrophic osteoarthropathy, primary, autosomal recessive, 1",http://purl.obolibrary.org/obo/MONDO_0016620,primary hypertrophic osteoarthropathy,http://identifiers.org/hgnc/5154,HPGD
+http://purl.obolibrary.org/obo/MONDO_0013756,"hypertrophic osteoarthropathy, primary, autosomal recessive, 2",http://purl.obolibrary.org/obo/MONDO_0016620,primary hypertrophic osteoarthropathy,http://identifiers.org/hgnc/10955,SLCO2A1
+http://purl.obolibrary.org/obo/MONDO_0014891,"hyperuricemic nephropathy, familial juvenile type 4",http://purl.obolibrary.org/obo/MONDO_0000608,familial juvenile hyperuricemic nephropathy,http://identifiers.org/hgnc/18276,SEC61A1
+http://purl.obolibrary.org/obo/MONDO_0007538,hypocalcified amelogenesis imperfecta,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/24797,FAM83H
+http://purl.obolibrary.org/obo/MONDO_0010635,hypogonadotropic hypogonadism 1 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/6211,ANOS1
+http://purl.obolibrary.org/obo/MONDO_0013912,hypogonadotropic hypogonadism 10 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/11521,TAC3
+http://purl.obolibrary.org/obo/MONDO_0013913,hypogonadotropic hypogonadism 11 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/11528,TACR3
+http://purl.obolibrary.org/obo/MONDO_0013915,hypogonadotropic hypogonadism 13 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/6341,KISS1
+http://purl.obolibrary.org/obo/MONDO_0013926,hypogonadotropic hypogonadism 14 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/13831,WDR11
+http://purl.obolibrary.org/obo/MONDO_0013946,hypogonadotropic hypogonadism 15 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/5201,HS6ST1
+http://purl.obolibrary.org/obo/MONDO_0013961,hypogonadotropic hypogonadism 16 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/10723,SEMA3A
+http://purl.obolibrary.org/obo/MONDO_0014102,hypogonadotropic hypogonadism 17 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/15533,SPRY4
+http://purl.obolibrary.org/obo/MONDO_0014103,hypogonadotropic hypogonadism 18 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/17616,IL17RD
+http://purl.obolibrary.org/obo/MONDO_0014105,hypogonadotropic hypogonadism 19 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/3072,DUSP6
+http://purl.obolibrary.org/obo/MONDO_0007844,hypogonadotropic hypogonadism 2 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/3688,FGFR1
+http://purl.obolibrary.org/obo/MONDO_0014106,hypogonadotropic hypogonadism 20 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/3673,FGF17
+http://purl.obolibrary.org/obo/MONDO_0014107,hypogonadotropic hypogonadism 21 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/3762,FLRT3
+http://purl.obolibrary.org/obo/MONDO_0014461,hypogonadotropic hypogonadism 22 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/22788,FEZF1
+http://purl.obolibrary.org/obo/MONDO_0009223,hypogonadotropic hypogonadism 23 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/6584,LHB
+http://purl.obolibrary.org/obo/MONDO_0009239,hypogonadotropic hypogonadism 24 without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/3964,FSHB
+http://purl.obolibrary.org/obo/MONDO_0009482,hypogonadotropic hypogonadism 3 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/15836,PROKR2
+http://purl.obolibrary.org/obo/MONDO_0012528,hypogonadotropic hypogonadism 4 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/18455,PROK2
+http://purl.obolibrary.org/obo/MONDO_0012880,hypogonadotropic hypogonadism 5 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/20626,CHD7
+http://purl.obolibrary.org/obo/MONDO_0012988,hypogonadotropic hypogonadism 6 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/3686,FGF8
+http://purl.obolibrary.org/obo/MONDO_0013910,hypogonadotropic hypogonadism 8 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/4510,KISS1R
+http://purl.obolibrary.org/obo/MONDO_0013911,hypogonadotropic hypogonadism 9 with or without anosmia,http://purl.obolibrary.org/obo/MONDO_0018555,hypogonadotropic hypogonadism,http://identifiers.org/hgnc/29843,NSMF
+http://purl.obolibrary.org/obo/MONDO_0007093,hypomaturation-hypoplastic amelogenesis imperfecta with taurodontism,http://purl.obolibrary.org/obo/MONDO_0019507,amelogenesis imperfecta,http://identifiers.org/hgnc/2916,DLX3
+http://purl.obolibrary.org/obo/MONDO_0014632,hypomyelinating leukodystrophy 10,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/30262,PYCR2
+http://purl.obolibrary.org/obo/MONDO_0014666,hypomyelinating leukodystrophy 11,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/20194,POLR1C
+http://purl.obolibrary.org/obo/MONDO_0014732,hypomyelinating leukodystrophy 12,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/14583,VPS11
+http://purl.obolibrary.org/obo/MONDO_0014813,hypomyelinating leukodystrophy 13,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/26938,HIKESHI
+http://purl.obolibrary.org/obo/MONDO_0012125,hypomyelinating leukodystrophy 2,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/17494,GJC2
+http://purl.obolibrary.org/obo/MONDO_0009843,hypomyelinating leukodystrophy 3,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/10648,AIMP1
+http://purl.obolibrary.org/obo/MONDO_0012824,hypomyelinating leukodystrophy 4,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/5261,HSPD1
+http://purl.obolibrary.org/obo/MONDO_0012514,hypomyelinating leukodystrophy 5,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/24587,FAM126A
+http://purl.obolibrary.org/obo/MONDO_0013722,hypomyelinating leukodystrophy 8 with or without oligodontia and-or hypogonadotropic hypogonadism,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/30348,POLR3B
+http://purl.obolibrary.org/obo/MONDO_0014506,hypomyelinating leukodystrophy 9,http://purl.obolibrary.org/obo/MONDO_0019046,leukodystrophy,http://identifiers.org/hgnc/9870,RARS
+http://purl.obolibrary.org/obo/MONDO_0009430,"hypophosphatemic rickets, autosomal recessive, 1",http://purl.obolibrary.org/obo/MONDO_0017324,autosomal recessive hypophosphatemic rickets,http://identifiers.org/hgnc/2932,DMP1
+http://purl.obolibrary.org/obo/MONDO_0013219,"hypophosphatemic rickets, autosomal recessive, 2",http://purl.obolibrary.org/obo/MONDO_0017324,autosomal recessive hypophosphatemic rickets,http://identifiers.org/hgnc/3356,ENPP1
+http://purl.obolibrary.org/obo/MONDO_0009433,hypoplastic left heart syndrome 1,http://purl.obolibrary.org/obo/MONDO_0004933,hypoplastic left heart syndrome,http://identifiers.org/hgnc/4274,GJA1
+http://purl.obolibrary.org/obo/MONDO_0013752,hypoplastic left heart syndrome 2,http://purl.obolibrary.org/obo/MONDO_0004933,hypoplastic left heart syndrome,http://identifiers.org/hgnc/2488,NKX2-5
+http://purl.obolibrary.org/obo/MONDO_0009154,"hypothyroidism, congenital, nongoitrous, 5",http://purl.obolibrary.org/obo/MONDO_0000045,"hypothyroidism, congenital, nongoitrous",http://identifiers.org/hgnc/2488,NKX2-5
+http://purl.obolibrary.org/obo/MONDO_0012718,hypotonia with lactic acidemia and hyperammonemia,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/14508,MRPS22
+http://purl.obolibrary.org/obo/MONDO_0024567,"hypotonia, infantile, with psychomotor retardation and characteristic facies 1",http://purl.obolibrary.org/obo/MONDO_0014176,"hypotonia, infantile, with psychomotor retardation and characteristic facies",http://identifiers.org/hgnc/19082,NALCN
+http://purl.obolibrary.org/obo/MONDO_0014777,"hypotonia, infantile, with psychomotor retardation and characteristic facies 2; IHPRF2",http://purl.obolibrary.org/obo/MONDO_0014176,"hypotonia, infantile, with psychomotor retardation and characteristic facies",http://identifiers.org/hgnc/26582,UNC80
+http://purl.obolibrary.org/obo/MONDO_0011549,hypotrichosis 1,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/15718,APCDD1
+http://purl.obolibrary.org/obo/MONDO_0014027,hypotrichosis 11,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/11161,SNRPE
+http://purl.obolibrary.org/obo/MONDO_0014384,hypotrichosis 12,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/10313,RPL21
+http://purl.obolibrary.org/obo/MONDO_0014390,hypotrichosis 13,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/28927,KRT71
+http://purl.obolibrary.org/obo/MONDO_0007805,hypotrichosis 2,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/1802,CDSN
+http://purl.obolibrary.org/obo/MONDO_0013514,hypotrichosis 3,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/28929,KRT74
+http://purl.obolibrary.org/obo/MONDO_0007806,hypotrichosis 4,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/5172,HR
+http://purl.obolibrary.org/obo/MONDO_0011932,hypotrichosis 6,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/21307,DSG4
+http://purl.obolibrary.org/obo/MONDO_0011452,hypotrichosis 7,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/18483,LIPH
+http://purl.obolibrary.org/obo/MONDO_0010206,hypotrichosis 8,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://identifiers.org/hgnc/15520,LPAR6
+http://purl.obolibrary.org/obo/MONDO_0014280,immunodeficiency 19,http://purl.obolibrary.org/obo/MONDO_0015974,severe combined immunodeficiency (disease),http://identifiers.org/hgnc/1673,CD3D
+http://purl.obolibrary.org/obo/MONDO_0012426,immunodeficiency 25,http://purl.obolibrary.org/obo/MONDO_0015974,severe combined immunodeficiency (disease),http://identifiers.org/hgnc/1677,CD247
+http://purl.obolibrary.org/obo/MONDO_0013953,immunodeficiency 28,http://purl.obolibrary.org/obo/MONDO_0003778,primary immunodeficiency disease,http://identifiers.org/hgnc/5440,IFNGR2
+http://purl.obolibrary.org/obo/MONDO_0014491,immunodeficiency 37,http://purl.obolibrary.org/obo/MONDO_0003778,primary immunodeficiency disease,http://identifiers.org/hgnc/989,BCL10
+http://purl.obolibrary.org/obo/MONDO_0014597,immunodeficiency 39,http://purl.obolibrary.org/obo/MONDO_0003778,primary immunodeficiency disease,http://identifiers.org/hgnc/6122,IRF7
+http://purl.obolibrary.org/obo/MONDO_0010504,immunodeficiency 47; IMD47,http://purl.obolibrary.org/obo/MONDO_0003778,primary immunodeficiency disease,http://identifiers.org/hgnc/868,ATP6AP1
+http://purl.obolibrary.org/obo/MONDO_0014981,immunodeficiency 49; IMD49,http://purl.obolibrary.org/obo/MONDO_0003778,primary immunodeficiency disease,http://identifiers.org/hgnc/13222,BCL11B
+http://purl.obolibrary.org/obo/MONDO_0014260,"immunodeficiency, common variable, 10",http://purl.obolibrary.org/obo/MONDO_0015517,common variable immunodeficiency,http://identifiers.org/hgnc/7795,NFKB2
+http://purl.obolibrary.org/obo/MONDO_0014697,"immunodeficiency, common variable, 12",http://purl.obolibrary.org/obo/MONDO_0015517,common variable immunodeficiency,http://identifiers.org/hgnc/7794,NFKB1
+http://purl.obolibrary.org/obo/MONDO_0013285,"immunodeficiency, common variable, 5",http://purl.obolibrary.org/obo/MONDO_0015517,common variable immunodeficiency,http://identifiers.org/hgnc/7315,MS4A1
+http://purl.obolibrary.org/obo/MONDO_0013286,"immunodeficiency, common variable, 6",http://purl.obolibrary.org/obo/MONDO_0015517,common variable immunodeficiency,http://identifiers.org/hgnc/1701,CD81
+http://purl.obolibrary.org/obo/MONDO_0009454,immunodeficiency-centromeric instability-facial anomalies syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000133,immunodeficiency-centromeric instability-facial anomalies syndrome,http://identifiers.org/hgnc/2979,DNMT3B
+http://purl.obolibrary.org/obo/MONDO_0013553,immunodeficiency-centromeric instability-facial anomalies syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000133,immunodeficiency-centromeric instability-facial anomalies syndrome,http://identifiers.org/hgnc/21143,ZBTB24
+http://purl.obolibrary.org/obo/MONDO_0014828,immunodeficiency-centromeric instability-facial anomalies syndrome 3,http://purl.obolibrary.org/obo/MONDO_0000133,immunodeficiency-centromeric instability-facial anomalies syndrome,http://identifiers.org/hgnc/14628,CDCA7
+http://purl.obolibrary.org/obo/MONDO_0014829,immunodeficiency-centromeric instability-facial anomalies syndrome 4,http://purl.obolibrary.org/obo/MONDO_0000133,immunodeficiency-centromeric instability-facial anomalies syndrome,http://identifiers.org/hgnc/4861,HELLS
+http://purl.obolibrary.org/obo/MONDO_0012291,immunoglobulin A deficiency 2,http://purl.obolibrary.org/obo/MONDO_0001341,selective IgA deficiency disease,http://identifiers.org/hgnc/18153,TNFRSF13B
+http://purl.obolibrary.org/obo/MONDO_0014178,inclusion body myopathy with early-onset Paget disease with or without frontotemporal dementia 2,http://purl.obolibrary.org/obo/MONDO_0000507,inclusion body myopathy with Paget disease of bone and frontotemporal dementia,http://identifiers.org/hgnc/5033,HNRNPA2B1
+http://purl.obolibrary.org/obo/MONDO_0014179,inclusion body myopathy with early-onset Paget disease with or without frontotemporal dementia 3,http://purl.obolibrary.org/obo/MONDO_0000507,inclusion body myopathy with Paget disease of bone and frontotemporal dementia,http://identifiers.org/hgnc/5031,HNRNPA1
+http://purl.obolibrary.org/obo/MONDO_0014162,infantile hypertrophic cardiomyopathy due to MRPL44 deficiency,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/16650,MRPL44
+http://purl.obolibrary.org/obo/MONDO_0024568,infantile liver failure syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000023,infantile liver failure,http://identifiers.org/hgnc/6512,LARS
+http://purl.obolibrary.org/obo/MONDO_0010060,infantile onset spinocerebellar ataxia,http://purl.obolibrary.org/obo/MONDO_0020046,autosomal recessive degenerative and progressive cerebellar ataxia,http://identifiers.org/hgnc/1160,TWNK
+http://purl.obolibrary.org/obo/MONDO_0009960,inflammatory bowel disease 1,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/5331,NOD2
+http://purl.obolibrary.org/obo/MONDO_0012610,inflammatory bowel disease 10,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/21498,ATG16L1
+http://purl.obolibrary.org/obo/MONDO_0012831,inflammatory bowel disease 13,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/40,ABCB1
+http://purl.obolibrary.org/obo/MONDO_0012832,inflammatory bowel disease 14,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/6120,IRF5
+http://purl.obolibrary.org/obo/MONDO_0012840,inflammatory bowel disease 17,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/19100,IL23R
+http://purl.obolibrary.org/obo/MONDO_0012845,inflammatory bowel disease 19,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/29597,IRGM
+http://purl.obolibrary.org/obo/MONDO_0012941,inflammatory bowel disease 25,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/5965,IL10RB
+http://purl.obolibrary.org/obo/MONDO_0013153,inflammatory bowel disease 28,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease,http://identifiers.org/hgnc/5964,IL10RA
+http://purl.obolibrary.org/obo/MONDO_0013693,"inflammatory skin and bowel disease, neonatal, 1",http://purl.obolibrary.org/obo/MONDO_0017411,neonatal inflammatory skin and bowel disease,http://identifiers.org/hgnc/195,ADAM17
+http://purl.obolibrary.org/obo/MONDO_0014481,"inflammatory skin and bowel disease, neonatal, 2",http://purl.obolibrary.org/obo/MONDO_0017411,neonatal inflammatory skin and bowel disease,http://identifiers.org/hgnc/3236,EGFR
+http://purl.obolibrary.org/obo/MONDO_0010488,"intellectual disability, X-linked 100",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/13339,KIF4A
+http://purl.obolibrary.org/obo/MONDO_0010489,"intellectual disability, X-linked 101",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/7096,MID2
+http://purl.obolibrary.org/obo/MONDO_0010497,"intellectual disability, X-linked 102",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/2745,DDX3X
+http://purl.obolibrary.org/obo/MONDO_0010508,"intellectual disability, X-linked 103; MRX103",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/29347,KLHL15
+http://purl.obolibrary.org/obo/MONDO_0010509,"intellectual disability, X-linked 104; MRX104",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/29007,FRMPD4
+http://purl.obolibrary.org/obo/MONDO_0010510,"intellectual disability, X-linked 105; MRX105",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/13486,USP27X
+http://purl.obolibrary.org/obo/MONDO_0010447,"intellectual disability, X-linked 19",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/10432,RPS6KA3
+http://purl.obolibrary.org/obo/MONDO_0010256,"intellectual disability, X-linked 21",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/5996,IL1RAPL1
+http://purl.obolibrary.org/obo/MONDO_0010361,"intellectual disability, X-linked 30",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/8592,PAK3
+http://purl.obolibrary.org/obo/MONDO_0010451,"intellectual disability, X-linked 41",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/4226,GDI1
+http://purl.obolibrary.org/obo/MONDO_0010344,"intellectual disability, X-linked 45",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/13156,ZNF81
+http://purl.obolibrary.org/obo/MONDO_0010326,"intellectual disability, X-linked 46",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/685,ARHGEF6
+http://purl.obolibrary.org/obo/MONDO_0010266,"intellectual disability, X-linked 58",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/11854,TSPAN7
+http://purl.obolibrary.org/obo/MONDO_0010506,"intellectual disability, X-linked 61; MRX61",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/13429,RLIM
+http://purl.obolibrary.org/obo/MONDO_0010313,"intellectual disability, X-linked 63",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/3571,ACSL4
+http://purl.obolibrary.org/obo/MONDO_0010660,"intellectual disability, X-linked 9",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/13254,FTSJ1
+http://purl.obolibrary.org/obo/MONDO_0010452,"intellectual disability, X-linked 90",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/2902,DLG3
+http://purl.obolibrary.org/obo/MONDO_0010363,"intellectual disability, X-linked 91",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/20342,ZDHHC15
+http://purl.obolibrary.org/obo/MONDO_0010393,"intellectual disability, X-linked 93",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/17342,BRWD3
+http://purl.obolibrary.org/obo/MONDO_0010429,"intellectual disability, X-linked 96",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/11506,SYP
+http://purl.obolibrary.org/obo/MONDO_0010430,"intellectual disability, X-linked 97",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/13128,ZNF711
+http://purl.obolibrary.org/obo/MONDO_0010487,"intellectual disability, X-linked 99",http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://identifiers.org/hgnc/12632,USP9X
+http://purl.obolibrary.org/obo/MONDO_0010502,"intellectual disability, X-linked 99, syndromic, female-restricted; MRXS99F",http://purl.obolibrary.org/obo/MONDO_0020119,X-linked syndromic intellectual disability,http://identifiers.org/hgnc/12632,USP9X
+http://purl.obolibrary.org/obo/MONDO_0010500,"intellectual disability, X-linked, syndromic 33",http://purl.obolibrary.org/obo/MONDO_0020119,X-linked syndromic intellectual disability,http://identifiers.org/hgnc/11535,TAF1
+http://purl.obolibrary.org/obo/MONDO_0007974,"intellectual disability, autosomal dominant 1",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/20444,MBD5
+http://purl.obolibrary.org/obo/MONDO_0013657,"intellectual disability, autosomal dominant 10",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/1406,CACNG2
+http://purl.obolibrary.org/obo/MONDO_0013658,"intellectual disability, autosomal dominant 11",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/3378,EPB41L1
+http://purl.obolibrary.org/obo/MONDO_0013805,"intellectual disability, autosomal dominant 13",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/2961,DYNC1H1
+http://purl.obolibrary.org/obo/MONDO_0013819,"intellectual disability, autosomal dominant 14",http://purl.obolibrary.org/obo/MONDO_0015452,Coffin-Siris syndrome,http://identifiers.org/hgnc/11110,ARID1A
+http://purl.obolibrary.org/obo/MONDO_0013820,"intellectual disability, autosomal dominant 15",http://purl.obolibrary.org/obo/MONDO_0015452,Coffin-Siris syndrome,http://identifiers.org/hgnc/11103,SMARCB1
+http://purl.obolibrary.org/obo/MONDO_0013821,"intellectual disability, autosomal dominant 16",http://purl.obolibrary.org/obo/MONDO_0015452,Coffin-Siris syndrome,http://identifiers.org/hgnc/11100,SMARCA4
+http://purl.obolibrary.org/obo/MONDO_0013581,"intellectual disability, autosomal dominant 2",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/19191,DOCK8
+http://purl.obolibrary.org/obo/MONDO_0013266,"intellectual disability, autosomal dominant 20",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/6996,MEF2C
+http://purl.obolibrary.org/obo/MONDO_0012869,"intellectual disability, autosomal dominant 22",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/13030,ZBTB18
+http://purl.obolibrary.org/obo/MONDO_0014357,"intellectual disability, autosomal dominant 24",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/14677,DEAF1
+http://purl.obolibrary.org/obo/MONDO_0014482,"intellectual disability, autosomal dominant 29",http://purl.obolibrary.org/obo/MONDO_0018574,intellectual disability-expressive aphasia-facial dysmorphism syndrome,http://identifiers.org/hgnc/15573,SETBP1
+http://purl.obolibrary.org/obo/MONDO_0012946,"intellectual disability, autosomal dominant 3",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/1754,CDH15
+http://purl.obolibrary.org/obo/MONDO_0014486,"intellectual disability, autosomal dominant 30",http://purl.obolibrary.org/obo/MONDO_0018574,intellectual disability-expressive aphasia-facial dysmorphism syndrome,http://identifiers.org/hgnc/16966,ZMYND11
+http://purl.obolibrary.org/obo/MONDO_0014580,"intellectual disability, autosomal dominant 33",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/3010,DPP6
+http://purl.obolibrary.org/obo/MONDO_0014599,"intellectual disability, autosomal dominant 34",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/2205,COL4A3BP
+http://purl.obolibrary.org/obo/MONDO_0014617,"intellectual disability, autosomal dominant 38",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/3192,EEF1A2
+http://purl.obolibrary.org/obo/MONDO_0014678,"intellectual disability, autosomal dominant 39",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/7623,MYT1L
+http://purl.obolibrary.org/obo/MONDO_0012947,"intellectual disability, autosomal dominant 4",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/23204,KIRREL3
+http://purl.obolibrary.org/obo/MONDO_0014699,"intellectual disability, autosomal dominant 40",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/20311,CHAMP1
+http://purl.obolibrary.org/obo/MONDO_0014842,"intellectual disability, autosomal dominant 41; MRD41",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/29529,TBL1XR1
+http://purl.obolibrary.org/obo/MONDO_0014855,"intellectual disability, autosomal dominant 42",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/4396,GNB1
+http://purl.obolibrary.org/obo/MONDO_0014858,"intellectual disability, autosomal dominant 43",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/4921,HIVEP2
+http://purl.obolibrary.org/obo/MONDO_0012960,"intellectual disability, autosomal dominant 5",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/11497,SYNGAP1
+http://purl.obolibrary.org/obo/MONDO_0013509,"intellectual disability, autosomal dominant 6",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/4586,GRIN2B
+http://purl.obolibrary.org/obo/MONDO_0013655,"intellectual disability, autosomal dominant 8",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/4584,GRIN1
+http://purl.obolibrary.org/obo/MONDO_0013656,"intellectual disability, autosomal dominant 9",http://purl.obolibrary.org/obo/MONDO_0015802,autosomal dominant non-syndromic intellectual disability,http://identifiers.org/hgnc/888,KIF1A
+http://purl.obolibrary.org/obo/MONDO_0009580,"intellectual disability, autosomal recessive 1",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/9477,PRSS12
+http://purl.obolibrary.org/obo/MONDO_0013173,"intellectual disability, autosomal recessive 13",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/30832,TRAPPC9
+http://purl.obolibrary.org/obo/MONDO_0013528,"intellectual disability, autosomal recessive 14",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/4551,TECR
+http://purl.obolibrary.org/obo/MONDO_0013624,"intellectual disability, autosomal recessive 15",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/6823,MAN1B1
+http://purl.obolibrary.org/obo/MONDO_0013651,"intellectual disability, autosomal recessive 18",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/2372,MED23
+http://purl.obolibrary.org/obo/MONDO_0011828,"intellectual disability, autosomal recessive 2",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/30185,CRBN
+http://purl.obolibrary.org/obo/MONDO_0013702,"intellectual disability, autosomal recessive 27",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/30922,LINS1
+http://purl.obolibrary.org/obo/MONDO_0012037,"intellectual disability, autosomal recessive 3",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/30237,CC2D1A
+http://purl.obolibrary.org/obo/MONDO_0013785,"intellectual disability, autosomal recessive 34",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/2340,CRADD
+http://purl.obolibrary.org/obo/MONDO_0014348,"intellectual disability, autosomal recessive 42",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/25712,PGAP1
+http://purl.obolibrary.org/obo/MONDO_0014354,"intellectual disability, autosomal recessive 43",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/29174,WASHC4
+http://purl.obolibrary.org/obo/MONDO_0014409,"intellectual disability, autosomal recessive 44",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/26988,METTL23
+http://purl.obolibrary.org/obo/MONDO_0014430,"intellectual disability, autosomal recessive 45",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/16510,FBXO31
+http://purl.obolibrary.org/obo/MONDO_0014499,"intellectual disability, autosomal recessive 46",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/7680,NDST1
+http://purl.obolibrary.org/obo/MONDO_0014524,"intellectual disability, autosomal recessive 47",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/14074,FMN2
+http://purl.obolibrary.org/obo/MONDO_0012613,"intellectual disability, autosomal recessive 5",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/25994,NSUN2
+http://purl.obolibrary.org/obo/MONDO_0014649,"intellectual disability, autosomal recessive 50",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/26114,EDC3
+http://purl.obolibrary.org/obo/MONDO_0014759,"intellectual disability, autosomal recessive 51; MRT51",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/5028,HNMT
+http://purl.obolibrary.org/obo/MONDO_0014815,"intellectual disability, autosomal recessive 52",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/19263,LMAN2L
+http://purl.obolibrary.org/obo/MONDO_0014876,"intellectual disability, autosomal recessive 54; MRT54",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/30765,TNIK
+http://purl.obolibrary.org/obo/MONDO_0014930,"intellectual disability, autosomal recessive 56; MRT56",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/20509,ZC3H14
+http://purl.obolibrary.org/obo/MONDO_0014962,"intellectual disability, autosomal recessive 57; MRT57",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/15505,MBOAT7
+http://purl.obolibrary.org/obo/MONDO_0014996,"intellectual disability, autosomal recessive 58; MRT58",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/18248,ELP2
+http://purl.obolibrary.org/obo/MONDO_0015020,"intellectual disability, autosomal recessive 59; MRT59",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/6050,IMPA1
+http://purl.obolibrary.org/obo/MONDO_0012614,"intellectual disability, autosomal recessive 6",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/4580,GRIK2
+http://purl.obolibrary.org/obo/MONDO_0012615,"intellectual disability, autosomal recessive 7",http://purl.obolibrary.org/obo/MONDO_0019502,autosomal recessive non-syndromic intellectual disability,http://identifiers.org/hgnc/30242,TUSC3
+http://purl.obolibrary.org/obo/MONDO_0011176,intestinal hypomagnesemia 1,http://purl.obolibrary.org/obo/MONDO_0018100,primary hypomagnesemia,http://identifiers.org/hgnc/17995,TRPM6
+http://purl.obolibrary.org/obo/MONDO_0013843,intestinal obstruction in the newborn due to guanylate cyclase 2C deficiency,http://purl.obolibrary.org/obo/MONDO_0054868,meconium ileus,http://identifiers.org/hgnc/4688,GUCY2C
+http://purl.obolibrary.org/obo/MONDO_0010387,"invasive pneumococcal disease, recurrent isolated, 2",http://purl.obolibrary.org/obo/MONDO_0000049,"invasive pneumococcal disease, recurrent isolated",http://identifiers.org/hgnc/5961,IKBKG
+http://purl.obolibrary.org/obo/MONDO_0007118,isolated anhidrosis with normal sweat glands,http://purl.obolibrary.org/obo/MONDO_0006527,anhidrosis,http://identifiers.org/hgnc/6181,ITPR2
+http://purl.obolibrary.org/obo/MONDO_0012409,isolated microphthalmia 2,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/1975,VSX2
+http://purl.obolibrary.org/obo/MONDO_0012604,isolated microphthalmia 3,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/18662,RAX
+http://purl.obolibrary.org/obo/MONDO_0013130,isolated microphthalmia 4,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/4221,GDF6
+http://purl.obolibrary.org/obo/MONDO_0012605,isolated microphthalmia 5,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/18121,MFRP
+http://purl.obolibrary.org/obo/MONDO_0013293,isolated microphthalmia 6,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/39433,PRSS56
+http://purl.obolibrary.org/obo/MONDO_0013377,isolated microphthalmia 7,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/4218,GDF3
+http://purl.obolibrary.org/obo/MONDO_0014050,isolated microphthalmia 8,http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://identifiers.org/hgnc/409,ALDH1A3
+http://purl.obolibrary.org/obo/MONDO_0014231,juvenile onset Parkinson disease 19A,http://purl.obolibrary.org/obo/MONDO_0005180,Parkinson disease,http://identifiers.org/hgnc/15469,DNAJC6
+http://purl.obolibrary.org/obo/MONDO_0013898,karyomegalic interstitial nephritis,http://purl.obolibrary.org/obo/MONDO_0001085,interstitial nephritis,http://identifiers.org/hgnc/29170,FAN1
+http://purl.obolibrary.org/obo/MONDO_0007851,keratoconus 1,http://purl.obolibrary.org/obo/MONDO_0015486,keratoconus (disease),http://identifiers.org/hgnc/12723,VSX1
+http://purl.obolibrary.org/obo/MONDO_0013034,keratosis palmoplantaris striata 2,http://purl.obolibrary.org/obo/MONDO_0018865,striate palmoplantar keratoderma,http://identifiers.org/hgnc/3052,DSP
+http://purl.obolibrary.org/obo/MONDO_0011881,keratosis palmoplantaris striata 3,http://purl.obolibrary.org/obo/MONDO_0018865,striate palmoplantar keratoderma,http://identifiers.org/hgnc/6412,KRT1
+http://purl.obolibrary.org/obo/MONDO_0011403,left ventricular noncompaction 1,http://purl.obolibrary.org/obo/MONDO_0018901,left ventricular noncompaction,http://identifiers.org/hgnc/3057,DTNA
+http://purl.obolibrary.org/obo/MONDO_0014163,left ventricular noncompaction 10,http://purl.obolibrary.org/obo/MONDO_0018901,left ventricular noncompaction,http://identifiers.org/hgnc/7551,MYBPC3
+http://purl.obolibrary.org/obo/MONDO_0014042,left ventricular noncompaction 7,http://purl.obolibrary.org/obo/MONDO_0018901,left ventricular noncompaction,http://identifiers.org/hgnc/21086,MIB1
+http://purl.obolibrary.org/obo/MONDO_0014152,left ventricular noncompaction 8,http://purl.obolibrary.org/obo/MONDO_0015470,familial isolated dilated cardiomyopathy,http://identifiers.org/hgnc/14000,PRDM16
+http://purl.obolibrary.org/obo/MONDO_0009518,"leprosy, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0005124,leprosy,http://identifiers.org/hgnc/11848,TLR2
+http://purl.obolibrary.org/obo/MONDO_0012595,"leprosy, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0005124,leprosy,http://identifiers.org/hgnc/6709,LTA
+http://purl.obolibrary.org/obo/MONDO_0013185,"leprosy, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0005124,leprosy,http://identifiers.org/hgnc/11847,TLR1
+http://purl.obolibrary.org/obo/MONDO_0009670,lethal congenital contracture syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/4315,GLE1
+http://purl.obolibrary.org/obo/MONDO_0014965,lethal congenital contracture syndrome 11; LCCS11,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/29514,GLDN
+http://purl.obolibrary.org/obo/MONDO_0011868,lethal congenital contracture syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/3431,ERBB3
+http://purl.obolibrary.org/obo/MONDO_0012656,lethal congenital contracture syndrome 3,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/8996,PIP5K1C
+http://purl.obolibrary.org/obo/MONDO_0013965,lethal congenital contracture syndrome 4,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/7549,MYBPC1
+http://purl.obolibrary.org/obo/MONDO_0014549,lethal congenital contracture syndrome 6,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/32550,ZBTB42
+http://purl.obolibrary.org/obo/MONDO_0014569,lethal congenital contracture syndrome 7,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/8011,CNTNAP1
+http://purl.obolibrary.org/obo/MONDO_0014570,lethal congenital contracture syndrome 8,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/237,ADCY6
+http://purl.obolibrary.org/obo/MONDO_0014670,lethal congenital contracture syndrome 9,http://purl.obolibrary.org/obo/MONDO_0017436,lethal congenital contracture syndrome,http://identifiers.org/hgnc/13841,ADGRG6
+http://purl.obolibrary.org/obo/MONDO_0009867,lethal congenital glycogen storage disease of heart,http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://identifiers.org/hgnc/9386,PRKAG2
+http://purl.obolibrary.org/obo/MONDO_0014976,lethal left ventricular non-compaction-seizures-hypotonia-cataract-developmental delay syndrome,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/7104,MIPEP
+http://purl.obolibrary.org/obo/MONDO_0014241,"leukemia, acute lymphoblastic, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0020511,precursor B-cell acute lymphoblastic leukemia,http://identifiers.org/hgnc/8619,PAX5
+http://purl.obolibrary.org/obo/MONDO_0007293,leukocyte adhesion deficiency 1,http://purl.obolibrary.org/obo/MONDO_0017570,leukocyte adhesion deficiency,http://identifiers.org/hgnc/6155,ITGB2
+http://purl.obolibrary.org/obo/MONDO_0013016,leukocyte adhesion deficiency 3,http://purl.obolibrary.org/obo/MONDO_0017570,leukocyte adhesion deficiency,http://identifiers.org/hgnc/23151,FERMT3
+http://purl.obolibrary.org/obo/MONDO_0013971,leukoencephalopathy-thalamus and brainstem anomalies-high lactate syndrome,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/29419,EARS2
+http://purl.obolibrary.org/obo/MONDO_0024552,linear skin defects with multiple congenital anomalies 1,http://purl.obolibrary.org/obo/MONDO_0010672,microphthalmia with linear skin defects syndrome,http://identifiers.org/hgnc/4837,HCCS
+http://purl.obolibrary.org/obo/MONDO_0010474,linear skin defects with multiple congenital anomalies 2,http://purl.obolibrary.org/obo/MONDO_0010672,microphthalmia with linear skin defects syndrome,http://identifiers.org/hgnc/2291,COX7B
+http://purl.obolibrary.org/obo/MONDO_0010494,linear skin defects with multiple congenital anomalies 3,http://purl.obolibrary.org/obo/MONDO_0010672,microphthalmia with linear skin defects syndrome,http://identifiers.org/hgnc/20372,NDUFB11
+http://purl.obolibrary.org/obo/MONDO_0013527,lissencephaly 4,http://purl.obolibrary.org/obo/MONDO_0018838,lissencephaly (disease),http://identifiers.org/hgnc/17619,NDE1
+http://purl.obolibrary.org/obo/MONDO_0014534,lissencephaly 6 with microcephaly,http://purl.obolibrary.org/obo/MONDO_0015204,microlissencephaly,http://identifiers.org/hgnc/6217,KATNB1
+http://purl.obolibrary.org/obo/MONDO_0014992,lissencephaly 8; LIS8,http://purl.obolibrary.org/obo/MONDO_0018838,lissencephaly (disease),http://identifiers.org/hgnc/26899,TMTC3
+http://purl.obolibrary.org/obo/MONDO_0012737,long QT syndrome 10,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/10592,SCN4B
+http://purl.obolibrary.org/obo/MONDO_0012738,long QT syndrome 11,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/379,AKAP9
+http://purl.obolibrary.org/obo/MONDO_0013062,long QT syndrome 12,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/11167,SNTA1
+http://purl.obolibrary.org/obo/MONDO_0013279,long QT syndrome 13,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/6266,KCNJ5
+http://purl.obolibrary.org/obo/MONDO_0014548,long QT syndrome 14,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/1442,CALM1
+http://purl.obolibrary.org/obo/MONDO_0014550,long QT syndrome 15,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/1445,CALM2
+http://purl.obolibrary.org/obo/MONDO_0011377,long QT syndrome 3,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/10593,SCN5A
+http://purl.obolibrary.org/obo/MONDO_0013372,long QT syndrome 5,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/6240,KCNE1
+http://purl.obolibrary.org/obo/MONDO_0013370,long QT syndrome 6,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/6242,KCNE2
+http://purl.obolibrary.org/obo/MONDO_0012736,long QT syndrome 9,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome,http://identifiers.org/hgnc/1529,CAV3
+http://purl.obolibrary.org/obo/MONDO_0007919,"lymphedema, hereditary, 1A",http://purl.obolibrary.org/obo/MONDO_0019313,hereditary lymphedema,http://identifiers.org/hgnc/3767,FLT4
+http://purl.obolibrary.org/obo/MONDO_0013278,"lymphedema, hereditary, 1C",http://purl.obolibrary.org/obo/MONDO_0019313,hereditary lymphedema,http://identifiers.org/hgnc/17494,GJC2
+http://purl.obolibrary.org/obo/MONDO_0014393,"lymphedema, hereditary, 1D",http://purl.obolibrary.org/obo/MONDO_0019313,hereditary lymphedema,http://identifiers.org/hgnc/12682,VEGFC
+http://purl.obolibrary.org/obo/MONDO_0013081,lymphoproliferative syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016537,lymphoproliferative syndrome,http://identifiers.org/hgnc/6171,ITK
+http://purl.obolibrary.org/obo/MONDO_0014054,lymphoproliferative syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016537,lymphoproliferative syndrome,http://identifiers.org/hgnc/11922,CD27
+http://purl.obolibrary.org/obo/MONDO_0012145,"macular degeneration, age-related, 3",http://purl.obolibrary.org/obo/MONDO_0005150,age-related macular degeneration,http://identifiers.org/hgnc/3602,FBLN5
+http://purl.obolibrary.org/obo/MONDO_0024561,"macular dystrophy, vitelliform, 3",http://purl.obolibrary.org/obo/MONDO_0000390,vitelliform macular dystrophy,http://identifiers.org/hgnc/9942,PRPH2
+http://purl.obolibrary.org/obo/MONDO_0014508,"macular dystrophy, vitelliform, 4",http://purl.obolibrary.org/obo/MONDO_0000390,vitelliform macular dystrophy,http://identifiers.org/hgnc/6055,IMPG1
+http://purl.obolibrary.org/obo/MONDO_0014509,"macular dystrophy, vitelliform, 5",http://purl.obolibrary.org/obo/MONDO_0000390,vitelliform macular dystrophy,http://identifiers.org/hgnc/18362,IMPG2
+http://purl.obolibrary.org/obo/MONDO_0007783,"malignant hyperthermia, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0018493,malignant hyperthermia of anesthesia,http://identifiers.org/hgnc/10483,RYR1
+http://purl.obolibrary.org/obo/MONDO_0011163,"malignant hyperthermia, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0018493,malignant hyperthermia of anesthesia,http://identifiers.org/hgnc/1397,CACNA1S
+http://purl.obolibrary.org/obo/MONDO_0013240,maturity-onset diabetes of the young type 10,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/6081,INS
+http://purl.obolibrary.org/obo/MONDO_0013242,maturity-onset diabetes of the young type 11,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/1057,BLK
+http://purl.obolibrary.org/obo/MONDO_0014589,maturity-onset diabetes of the young type 13,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/6257,KCNJ11
+http://purl.obolibrary.org/obo/MONDO_0014674,maturity-onset diabetes of the young type 14,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/24035,APPL1
+http://purl.obolibrary.org/obo/MONDO_0007453,maturity-onset diabetes of the young type 2,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/4195,GCK
+http://purl.obolibrary.org/obo/MONDO_0010894,maturity-onset diabetes of the young type 3,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/11621,HNF1A
+http://purl.obolibrary.org/obo/MONDO_0011667,maturity-onset diabetes of the young type 4,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/6107,PDX1
+http://purl.obolibrary.org/obo/MONDO_0011668,maturity-onset diabetes of the young type 6,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/7762,NEUROD1
+http://purl.obolibrary.org/obo/MONDO_0012513,maturity-onset diabetes of the young type 7,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/11811,KLF11
+http://purl.obolibrary.org/obo/MONDO_0012348,maturity-onset diabetes of the young type 8,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/1848,CEL
+http://purl.obolibrary.org/obo/MONDO_0012818,maturity-onset diabetes of the young type 9,http://purl.obolibrary.org/obo/MONDO_0018911,maturity-onset diabetes of the young (disease),http://identifiers.org/hgnc/8618,PAX4
+http://purl.obolibrary.org/obo/MONDO_0011313,megalencephaly-polymicrogyria-polydactyly-hydrocephalus syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019375,megalencephaly-polymicrogyria-postaxial polydactyly-hydrocephalus syndrome,http://identifiers.org/hgnc/8980,PIK3R2
+http://purl.obolibrary.org/obo/MONDO_0014407,megalencephaly-polymicrogyria-polydactyly-hydrocephalus syndrome 2,http://purl.obolibrary.org/obo/MONDO_0019375,megalencephaly-polymicrogyria-postaxial polydactyly-hydrocephalus syndrome,http://identifiers.org/hgnc/393,AKT3
+http://purl.obolibrary.org/obo/MONDO_0014408,megalencephaly-polymicrogyria-polydactyly-hydrocephalus syndrome 3,http://purl.obolibrary.org/obo/MONDO_0019375,megalencephaly-polymicrogyria-postaxial polydactyly-hydrocephalus syndrome,http://identifiers.org/hgnc/1583,CCND2
+http://purl.obolibrary.org/obo/MONDO_0013113,metaphyseal anadysplasia 2,http://purl.obolibrary.org/obo/MONDO_0015177,metaphyseal anadysplasia,http://identifiers.org/hgnc/7176,MMP9
+http://purl.obolibrary.org/obo/MONDO_0009605,methemoglobinemia type 4,http://purl.obolibrary.org/obo/MONDO_0001117,methemoglobinemia,http://identifiers.org/hgnc/2570,CYB5A
+http://purl.obolibrary.org/obo/MONDO_0013341,methylmalonic acidemia due to transcobalamin receptor defect,http://purl.obolibrary.org/obo/MONDO_0002012,methylmalonic acidemia,http://identifiers.org/hgnc/16692,CD320
+http://purl.obolibrary.org/obo/MONDO_0009617,"microcephaly 1, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/6954,MCPH1
+http://purl.obolibrary.org/obo/MONDO_0014173,"microcephaly 11, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/3182,PHC1
+http://purl.obolibrary.org/obo/MONDO_0014484,"microcephaly 12, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/1777,CDK6
+http://purl.obolibrary.org/obo/MONDO_0014473,"microcephaly 13, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/1856,CENPE
+http://purl.obolibrary.org/obo/MONDO_0014623,"microcephaly 14, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/25403,SASS6
+http://purl.obolibrary.org/obo/MONDO_0014908,"microcephaly 17, primary, autosomal recessive; MCPH17",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/1985,CIT
+http://purl.obolibrary.org/obo/MONDO_0011488,"microcephaly 3, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/18672,CDK5RAP2
+http://purl.obolibrary.org/obo/MONDO_0012106,"microcephaly 5, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/19048,ASPM
+http://purl.obolibrary.org/obo/MONDO_0012029,"microcephaly 6, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/17272,CENPJ
+http://purl.obolibrary.org/obo/MONDO_0012989,"microcephaly 7, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/10879,STIL
+http://purl.obolibrary.org/obo/MONDO_0013849,"microcephaly 8, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/29086,CEP135
+http://purl.obolibrary.org/obo/MONDO_0013923,"microcephaly 9, primary, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0016660,autosomal recessive primary microcephaly,http://identifiers.org/hgnc/29298,CEP152
+http://purl.obolibrary.org/obo/MONDO_0009624,microcephaly and chorioretinopathy 1,http://purl.obolibrary.org/obo/MONDO_0000181,microcephaly and chorioretinopathy,http://identifiers.org/hgnc/18127,TUBGCP6
+http://purl.obolibrary.org/obo/MONDO_0014516,microcephaly and chorioretinopathy 2,http://purl.obolibrary.org/obo/MONDO_0000181,microcephaly and chorioretinopathy,http://identifiers.org/hgnc/11397,PLK4
+http://purl.obolibrary.org/obo/MONDO_0014592,microcephaly and chorioretinopathy 3,http://purl.obolibrary.org/obo/MONDO_0000181,microcephaly and chorioretinopathy,http://identifiers.org/hgnc/16691,TUBGCP4
+http://purl.obolibrary.org/obo/MONDO_0014785,"microcephaly, short stature, and impaired glucose metabolism 2; MSSGM2",http://purl.obolibrary.org/obo/MONDO_0000208,"microcephaly, short stature, and impaired glucose metabolism",http://identifiers.org/hgnc/14951,PPP1R15B
+http://purl.obolibrary.org/obo/MONDO_0014635,"microphthalmia, isolated, with coloboma 10",http://purl.obolibrary.org/obo/MONDO_0000170,"microphthalmia, isolated, with coloboma",http://identifiers.org/hgnc/9922,RBP4
+http://purl.obolibrary.org/obo/MONDO_0012408,"microphthalmia, isolated, with coloboma 3",http://purl.obolibrary.org/obo/MONDO_0000170,"microphthalmia, isolated, with coloboma",http://identifiers.org/hgnc/1975,VSX2
+http://purl.obolibrary.org/obo/MONDO_0012709,"microphthalmia, isolated, with coloboma 5",http://purl.obolibrary.org/obo/MONDO_0000170,"microphthalmia, isolated, with coloboma",http://identifiers.org/hgnc/10848,SHH
+http://purl.obolibrary.org/obo/MONDO_0013783,"microphthalmia, isolated, with coloboma 7",http://purl.obolibrary.org/obo/MONDO_0000170,"microphthalmia, isolated, with coloboma",http://identifiers.org/hgnc/47,ABCB6
+http://purl.obolibrary.org/obo/MONDO_0014059,"microphthalmia, isolated, with coloboma 9",http://purl.obolibrary.org/obo/MONDO_0000170,"microphthalmia, isolated, with coloboma",http://identifiers.org/hgnc/29944,TENM3
+http://purl.obolibrary.org/obo/MONDO_0013734,"microphthalmia, syndromic 11",http://purl.obolibrary.org/obo/MONDO_0016073,syndromic microphthalmia,http://identifiers.org/hgnc/12660,VAX1
+http://purl.obolibrary.org/obo/MONDO_0014229,"microphthalmia, syndromic 12",http://purl.obolibrary.org/obo/MONDO_0016073,syndromic microphthalmia,http://identifiers.org/hgnc/9865,RARB
+http://purl.obolibrary.org/obo/MONDO_0011386,"microvascular complications of diabetes, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/12680,VEGFA
+http://purl.obolibrary.org/obo/MONDO_0012962,"microvascular complications of diabetes, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/3415,EPO
+http://purl.obolibrary.org/obo/MONDO_0012963,"microvascular complications of diabetes, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/2707,ACE
+http://purl.obolibrary.org/obo/MONDO_0012966,"microvascular complications of diabetes, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/6000,IL1RN
+http://purl.obolibrary.org/obo/MONDO_0012969,"microvascular complications of diabetes, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/9204,PON1
+http://purl.obolibrary.org/obo/MONDO_0012970,"microvascular complications of diabetes, susceptibility to, 6",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/11180,SOD2
+http://purl.obolibrary.org/obo/MONDO_0012971,"microvascular complications of diabetes, susceptibility to, 7",http://purl.obolibrary.org/obo/MONDO_0000065,"microvascular complications of diabetes, susceptibility",http://identifiers.org/hgnc/4886,HFE
+http://purl.obolibrary.org/obo/MONDO_0009635,microvillus inclusion disease,http://purl.obolibrary.org/obo/MONDO_0000249,secretory diarrhea,http://identifiers.org/hgnc/7603,MYO5B
+http://purl.obolibrary.org/obo/MONDO_0007714,"migraine, familial hemiplegic, 1",http://purl.obolibrary.org/obo/MONDO_0005277,migraine disorder,http://identifiers.org/hgnc/1388,CACNA1A
+http://purl.obolibrary.org/obo/MONDO_0011232,"migraine, familial hemiplegic, 2",http://purl.obolibrary.org/obo/MONDO_0018925,familial or sporadic hemiplegic migraine,http://identifiers.org/hgnc/800,ATP1A2
+http://purl.obolibrary.org/obo/MONDO_0012320,"migraine, familial hemiplegic, 3",http://purl.obolibrary.org/obo/MONDO_0018925,familial or sporadic hemiplegic migraine,http://identifiers.org/hgnc/10585,SCN1A
+http://purl.obolibrary.org/obo/MONDO_0013344,"migraine, with or without aura, susceptibility to, 13",http://purl.obolibrary.org/obo/MONDO_0005277,migraine disorder,http://identifiers.org/hgnc/19439,KCNK18
+http://purl.obolibrary.org/obo/MONDO_0008002,mirror movements 1,http://purl.obolibrary.org/obo/MONDO_0016558,familial congenital mirror movements,http://identifiers.org/hgnc/2701,DCC
+http://purl.obolibrary.org/obo/MONDO_0013790,mirror movements 2,http://purl.obolibrary.org/obo/MONDO_0016558,familial congenital mirror movements,http://identifiers.org/hgnc/9817,RAD51
+http://purl.obolibrary.org/obo/MONDO_0014478,mirror movements 3,http://purl.obolibrary.org/obo/MONDO_0016558,familial congenital mirror movements,http://identifiers.org/hgnc/2955,DNAL4
+http://purl.obolibrary.org/obo/MONDO_0014039,mitochondrial DNA depletion syndrome 11,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/16205,MGME1
+http://purl.obolibrary.org/obo/MONDO_0014198,mitochondrial DNA depletion syndrome 13,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/13601,FBXL4
+http://purl.obolibrary.org/obo/MONDO_0014820,mitochondrial DNA depletion syndrome 14 (cardioencephalomyopathic type); MTDPS14,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/8140,OPA1
+http://purl.obolibrary.org/obo/MONDO_0014943,mitochondrial DNA depletion syndrome 15 (hepatocerebral type);,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/11741,TFAM
+http://purl.obolibrary.org/obo/MONDO_0009636,mitochondrial DNA depletion syndrome 3,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/2858,DGUOK
+http://purl.obolibrary.org/obo/MONDO_0012792,mitochondrial DNA depletion syndrome 8a,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/17296,RRM2B
+http://purl.obolibrary.org/obo/MONDO_0009504,mitochondrial DNA depletion syndrome 9,http://purl.obolibrary.org/obo/MONDO_0018158,mitochondrial DNA depletion syndrome,http://identifiers.org/hgnc/11449,SUCLG1
+http://purl.obolibrary.org/obo/MONDO_0007415,mitochondrial complex III deficiency nuclear type 1,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/1020,BCS1L
+http://purl.obolibrary.org/obo/MONDO_0014063,mitochondrial complex III deficiency nuclear type 2,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/26006,TTC19
+http://purl.obolibrary.org/obo/MONDO_0014064,mitochondrial complex III deficiency nuclear type 3,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/12582,UQCRB
+http://purl.obolibrary.org/obo/MONDO_0014065,mitochondrial complex III deficiency nuclear type 4,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/29594,UQCRQ
+http://purl.obolibrary.org/obo/MONDO_0014066,mitochondrial complex III deficiency nuclear type 5,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/12586,UQCRC2
+http://purl.obolibrary.org/obo/MONDO_0014194,mitochondrial complex III deficiency nuclear type 6,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/2579,CYC1
+http://purl.obolibrary.org/obo/MONDO_0014356,mitochondrial complex III deficiency nuclear type 7,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/21237,UQCC2
+http://purl.obolibrary.org/obo/MONDO_0014364,mitochondrial complex III deficiency nuclear type 8,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/28072,LYRM7
+http://purl.obolibrary.org/obo/MONDO_0014496,mitochondrial complex III deficiency nuclear type 9,http://purl.obolibrary.org/obo/MONDO_0015448,mitochondrial complex III deficiency,http://identifiers.org/hgnc/34399,UQCC3
+http://purl.obolibrary.org/obo/MONDO_0013547,mitochondrial complex V (ATP synthase) deficiency nuclear type 3,http://purl.obolibrary.org/obo/MONDO_0014471,mitochondrial proton-transporting ATP synthase complex deficiency,http://identifiers.org/hgnc/838,ATP5F1E
+http://purl.obolibrary.org/obo/MONDO_0011421,"mitochondrial complex V (ATP synthase) deficiency, nuclear type 1",http://purl.obolibrary.org/obo/MONDO_0014471,mitochondrial proton-transporting ATP synthase complex deficiency,http://identifiers.org/hgnc/18802,ATPAF2
+http://purl.obolibrary.org/obo/MONDO_0014091,mitochondrial complex v (ATP synthase) deficiency nuclear type 4,http://purl.obolibrary.org/obo/MONDO_0000066,mitochondrial complex deficiency,http://identifiers.org/hgnc/823,ATP5F1A
+http://purl.obolibrary.org/obo/MONDO_0013865,mitochondrial hypertrophic cardiomyopathy with lactic acidosis due to MTO1 deficiency,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/19261,MTO1
+http://purl.obolibrary.org/obo/MONDO_0009759,mosaic variegated aneuploidy syndrome 1,http://purl.obolibrary.org/obo/MONDO_0000141,mosaic variegated aneuploidy syndrome,http://identifiers.org/hgnc/1149,BUB1B
+http://purl.obolibrary.org/obo/MONDO_0013582,mosaic variegated aneuploidy syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000141,mosaic variegated aneuploidy syndrome,http://identifiers.org/hgnc/30794,CEP57
+http://purl.obolibrary.org/obo/MONDO_0013563,multiple congenital anomalies-hypotonia-seizures syndrome 1,http://purl.obolibrary.org/obo/MONDO_0015159,multiple congenital anomalies/dysmorphic syndrome-intellectual disability,http://identifiers.org/hgnc/8967,PIGN
+http://purl.obolibrary.org/obo/MONDO_0010466,multiple congenital anomalies-hypotonia-seizures syndrome 2,http://purl.obolibrary.org/obo/MONDO_0015159,multiple congenital anomalies/dysmorphic syndrome-intellectual disability,http://identifiers.org/hgnc/8957,PIGA
+http://purl.obolibrary.org/obo/MONDO_0014165,multiple congenital anomalies-hypotonia-seizures syndrome 3,http://purl.obolibrary.org/obo/MONDO_0015159,multiple congenital anomalies/dysmorphic syndrome-intellectual disability,http://identifiers.org/hgnc/14938,PIGT
+http://purl.obolibrary.org/obo/MONDO_0007540,multiple endocrine neoplasia type 1,http://purl.obolibrary.org/obo/MONDO_0017169,multiple endocrine neoplasia,http://identifiers.org/hgnc/7010,MEN1
+http://purl.obolibrary.org/obo/MONDO_0012552,multiple endocrine neoplasia type 4,http://purl.obolibrary.org/obo/MONDO_0017169,multiple endocrine neoplasia,http://identifiers.org/hgnc/1785,CDKN1B
+http://purl.obolibrary.org/obo/MONDO_0007561,multiple epiphyseal dysplasia type 1,http://purl.obolibrary.org/obo/MONDO_0016648,multiple epiphyseal dysplasia (disease),http://identifiers.org/hgnc/2227,COMP
+http://purl.obolibrary.org/obo/MONDO_0009189,multiple epiphyseal dysplasia type 4,http://purl.obolibrary.org/obo/MONDO_0016648,multiple epiphyseal dysplasia (disease),http://identifiers.org/hgnc/10994,SLC26A2
+http://purl.obolibrary.org/obo/MONDO_0011765,multiple epiphyseal dysplasia type 5,http://purl.obolibrary.org/obo/MONDO_0016648,multiple epiphyseal dysplasia (disease),http://identifiers.org/hgnc/6909,MATN3
+http://purl.obolibrary.org/obo/MONDO_0011582,multiple mitochondrial dysfunctions syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017338,fatal multiple mitochondrial dysfunctions syndrome,http://identifiers.org/hgnc/16287,NFU1
+http://purl.obolibrary.org/obo/MONDO_0013675,multiple mitochondrial dysfunctions syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017338,fatal multiple mitochondrial dysfunctions syndrome,http://identifiers.org/hgnc/24415,BOLA3
+http://purl.obolibrary.org/obo/MONDO_0014132,multiple mitochondrial dysfunctions syndrome 3,http://purl.obolibrary.org/obo/MONDO_0017338,fatal multiple mitochondrial dysfunctions syndrome,http://identifiers.org/hgnc/27302,IBA57
+http://purl.obolibrary.org/obo/MONDO_0014611,multiple mitochondrial dysfunctions syndrome 4,http://purl.obolibrary.org/obo/MONDO_0017338,fatal multiple mitochondrial dysfunctions syndrome,http://identifiers.org/hgnc/19857,ISCA2
+http://purl.obolibrary.org/obo/MONDO_0013893,"multiple sclerosis, susceptibility to, 5",http://purl.obolibrary.org/obo/MONDO_0007462,"multiple sclerosis, susceptibility to",http://identifiers.org/hgnc/11916,TNFRSF1A
+http://purl.obolibrary.org/obo/MONDO_0008519,multiple synostoses syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017923,multiple synostoses syndrome,http://identifiers.org/hgnc/7866,NOG
+http://purl.obolibrary.org/obo/MONDO_0012394,multiple synostoses syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017923,multiple synostoses syndrome,http://identifiers.org/hgnc/4220,GDF5
+http://purl.obolibrary.org/obo/MONDO_0013064,multiple synostoses syndrome 3,http://purl.obolibrary.org/obo/MONDO_0017923,multiple synostoses syndrome,http://identifiers.org/hgnc/3687,FGF9
+http://purl.obolibrary.org/obo/MONDO_0014022,"muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type a, 10",http://purl.obolibrary.org/obo/MONDO_0000171,"muscular dystrophy-dystroglycanopathy, type A",http://identifiers.org/hgnc/13530,RXYLT1
+http://purl.obolibrary.org/obo/MONDO_0014071,"muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type a, 11",http://purl.obolibrary.org/obo/MONDO_0000171,"muscular dystrophy-dystroglycanopathy, type A",http://identifiers.org/hgnc/28596,B3GALNT2
+http://purl.obolibrary.org/obo/MONDO_0014101,"muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type a, 12",http://purl.obolibrary.org/obo/MONDO_0000171,"muscular dystrophy-dystroglycanopathy, type A",http://identifiers.org/hgnc/26267,POMK
+http://purl.obolibrary.org/obo/MONDO_0013835,"muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type a, 7",http://purl.obolibrary.org/obo/MONDO_0000171,"muscular dystrophy-dystroglycanopathy, type A",http://identifiers.org/hgnc/37276,ISPD
+http://purl.obolibrary.org/obo/MONDO_0013904,"muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type a, 8",http://purl.obolibrary.org/obo/MONDO_0000171,"muscular dystrophy-dystroglycanopathy, type A",http://identifiers.org/hgnc/25902,POMGNT2
+http://purl.obolibrary.org/obo/MONDO_0014620,myoclonic dystonia 26,http://purl.obolibrary.org/obo/MONDO_0000903,myoclonus-dystonia syndrome,http://identifiers.org/hgnc/25705,KCTD17
+http://purl.obolibrary.org/obo/MONDO_0011076,myofibrillar myopathy 1,http://purl.obolibrary.org/obo/MONDO_0018943,myofibrillar myopathy (disease),http://identifiers.org/hgnc/2770,DES
+http://purl.obolibrary.org/obo/MONDO_0012130,myofibrillar myopathy 2,http://purl.obolibrary.org/obo/MONDO_0016108,autosomal dominant distal myopathy,http://identifiers.org/hgnc/2389,CRYAB
+http://purl.obolibrary.org/obo/MONDO_0012215,myofibrillar myopathy 3,http://purl.obolibrary.org/obo/MONDO_0016108,autosomal dominant distal myopathy,http://identifiers.org/hgnc/12399,MYOT
+http://purl.obolibrary.org/obo/MONDO_0012277,myofibrillar myopathy 4,http://purl.obolibrary.org/obo/MONDO_0018943,myofibrillar myopathy (disease),http://identifiers.org/hgnc/15710,LDB3
+http://purl.obolibrary.org/obo/MONDO_0012289,myofibrillar myopathy 5,http://purl.obolibrary.org/obo/MONDO_0018943,myofibrillar myopathy (disease),http://identifiers.org/hgnc/3756,FLNC
+http://purl.obolibrary.org/obo/MONDO_0013061,myofibrillar myopathy 6,http://purl.obolibrary.org/obo/MONDO_0018943,myofibrillar myopathy (disease),http://identifiers.org/hgnc/939,BAG3
+http://purl.obolibrary.org/obo/MONDO_0014922,myofibrillar myopathy 7,http://purl.obolibrary.org/obo/MONDO_0018943,myofibrillar myopathy (disease),http://identifiers.org/hgnc/26576,KY
+http://purl.obolibrary.org/obo/MONDO_0014993,myofibrillar myopathy 8,http://purl.obolibrary.org/obo/MONDO_0018943,myofibrillar myopathy (disease),http://identifiers.org/hgnc/26162,PYROXD1
+http://purl.obolibrary.org/obo/MONDO_0009227,"myofibromatosis, infantile, 1",http://purl.obolibrary.org/obo/MONDO_0016824,myofibromatosis,http://identifiers.org/hgnc/8804,PDGFRB
+http://purl.obolibrary.org/obo/MONDO_0014122,"myofibromatosis, infantile, 2",http://purl.obolibrary.org/obo/MONDO_0016824,myofibromatosis,http://identifiers.org/hgnc/7883,NOTCH3
+http://purl.obolibrary.org/obo/MONDO_0009709,"myopathy, centronuclear, 2",http://purl.obolibrary.org/obo/MONDO_0018947,centronuclear myopathy,http://identifiers.org/hgnc/1052,BIN1
+http://purl.obolibrary.org/obo/MONDO_0013736,"myopathy, centronuclear, 3",http://purl.obolibrary.org/obo/MONDO_0008048,autosomal dominant centronuclear myopathy,http://identifiers.org/hgnc/7566,MYF6
+http://purl.obolibrary.org/obo/MONDO_0014418,"myopathy, centronuclear, 5",http://purl.obolibrary.org/obo/MONDO_0015705,autosomal recessive centronuclear myopathy,http://identifiers.org/hgnc/16901,SPEG
+http://purl.obolibrary.org/obo/MONDO_0014877,"myopathy, distal, 5; MPD5",http://purl.obolibrary.org/obo/MONDO_0018949,distal myopathy,http://identifiers.org/hgnc/20093,ADSSL1
+http://purl.obolibrary.org/obo/MONDO_0024553,"myopathy, lactic acidosis, and sideroblastic anemia 1",http://purl.obolibrary.org/obo/MONDO_0000863,"myopathy, lactic acidosis, and sideroblastic anemia",http://identifiers.org/hgnc/15508,PUS1
+http://purl.obolibrary.org/obo/MONDO_0013307,"myopathy, lactic acidosis, and sideroblastic anemia 2",http://purl.obolibrary.org/obo/MONDO_0010892,mitochondrial myopathy and sideroblastic anemia,http://identifiers.org/hgnc/24249,YARS2
+http://purl.obolibrary.org/obo/MONDO_0024531,"myopathy, tubular aggregate, 1",http://purl.obolibrary.org/obo/MONDO_0008051,tubular aggregate myopathy,http://identifiers.org/hgnc/11386,STIM1
+http://purl.obolibrary.org/obo/MONDO_0014383,"myopathy, tubular aggregate, 2",http://purl.obolibrary.org/obo/MONDO_0008051,tubular aggregate myopathy,http://identifiers.org/hgnc/25896,ORAI1
+http://purl.obolibrary.org/obo/MONDO_0013604,"myopia 21, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0001384,myopia (disease),http://identifiers.org/hgnc/29222,ZNF644
+http://purl.obolibrary.org/obo/MONDO_0014982,"myopia 25, autosomal dominant; MYP25",http://purl.obolibrary.org/obo/MONDO_0001384,myopia (disease),http://identifiers.org/hgnc/8547,P4HA2
+http://purl.obolibrary.org/obo/MONDO_0012154,myopia 6,http://purl.obolibrary.org/obo/MONDO_0001384,myopia (disease),http://identifiers.org/hgnc/10604,SCO2
+http://purl.obolibrary.org/obo/MONDO_0008056,myotonic dystrophy type 1,http://purl.obolibrary.org/obo/MONDO_0016107,myotonic dystrophy,http://identifiers.org/hgnc/2933,DMPK
+http://purl.obolibrary.org/obo/MONDO_0011266,myotonic dystrophy type 2,http://purl.obolibrary.org/obo/MONDO_0016107,myotonic dystrophy,http://identifiers.org/hgnc/13164,CNBP
+http://purl.obolibrary.org/obo/MONDO_0012299,nanophthalmos 2,http://purl.obolibrary.org/obo/MONDO_0005514,nanophthalmia,http://identifiers.org/hgnc/18121,MFRP
+http://purl.obolibrary.org/obo/MONDO_0014426,nanophthalmos 4,http://purl.obolibrary.org/obo/MONDO_0005514,nanophthalmia,http://identifiers.org/hgnc/24529,TMEM98
+http://purl.obolibrary.org/obo/MONDO_0008062,narcolepsy 1,http://purl.obolibrary.org/obo/MONDO_0021107,narcolepsy,http://identifiers.org/hgnc/4847,HCRT
+http://purl.obolibrary.org/obo/MONDO_0013652,narcolepsy 7,http://purl.obolibrary.org/obo/MONDO_0021107,narcolepsy,http://identifiers.org/hgnc/7197,MOG
+http://purl.obolibrary.org/obo/MONDO_0011775,"nasopharyngeal carcinoma, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0015459,nasopharyngeal carcinoma,http://identifiers.org/hgnc/11998,TP53
+http://purl.obolibrary.org/obo/MONDO_0014902,"nasopharyngeal carcinoma, susceptibility to, 3; NPCA3",http://purl.obolibrary.org/obo/MONDO_0015459,nasopharyngeal carcinoma,http://identifiers.org/hgnc/7381,MST1R
+http://purl.obolibrary.org/obo/MONDO_0012239,nemaline myopathy 1,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/12012,TPM3
+http://purl.obolibrary.org/obo/MONDO_0014513,nemaline myopathy 10,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/6649,LMOD3
+http://purl.obolibrary.org/obo/MONDO_0015023,nemaline myopathy 11,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/23246,MYPN
+http://purl.obolibrary.org/obo/MONDO_0009725,nemaline myopathy 2,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/7720,NEB
+http://purl.obolibrary.org/obo/MONDO_0008070,nemaline myopathy 3,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/129,ACTA1
+http://purl.obolibrary.org/obo/MONDO_0012240,nemaline myopathy 4,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/12011,TPM2
+http://purl.obolibrary.org/obo/MONDO_0011539,nemaline myopathy 5,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/11948,TNNT1
+http://purl.obolibrary.org/obo/MONDO_0012237,nemaline myopathy 6,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/37227,KBTBD13
+http://purl.obolibrary.org/obo/MONDO_0012538,nemaline myopathy 7,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/1875,CFL2
+http://purl.obolibrary.org/obo/MONDO_0014138,nemaline myopathy 8,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/30372,KLHL40
+http://purl.obolibrary.org/obo/MONDO_0014326,nemaline myopathy 9,http://purl.obolibrary.org/obo/MONDO_0018958,nemaline myopathy,http://identifiers.org/hgnc/16905,KLHL41
+http://purl.obolibrary.org/obo/MONDO_0014775,neonatal severe cardiopulmonary failure due to mitochondrial methylation defect,http://purl.obolibrary.org/obo/MONDO_0000732,combined oxidative phosphorylation deficiency,http://identifiers.org/hgnc/20661,SLC25A26
+http://purl.obolibrary.org/obo/MONDO_0009728,nephronophthisis 1,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/7905,NPHP1
+http://purl.obolibrary.org/obo/MONDO_0013442,nephronophthisis 12,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/25660,TTC21B
+http://purl.obolibrary.org/obo/MONDO_0013916,nephronophthisis 14,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/16762,ZNF423
+http://purl.obolibrary.org/obo/MONDO_0013917,nephronophthisis 15,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/29182,CEP164
+http://purl.obolibrary.org/obo/MONDO_0014158,nephronophthisis 16,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/26724,ANKS6
+http://purl.obolibrary.org/obo/MONDO_0014374,nephronophthisis 18,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/17966,CEP83
+http://purl.obolibrary.org/obo/MONDO_0014537,nephronophthisis 19,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/18141,DCDC2
+http://purl.obolibrary.org/obo/MONDO_0011190,nephronophthisis 2,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/17870,INVS
+http://purl.obolibrary.org/obo/MONDO_0014997,nephronophthisis 20,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/29536,MAPKBP1
+http://purl.obolibrary.org/obo/MONDO_0011456,nephronophthisis 3,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/7907,NPHP3
+http://purl.obolibrary.org/obo/MONDO_0011752,nephronophthisis 4,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/19104,NPHP4
+http://purl.obolibrary.org/obo/MONDO_0012680,nephronophthisis 7,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/29450,GLIS2
+http://purl.obolibrary.org/obo/MONDO_0013444,nephronophthisis 9,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/13387,NEK8
+http://purl.obolibrary.org/obo/MONDO_0013163,nephronophthisis-like nephropathy 1,http://purl.obolibrary.org/obo/MONDO_0019005,nephronophthisis (disease),http://identifiers.org/hgnc/28052,XPNPEP3
+http://purl.obolibrary.org/obo/MONDO_0014373,"nephrotic syndrome, type 10",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/3334,EMP2
+http://purl.obolibrary.org/obo/MONDO_0014752,"nephrotic syndrome, type 11; NPHS11",http://purl.obolibrary.org/obo/MONDO_0002350,familial nephrotic syndrome,http://identifiers.org/hgnc/29914,NUP107
+http://purl.obolibrary.org/obo/MONDO_0014817,"nephrotic syndrome, type 12; NPHS12",http://purl.obolibrary.org/obo/MONDO_0002350,familial nephrotic syndrome,http://identifiers.org/hgnc/28958,NUP93
+http://purl.obolibrary.org/obo/MONDO_0014818,"nephrotic syndrome, type 13; NPHS13",http://purl.obolibrary.org/obo/MONDO_0002350,familial nephrotic syndrome,http://identifiers.org/hgnc/18658,NUP205
+http://purl.obolibrary.org/obo/MONDO_0010974,"nephrotic syndrome, type 2",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/13394,NPHS2
+http://purl.obolibrary.org/obo/MONDO_0012546,"nephrotic syndrome, type 3",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/17175,PLCE1
+http://purl.obolibrary.org/obo/MONDO_0009733,"nephrotic syndrome, type 4",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/12796,WT1
+http://purl.obolibrary.org/obo/MONDO_0013619,"nephrotic syndrome, type 6",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/9678,PTPRO
+http://purl.obolibrary.org/obo/MONDO_0014099,"nephrotic syndrome, type 8",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/678,ARHGDIA
+http://purl.obolibrary.org/obo/MONDO_0014257,"nephrotic syndrome, type 9",http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome,http://identifiers.org/hgnc/19041,COQ8B
+http://purl.obolibrary.org/obo/MONDO_0013083,"neuroblastoma, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://identifiers.org/hgnc/427,ALK
+http://purl.obolibrary.org/obo/MONDO_0013674,neurodegeneration with brain iron accumulation 4,http://purl.obolibrary.org/obo/MONDO_0018307,neurodegeneration with brain iron accumulation,http://identifiers.org/hgnc/25443,C19orf12
+http://purl.obolibrary.org/obo/MONDO_0010476,neurodegeneration with brain iron accumulation 5,http://purl.obolibrary.org/obo/MONDO_0018307,neurodegeneration with brain iron accumulation,http://identifiers.org/hgnc/28912,WDR45
+http://purl.obolibrary.org/obo/MONDO_0014290,neurodegeneration with brain iron accumulation 6,http://purl.obolibrary.org/obo/MONDO_0018307,neurodegeneration with brain iron accumulation,http://identifiers.org/hgnc/29932,COASY
+http://purl.obolibrary.org/obo/MONDO_0009744,neuronal ceroid lipofuscinosis 1,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/9325,PPT1
+http://purl.obolibrary.org/obo/MONDO_0012414,neuronal ceroid lipofuscinosis 10,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2529,CTSD
+http://purl.obolibrary.org/obo/MONDO_0013866,neuronal ceroid lipofuscinosis 11,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/4601,GRN
+http://purl.obolibrary.org/obo/MONDO_0014147,neuronal ceroid lipofuscinosis 13,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2531,CTSF
+http://purl.obolibrary.org/obo/MONDO_0008769,neuronal ceroid lipofuscinosis 2,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2073,TPP1
+http://purl.obolibrary.org/obo/MONDO_0008767,neuronal ceroid lipofuscinosis 3,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2074,CLN3
+http://purl.obolibrary.org/obo/MONDO_0008768,neuronal ceroid lipofuscinosis 4A,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2077,CLN6
+http://purl.obolibrary.org/obo/MONDO_0009745,neuronal ceroid lipofuscinosis 5,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2076,CLN5
+http://purl.obolibrary.org/obo/MONDO_0011144,neuronal ceroid lipofuscinosis 6,http://purl.obolibrary.org/obo/MONDO_0015674,late infantile neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2077,CLN6
+http://purl.obolibrary.org/obo/MONDO_0012588,neuronal ceroid lipofuscinosis 7,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/28486,MFSD8
+http://purl.obolibrary.org/obo/MONDO_0010830,neuronal ceroid lipofuscinosis 8,http://purl.obolibrary.org/obo/MONDO_0016295,neuronal ceroid lipofuscinosis,http://identifiers.org/hgnc/2079,CLN8
+http://purl.obolibrary.org/obo/MONDO_0008025,"neuronopathy, distal hereditary motor, type 2A",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/30171,HSPB8
+http://purl.obolibrary.org/obo/MONDO_0012080,"neuronopathy, distal hereditary motor, type 2B",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/5246,HSPB1
+http://purl.obolibrary.org/obo/MONDO_0013243,"neuronopathy, distal hereditary motor, type 2C",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/5248,HSPB3
+http://purl.obolibrary.org/obo/MONDO_0014259,"neuronopathy, distal hereditary motor, type 2D",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/28844,FBXO38
+http://purl.obolibrary.org/obo/MONDO_0013884,"neuronopathy, distal hereditary motor, type 5B",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/25786,REEP1
+http://purl.obolibrary.org/obo/MONDO_0008024,"neuronopathy, distal hereditary motor, type 7A",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/14025,SLC5A7
+http://purl.obolibrary.org/obo/MONDO_0011879,"neuronopathy, distal hereditary motor, type 7B",http://purl.obolibrary.org/obo/MONDO_0000075,"neuronopathy, distal hereditary motor",http://identifiers.org/hgnc/2711,DCTN1
+http://purl.obolibrary.org/obo/MONDO_0011002,"neuropathy, hereditary motor and sensory, type 6A",http://purl.obolibrary.org/obo/MONDO_0019551,hereditary motor and sensory neuropathy type 6,http://identifiers.org/hgnc/16877,MFN2
+http://purl.obolibrary.org/obo/MONDO_0014671,"neuropathy, hereditary motor and sensory, type 6B",http://purl.obolibrary.org/obo/MONDO_0019551,hereditary motor and sensory neuropathy type 6,http://identifiers.org/hgnc/25198,SLC25A46
+http://purl.obolibrary.org/obo/MONDO_0008086,"neuropathy, hereditary sensory and autonomic, type 1A",http://purl.obolibrary.org/obo/MONDO_0018213,hereditary sensory and autonomic neuropathy type 1,http://identifiers.org/hgnc/11277,SPTLC1
+http://purl.obolibrary.org/obo/MONDO_0013142,"neuropathy, hereditary sensory and autonomic, type 2B",http://purl.obolibrary.org/obo/MONDO_0019941,hereditary sensory and autonomic neuropathy type 2,http://identifiers.org/hgnc/25964,RETREG1
+http://purl.obolibrary.org/obo/MONDO_0014286,"neuropathy, hereditary sensory, type 1F",http://purl.obolibrary.org/obo/MONDO_0018213,hereditary sensory and autonomic neuropathy type 1,http://identifiers.org/hgnc/24526,ATL3
+http://purl.obolibrary.org/obo/MONDO_0013634,"neuropathy, hereditary sensory, type 2C",http://purl.obolibrary.org/obo/MONDO_0019941,hereditary sensory and autonomic neuropathy type 2,http://identifiers.org/hgnc/888,KIF1A
+http://purl.obolibrary.org/obo/MONDO_0013139,"neutropenia, severe congenital, 2, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0008742,autosomal dominant severe congenital neutropenia,http://identifiers.org/hgnc/4237,GFI1
+http://purl.obolibrary.org/obo/MONDO_0013596,nonsyndromic congenital nail disorder 10,http://purl.obolibrary.org/obo/MONDO_0019284,inherited isolated nail anomaly,http://identifiers.org/hgnc/4044,FZD6
+http://purl.obolibrary.org/obo/MONDO_0007900,nonsyndromic congenital nail disorder 3,http://purl.obolibrary.org/obo/MONDO_0019284,inherited isolated nail anomaly,http://identifiers.org/hgnc/9060,PLCD1
+http://purl.obolibrary.org/obo/MONDO_0008798,nonsyndromic congenital nail disorder 4,http://purl.obolibrary.org/obo/MONDO_0019211,isolated congenital anonychia,http://identifiers.org/hgnc/16175,RSPO4
+http://purl.obolibrary.org/obo/MONDO_0011852,nonsyndromic congenital nail disorder 8,http://purl.obolibrary.org/obo/MONDO_0019284,inherited isolated nail anomaly,http://identifiers.org/hgnc/2214,COL7A1
+http://purl.obolibrary.org/obo/MONDO_0010693,"nystagmus 1, congenital, X-linked",http://purl.obolibrary.org/obo/MONDO_0005712,congenital nystagmus,http://identifiers.org/hgnc/8079,FRMD7
+http://purl.obolibrary.org/obo/MONDO_0008745,oculocutaneous albinism type 1A,http://purl.obolibrary.org/obo/MONDO_0018910,oculocutaneous albinism,http://identifiers.org/hgnc/12442,TYR
+http://purl.obolibrary.org/obo/MONDO_0008747,oculocutaneous albinism type 3,http://purl.obolibrary.org/obo/MONDO_0018910,oculocutaneous albinism,http://identifiers.org/hgnc/12450,TYRP1
+http://purl.obolibrary.org/obo/MONDO_0011683,oculocutaneous albinism type 4,http://purl.obolibrary.org/obo/MONDO_0018910,oculocutaneous albinism,http://identifiers.org/hgnc/16472,SLC45A2
+http://purl.obolibrary.org/obo/MONDO_0014070,oculocutaneous albinism type 7,http://purl.obolibrary.org/obo/MONDO_0018910,oculocutaneous albinism,http://identifiers.org/hgnc/23405,LRMDA
+http://purl.obolibrary.org/obo/MONDO_0021573,oocyte maturation defect 2,http://purl.obolibrary.org/obo/MONDO_0014769,inherited oocyte maturation defect,http://identifiers.org/hgnc/20773,TUBB8
+http://purl.obolibrary.org/obo/MONDO_0015011,optic atrophy 11; OPA11,http://purl.obolibrary.org/obo/MONDO_0014753,autosomal recessive isolated optic atrophy,http://identifiers.org/hgnc/12843,YME1L1
+http://purl.obolibrary.org/obo/MONDO_0014571,optic atrophy 8,http://purl.obolibrary.org/obo/MONDO_0014753,autosomal recessive isolated optic atrophy,http://identifiers.org/hgnc/118,ACO2
+http://purl.obolibrary.org/obo/MONDO_0013378,orofacial cleft 10,http://purl.obolibrary.org/obo/MONDO_0000358,orofacial cleft,http://identifiers.org/hgnc/12502,SUMO1
+http://purl.obolibrary.org/obo/MONDO_0010906,orofacial cleft 11,http://purl.obolibrary.org/obo/MONDO_0000358,orofacial cleft,http://identifiers.org/hgnc/1071,BMP4
+http://purl.obolibrary.org/obo/MONDO_0014772,orofacial cleft 15,http://purl.obolibrary.org/obo/MONDO_0016044,cleft lip/palate,http://identifiers.org/hgnc/2917,DLX4
+http://purl.obolibrary.org/obo/MONDO_0012142,orofacial cleft 5,http://purl.obolibrary.org/obo/MONDO_0000358,orofacial cleft,http://identifiers.org/hgnc/7391,MSX1
+http://purl.obolibrary.org/obo/MONDO_0012141,"orofacial cleft 6, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0000358,orofacial cleft,http://identifiers.org/hgnc/6121,IRF6
+http://purl.obolibrary.org/obo/MONDO_0014413,orofaciodigital syndrome type 14,http://purl.obolibrary.org/obo/MONDO_0015375,orofaciodigital syndrome,http://identifiers.org/hgnc/24564,C2CD3
+http://purl.obolibrary.org/obo/MONDO_0008143,osteoarthritis susceptibility 1,http://purl.obolibrary.org/obo/MONDO_0005178,osteoarthritis,http://identifiers.org/hgnc/3959,FRZB
+http://purl.obolibrary.org/obo/MONDO_0007704,osteoarthritis susceptibility 2,http://purl.obolibrary.org/obo/MONDO_0005178,osteoarthritis,http://identifiers.org/hgnc/6909,MATN3
+http://purl.obolibrary.org/obo/MONDO_0011923,osteoarthritis susceptibility 3,http://purl.obolibrary.org/obo/MONDO_0005178,osteoarthritis,http://identifiers.org/hgnc/14872,ASPN
+http://purl.obolibrary.org/obo/MONDO_0012893,osteoarthritis susceptibility 5,http://purl.obolibrary.org/obo/MONDO_0005178,osteoarthritis,http://identifiers.org/hgnc/4220,GDF5
+http://purl.obolibrary.org/obo/MONDO_0013459,osteogenesis imperfecta type 10,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/1546,SERPINH1
+http://purl.obolibrary.org/obo/MONDO_0012592,osteogenesis imperfecta type 11,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/18169,FKBP10
+http://purl.obolibrary.org/obo/MONDO_0013460,osteogenesis imperfecta type 12,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/17321,SP7
+http://purl.obolibrary.org/obo/MONDO_0013924,osteogenesis imperfecta type 13,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/1067,BMP1
+http://purl.obolibrary.org/obo/MONDO_0014029,osteogenesis imperfecta type 14,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/25535,TMEM38B
+http://purl.obolibrary.org/obo/MONDO_0014086,osteogenesis imperfecta type 15,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/12774,WNT1
+http://purl.obolibrary.org/obo/MONDO_0014672,osteogenesis imperfecta type 17,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/11219,SPARC
+http://purl.obolibrary.org/obo/MONDO_0012591,osteogenesis imperfecta type 5,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/16644,IFITM5
+http://purl.obolibrary.org/obo/MONDO_0013515,osteogenesis imperfecta type 6,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/8824,SERPINF1
+http://purl.obolibrary.org/obo/MONDO_0012536,osteogenesis imperfecta type 7,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/2379,CRTAP
+http://purl.obolibrary.org/obo/MONDO_0012581,osteogenesis imperfecta type 8,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/19316,P3H1
+http://purl.obolibrary.org/obo/MONDO_0009805,osteogenesis imperfecta type 9,http://purl.obolibrary.org/obo/MONDO_0019019,osteogenesis imperfecta,http://identifiers.org/hgnc/9255,PPIB
+http://purl.obolibrary.org/obo/MONDO_0024532,otofaciocervical syndrome 1,http://purl.obolibrary.org/obo/MONDO_0008163,otofaciocervical syndrome,http://identifiers.org/hgnc/3519,EYA1
+http://purl.obolibrary.org/obo/MONDO_0014254,otofaciocervical syndrome 2,http://purl.obolibrary.org/obo/MONDO_0008163,otofaciocervical syndrome,http://identifiers.org/hgnc/8615,PAX1
+http://purl.obolibrary.org/obo/MONDO_0010349,ovarian dysgenesis 2,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/1068,BMP15
+http://purl.obolibrary.org/obo/MONDO_0013689,ovarian dysgenesis 3,http://purl.obolibrary.org/obo/MONDO_0009299,46 XX gonadal dysgenesis,http://identifiers.org/hgnc/17928,PSMC3IP
+http://purl.obolibrary.org/obo/MONDO_0008173,pachyonychia congenita 1,http://purl.obolibrary.org/obo/MONDO_0016471,pachyonychia congenita,http://identifiers.org/hgnc/6423,KRT16
+http://purl.obolibrary.org/obo/MONDO_0008174,pachyonychia congenita 2,http://purl.obolibrary.org/obo/MONDO_0016471,pachyonychia congenita,http://identifiers.org/hgnc/6427,KRT17
+http://purl.obolibrary.org/obo/MONDO_0014324,pachyonychia congenita 3,http://purl.obolibrary.org/obo/MONDO_0016471,pachyonychia congenita,http://identifiers.org/hgnc/6443,KRT6A
+http://purl.obolibrary.org/obo/MONDO_0014325,pachyonychia congenita 4,http://purl.obolibrary.org/obo/MONDO_0016471,pachyonychia congenita,http://identifiers.org/hgnc/6444,KRT6B
+http://purl.obolibrary.org/obo/MONDO_0013073,"palmoplantar keratoderma, nonepidermolytic, focal 1",http://purl.obolibrary.org/obo/MONDO_0006588,nonepidermolytic palmoplantar keratoderma,http://identifiers.org/hgnc/6423,KRT16
+http://purl.obolibrary.org/obo/MONDO_0007858,"palmoplantar keratoderma, punctate type 1A",http://purl.obolibrary.org/obo/MONDO_0017675,punctate palmoplantar keratoderma,http://identifiers.org/hgnc/25662,AAGAB
+http://purl.obolibrary.org/obo/MONDO_0024547,pancreatic agenesis 1,http://purl.obolibrary.org/obo/MONDO_0009832,pancreatic agenesis,http://identifiers.org/hgnc/6107,PDX1
+http://purl.obolibrary.org/obo/MONDO_0014406,pancreatic agenesis 2,http://purl.obolibrary.org/obo/MONDO_0009832,pancreatic agenesis,http://identifiers.org/hgnc/23734,PTF1A
+http://purl.obolibrary.org/obo/MONDO_0011739,"pancreatic cancer, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0015278,familial pancreatic carcinoma,http://identifiers.org/hgnc/17068,PALLD
+http://purl.obolibrary.org/obo/MONDO_0013235,"pancreatic cancer, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0015278,familial pancreatic carcinoma,http://identifiers.org/hgnc/1101,BRCA2
+http://purl.obolibrary.org/obo/MONDO_0013236,"pancreatic cancer, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0015278,familial pancreatic carcinoma,http://identifiers.org/hgnc/26144,PALB2
+http://purl.obolibrary.org/obo/MONDO_0013685,"pancreatic cancer, susceptibility to, 4",http://purl.obolibrary.org/obo/MONDO_0015278,familial pancreatic carcinoma,http://identifiers.org/hgnc/1100,BRCA1
+http://purl.obolibrary.org/obo/MONDO_0014810,pancytopenia due to IKZF1 mutations,http://purl.obolibrary.org/obo/MONDO_0018035,syndrome with combined immunodeficiency,http://identifiers.org/hgnc/13176,IKZF1
+http://purl.obolibrary.org/obo/MONDO_0008192,paragangliomas 1,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://identifiers.org/hgnc/10683,SDHD
+http://purl.obolibrary.org/obo/MONDO_0011121,paragangliomas 2,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://identifiers.org/hgnc/26034,SDHAF2
+http://purl.obolibrary.org/obo/MONDO_0011544,paragangliomas 3,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://identifiers.org/hgnc/10682,SDHC
+http://purl.obolibrary.org/obo/MONDO_0007273,paragangliomas 4,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://identifiers.org/hgnc/10681,SDHB
+http://purl.obolibrary.org/obo/MONDO_0013602,paragangliomas 5,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://identifiers.org/hgnc/10680,SDHA
+http://purl.obolibrary.org/obo/MONDO_0008197,parietal foramina 1,http://purl.obolibrary.org/obo/MONDO_0018953,parietal foramina,http://identifiers.org/hgnc/7392,MSX2
+http://purl.obolibrary.org/obo/MONDO_0012309,parietal foramina 2,http://purl.obolibrary.org/obo/MONDO_0018953,parietal foramina,http://identifiers.org/hgnc/450,ALX4
+http://purl.obolibrary.org/obo/MONDO_0010438,paroxysmal nocturnal hemoglobinuria 1,http://purl.obolibrary.org/obo/MONDO_0018641,paroxysmal nocturnal hemoglobinuria,http://identifiers.org/hgnc/8957,PIGA
+http://purl.obolibrary.org/obo/MONDO_0014166,paroxysmal nocturnal hemoglobinuria 2,http://purl.obolibrary.org/obo/MONDO_0018641,paroxysmal nocturnal hemoglobinuria,http://identifiers.org/hgnc/14938,PIGT
+http://purl.obolibrary.org/obo/MONDO_0007326,paroxysmal nonkinesigenic dyskinesia 1,http://purl.obolibrary.org/obo/MONDO_0015427,paroxysmal dyskinesia,http://identifiers.org/hgnc/9153,PNKD
+http://purl.obolibrary.org/obo/MONDO_0024266,patent ductus arteriosus 3,http://purl.obolibrary.org/obo/MONDO_0011827,patent ductus arteriosus,http://identifiers.org/hgnc/9350,PRDM6
+http://purl.obolibrary.org/obo/MONDO_0008210,patterned macular dystrophy 1,http://purl.obolibrary.org/obo/MONDO_0020381,patterned macular dystrophy,http://identifiers.org/hgnc/9942,PRPH2
+http://purl.obolibrary.org/obo/MONDO_0012162,patterned macular dystrophy 2,http://purl.obolibrary.org/obo/MONDO_0020381,patterned macular dystrophy,http://identifiers.org/hgnc/2509,CTNNA1
+http://purl.obolibrary.org/obo/MONDO_0014920,patterned macular dystrophy 3,http://purl.obolibrary.org/obo/MONDO_0020381,patterned macular dystrophy,http://identifiers.org/hgnc/6888,MAPKAPK3
+http://purl.obolibrary.org/obo/MONDO_0024548,peeling skin syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019347,peeling skin syndrome,http://identifiers.org/hgnc/1802,CDSN
+http://purl.obolibrary.org/obo/MONDO_0011937,peeling skin syndrome 4,http://purl.obolibrary.org/obo/MONDO_0019347,peeling skin syndrome,http://identifiers.org/hgnc/2481,CSTA
+http://purl.obolibrary.org/obo/MONDO_0014923,peeling skin syndrome 5; PSS5,http://purl.obolibrary.org/obo/MONDO_0019347,peeling skin syndrome,http://identifiers.org/hgnc/8952,SERPINB8
+http://purl.obolibrary.org/obo/MONDO_0014240,periventricular nodular heterotopia 6,http://purl.obolibrary.org/obo/MONDO_0020341,periventricular nodular heterotopia,http://identifiers.org/hgnc/21056,ERMARD
+http://purl.obolibrary.org/obo/MONDO_0014966,periventricular nodular heterotopia 7; PVNH7,http://purl.obolibrary.org/obo/MONDO_0020341,periventricular nodular heterotopia,http://identifiers.org/hgnc/7728,NEDD4L
+http://purl.obolibrary.org/obo/MONDO_0013967,peroxisome biogenesis disorder 14B,http://purl.obolibrary.org/obo/MONDO_0019234,peroxisome biogenesis disorder,http://identifiers.org/hgnc/8853,PEX11B
+http://purl.obolibrary.org/obo/MONDO_0012509,"pigmented nodular adrenocortical disease, primary, 1",http://purl.obolibrary.org/obo/MONDO_0015999,primary pigmented nodular adrenocortical disease,http://identifiers.org/hgnc/9388,PRKAR1A
+http://purl.obolibrary.org/obo/MONDO_0012505,"pigmented nodular adrenocortical disease, primary, 2",http://purl.obolibrary.org/obo/MONDO_0015999,primary pigmented nodular adrenocortical disease,http://identifiers.org/hgnc/8773,PDE11A
+http://purl.obolibrary.org/obo/MONDO_0013616,"pigmented nodular adrenocortical disease, primary, 3",http://purl.obolibrary.org/obo/MONDO_0015999,primary pigmented nodular adrenocortical disease,http://identifiers.org/hgnc/8794,PDE8B
+http://purl.obolibrary.org/obo/MONDO_0014359,"pigmented nodular adrenocortical disease, primary, 4",http://purl.obolibrary.org/obo/MONDO_0015999,primary pigmented nodular adrenocortical disease,http://identifiers.org/hgnc/9380,PRKACA
+http://purl.obolibrary.org/obo/MONDO_0010492,"pituitary adenoma, growth hormone-secreting, 2",http://purl.obolibrary.org/obo/MONDO_0006373,pituitary gland adenoma,http://identifiers.org/hgnc/14963,GPR101
+http://purl.obolibrary.org/obo/MONDO_0024464,"pituitary hormone deficiency, combined, 1",http://purl.obolibrary.org/obo/MONDO_0013099,"combined pituitary hormone deficiencies, genetic form",http://identifiers.org/hgnc/9210,POU1F1
+http://purl.obolibrary.org/obo/MONDO_0009878,"pituitary hormone deficiency, combined, 2",http://purl.obolibrary.org/obo/MONDO_0013099,"combined pituitary hormone deficiencies, genetic form",http://identifiers.org/hgnc/9455,PROP1
+http://purl.obolibrary.org/obo/MONDO_0013518,"pituitary hormone deficiency, combined, 6",http://purl.obolibrary.org/obo/MONDO_0013099,"combined pituitary hormone deficiencies, genetic form",http://identifiers.org/hgnc/8522,OTX2
+http://purl.obolibrary.org/obo/MONDO_0012031,platelet-type bleeding disorder 10,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/1663,CD36
+http://purl.obolibrary.org/obo/MONDO_0013623,platelet-type bleeding disorder 11,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/14388,GP6
+http://purl.obolibrary.org/obo/MONDO_0013597,platelet-type bleeding disorder 14,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/11609,TBXAS1
+http://purl.obolibrary.org/obo/MONDO_0014078,platelet-type bleeding disorder 15,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/163,ACTN1
+http://purl.obolibrary.org/obo/MONDO_0008553,platelet-type bleeding disorder 17,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/4238,GFI1B
+http://purl.obolibrary.org/obo/MONDO_0014386,platelet-type bleeding disorder 18,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/9879,RASGRP2
+http://purl.obolibrary.org/obo/MONDO_0014518,platelet-type bleeding disorder 19,http://purl.obolibrary.org/obo/MONDO_0016361,isolated hereditary giant platelet disorder,http://identifiers.org/hgnc/9382,PRKACG
+http://purl.obolibrary.org/obo/MONDO_0014830,platelet-type bleeding disorder 20,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/32689,SLFN14
+http://purl.obolibrary.org/obo/MONDO_0013622,platelet-type bleeding disorder 9,http://purl.obolibrary.org/obo/MONDO_0000009,"inherited bleeding disorder, platelet-type",http://identifiers.org/hgnc/6137,ITGA2
+http://purl.obolibrary.org/obo/MONDO_0008263,polycystic kidney disease 1,http://purl.obolibrary.org/obo/MONDO_0004691,autosomal dominant polycystic kidney disease,http://identifiers.org/hgnc/9008,PKD1
+http://purl.obolibrary.org/obo/MONDO_0013131,polycystic kidney disease 2,http://purl.obolibrary.org/obo/MONDO_0004691,autosomal dominant polycystic kidney disease,http://identifiers.org/hgnc/9009,PKD2
+http://purl.obolibrary.org/obo/MONDO_0010916,polycystic kidney disease 3,http://purl.obolibrary.org/obo/MONDO_0004691,autosomal dominant polycystic kidney disease,http://identifiers.org/hgnc/4138,GANAB
+http://purl.obolibrary.org/obo/MONDO_0014526,polyglucosan body myopathy type 2,http://purl.obolibrary.org/obo/MONDO_0000192,polyglucosan body myopathy,http://identifiers.org/hgnc/4699,GYG1
+http://purl.obolibrary.org/obo/MONDO_0012405,"polyposis syndrome, hereditary mixed, 2",http://purl.obolibrary.org/obo/MONDO_0011023,hereditary mixed polyposis syndrome,http://identifiers.org/hgnc/1076,BMPR1A
+http://purl.obolibrary.org/obo/MONDO_0014349,pontocerebellar hypoplasia type 10,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/16999,CLP1
+http://purl.obolibrary.org/obo/MONDO_0011866,pontocerebellar hypoplasia type 1A,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/12718,VRK1
+http://purl.obolibrary.org/obo/MONDO_0013853,pontocerebellar hypoplasia type 1B,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/17944,EXOSC3
+http://purl.obolibrary.org/obo/MONDO_0010190,pontocerebellar hypoplasia type 2A,http://purl.obolibrary.org/obo/MONDO_0016759,pontocerebellar hypoplasia type 2,http://identifiers.org/hgnc/27561,TSEN54
+http://purl.obolibrary.org/obo/MONDO_0012890,pontocerebellar hypoplasia type 2B,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/28422,TSEN2
+http://purl.obolibrary.org/obo/MONDO_0012891,pontocerebellar hypoplasia type 2C,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/15506,TSEN34
+http://purl.obolibrary.org/obo/MONDO_0013438,pontocerebellar hypoplasia type 2D,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/30605,SEPSECS
+http://purl.obolibrary.org/obo/MONDO_0014370,pontocerebellar hypoplasia type 2E,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/25608,VPS53
+http://purl.obolibrary.org/obo/MONDO_0011948,pontocerebellar hypoplasia type 3,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/13406,PCLO
+http://purl.obolibrary.org/obo/MONDO_0012683,pontocerebellar hypoplasia type 6,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/21406,RARS2
+http://purl.obolibrary.org/obo/MONDO_0013993,pontocerebellar hypoplasia type 7,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/15954,TOE1
+http://purl.obolibrary.org/obo/MONDO_0013990,pontocerebellar hypoplasia type 8,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/8740,CHMP1A
+http://purl.obolibrary.org/obo/MONDO_0014351,pontocerebellar hypoplasia type 9,http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/469,AMPD2
+http://purl.obolibrary.org/obo/MONDO_0014485,"pontocerebellar hypoplasia, type 1C",http://purl.obolibrary.org/obo/MONDO_0016396,pontocerebellar hypoplasia type 1,http://identifiers.org/hgnc/17035,EXOSC8
+http://purl.obolibrary.org/obo/MONDO_0014874,"pontocerebellar hypoplasia, type 2F; PCH2F",http://purl.obolibrary.org/obo/MONDO_0020135,non-syndromic pontocerebellar hypoplasia,http://identifiers.org/hgnc/16791,TSEN15
+http://purl.obolibrary.org/obo/MONDO_0008289,porencephaly 1,http://purl.obolibrary.org/obo/MONDO_0017410,porencephaly,http://identifiers.org/hgnc/2202,COL4A1
+http://purl.obolibrary.org/obo/MONDO_0013773,porencephaly 2,http://purl.obolibrary.org/obo/MONDO_0017410,porencephaly,http://identifiers.org/hgnc/2203,COL4A2
+http://purl.obolibrary.org/obo/MONDO_0014713,"porokeratosis 9, multiple types; POROK9",http://purl.obolibrary.org/obo/MONDO_0006602,porokeratosis (disease),http://identifiers.org/hgnc/3631,FDPS
+http://purl.obolibrary.org/obo/MONDO_0012199,posterior polymorphous corneal dystrophy 2,http://purl.obolibrary.org/obo/MONDO_0020364,posterior polymorphous corneal dystrophy,http://identifiers.org/hgnc/2216,COL8A2
+http://purl.obolibrary.org/obo/MONDO_0012200,posterior polymorphous corneal dystrophy 3,http://purl.obolibrary.org/obo/MONDO_0020364,posterior polymorphous corneal dystrophy,http://identifiers.org/hgnc/11642,ZEB1
+http://purl.obolibrary.org/obo/MONDO_0008302,"precocious puberty, central, 1",http://purl.obolibrary.org/obo/MONDO_0019165,central precocious puberty,http://identifiers.org/hgnc/4510,KISS1R
+http://purl.obolibrary.org/obo/MONDO_0014137,"precocious puberty, central, 2",http://purl.obolibrary.org/obo/MONDO_0019165,central precocious puberty,http://identifiers.org/hgnc/7114,MKRN3
+http://purl.obolibrary.org/obo/MONDO_0012266,preeclampsia/eclampsia 4,http://purl.obolibrary.org/obo/MONDO_0005081,preeclampsia,http://identifiers.org/hgnc/23508,STOX1
+http://purl.obolibrary.org/obo/MONDO_0013817,preeclampsia/eclampsia 5,http://purl.obolibrary.org/obo/MONDO_0005081,preeclampsia,http://identifiers.org/hgnc/19012,CORIN
+http://purl.obolibrary.org/obo/MONDO_0013727,"pregnancy loss, recurrent, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0000144,"pregnancy loss, recurrent, susceptibility",http://identifiers.org/hgnc/3542,F5
+http://purl.obolibrary.org/obo/MONDO_0013728,"pregnancy loss, recurrent, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0000144,"pregnancy loss, recurrent, susceptibility",http://identifiers.org/hgnc/3535,F2
+http://purl.obolibrary.org/obo/MONDO_0013729,"pregnancy loss, recurrent, susceptibility to, 3",http://purl.obolibrary.org/obo/MONDO_0000144,"pregnancy loss, recurrent, susceptibility",http://identifiers.org/hgnc/543,ANXA5
+http://purl.obolibrary.org/obo/MONDO_0014783,preimplantation embryonic lethality 1; PREMBL1,http://purl.obolibrary.org/obo/MONDO_0000218,preimplantation embryonic lethality,http://identifiers.org/hgnc/30788,TLE6
+http://purl.obolibrary.org/obo/MONDO_0014978,preimplantation embryonic lethality 2; PREMBL2,http://purl.obolibrary.org/obo/MONDO_0000218,preimplantation embryonic lethality,http://identifiers.org/hgnc/20449,PADI6
+http://purl.obolibrary.org/obo/MONDO_0010706,premature ovarian failure 1,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/3775,FMR1
+http://purl.obolibrary.org/obo/MONDO_0014843,premature ovarian failure 11; POF11,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/3438,ERCC6
+http://purl.obolibrary.org/obo/MONDO_0014844,premature ovarian failure 12; POF12,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/28852,SYCE1
+http://purl.obolibrary.org/obo/MONDO_0010350,premature ovarian failure 2A,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/2877,DIAPH2
+http://purl.obolibrary.org/obo/MONDO_0010373,premature ovarian failure 2B,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/13711,POF1B
+http://purl.obolibrary.org/obo/MONDO_0012689,premature ovarian failure 5,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/22448,NOBOX
+http://purl.obolibrary.org/obo/MONDO_0012861,premature ovarian failure 6,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/24669,FIGLA
+http://purl.obolibrary.org/obo/MONDO_0013065,premature ovarian failure 7,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/7983,NR5A1
+http://purl.obolibrary.org/obo/MONDO_0014321,premature ovarian failure 8,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/11356,STAG3
+http://purl.obolibrary.org/obo/MONDO_0014322,premature ovarian failure 9,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure,http://identifiers.org/hgnc/20193,HFM1
+http://purl.obolibrary.org/obo/MONDO_0009484,primary ciliary dyskinesia 1,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/2954,DNAI1
+http://purl.obolibrary.org/obo/MONDO_0012918,primary ciliary dyskinesia 10,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/20188,DNAAF2
+http://purl.obolibrary.org/obo/MONDO_0012978,primary ciliary dyskinesia 11,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/21558,RSPH4A
+http://purl.obolibrary.org/obo/MONDO_0012979,primary ciliary dyskinesia 12,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/21057,RSPH9
+http://purl.obolibrary.org/obo/MONDO_0013174,primary ciliary dyskinesia 13,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/30539,DNAAF1
+http://purl.obolibrary.org/obo/MONDO_0013434,primary ciliary dyskinesia 14,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/25244,CCDC39
+http://purl.obolibrary.org/obo/MONDO_0013435,primary ciliary dyskinesia 15,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/26090,CCDC40
+http://purl.obolibrary.org/obo/MONDO_0013525,primary ciliary dyskinesia 16,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/23247,DNAL1
+http://purl.obolibrary.org/obo/MONDO_0013854,primary ciliary dyskinesia 17,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/32700,CCDC103
+http://purl.obolibrary.org/obo/MONDO_0013940,primary ciliary dyskinesia 18,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/26013,DNAAF5
+http://purl.obolibrary.org/obo/MONDO_0013979,primary ciliary dyskinesia 19,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/16725,LRRC6
+http://purl.obolibrary.org/obo/MONDO_0011718,primary ciliary dyskinesia 2,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/30492,DNAAF3
+http://purl.obolibrary.org/obo/MONDO_0014030,primary ciliary dyskinesia 20,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/26560,CCDC114
+http://purl.obolibrary.org/obo/MONDO_0014123,primary ciliary dyskinesia 21,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/24245,DRC1
+http://purl.obolibrary.org/obo/MONDO_0014192,primary ciliary dyskinesia 22,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/19412,ZMYND10
+http://purl.obolibrary.org/obo/MONDO_0014193,primary ciliary dyskinesia 23,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/25583,ARMC4
+http://purl.obolibrary.org/obo/MONDO_0014202,primary ciliary dyskinesia 24,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/12371,RSPH1
+http://purl.obolibrary.org/obo/MONDO_0014203,primary ciliary dyskinesia 25,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/21493,DNAAF4
+http://purl.obolibrary.org/obo/MONDO_0014211,primary ciliary dyskinesia 26,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/1301,CFAP298
+http://purl.obolibrary.org/obo/MONDO_0014215,primary ciliary dyskinesia 27,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/29937,CCDC65
+http://purl.obolibrary.org/obo/MONDO_0014216,primary ciliary dyskinesia 28,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/11212,SPAG1
+http://purl.obolibrary.org/obo/MONDO_0014378,primary ciliary dyskinesia 29,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/18576,CCNO
+http://purl.obolibrary.org/obo/MONDO_0012085,primary ciliary dyskinesia 3,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/2950,DNAH5
+http://purl.obolibrary.org/obo/MONDO_0014465,primary ciliary dyskinesia 30,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/28303,CCDC151
+http://purl.obolibrary.org/obo/MONDO_0014657,primary ciliary dyskinesia 32,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/21054,RSPH3
+http://purl.obolibrary.org/obo/MONDO_0014750,primary ciliary dyskinesia 33,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/4166,GAS8
+http://purl.obolibrary.org/obo/MONDO_0014909,primary ciliary dyskinesia 34,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/30718,DNAJB13
+http://purl.obolibrary.org/obo/MONDO_0014910,primary ciliary dyskinesia 35,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/25280,TTC25
+http://purl.obolibrary.org/obo/MONDO_0012088,primary ciliary dyskinesia 5,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/19368,HYDIN
+http://purl.obolibrary.org/obo/MONDO_0012571,primary ciliary dyskinesia 6,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/16473,NME8
+http://purl.obolibrary.org/obo/MONDO_0012748,primary ciliary dyskinesia 7,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/2942,DNAH11
+http://purl.obolibrary.org/obo/MONDO_0012906,primary ciliary dyskinesia 9,http://purl.obolibrary.org/obo/MONDO_0016575,primary ciliary dyskinesia,http://identifiers.org/hgnc/18744,DNAI2
+http://purl.obolibrary.org/obo/MONDO_0014754,primary coenzyme Q10 deficiency 8,http://purl.obolibrary.org/obo/MONDO_0018151,coenzyme Q10 deficiency,http://identifiers.org/hgnc/2244,COQ7
+http://purl.obolibrary.org/obo/MONDO_0007572,primary familial polycythemia due to EPO receptor mutation,http://purl.obolibrary.org/obo/MONDO_0001115,familial polycythemia,http://identifiers.org/hgnc/3416,EPOR
+http://purl.obolibrary.org/obo/MONDO_0009823,primary hyperoxaluria type 1,http://purl.obolibrary.org/obo/MONDO_0002474,primary hyperoxaluria,http://identifiers.org/hgnc/341,AGXT
+http://purl.obolibrary.org/obo/MONDO_0009824,primary hyperoxaluria type 2,http://purl.obolibrary.org/obo/MONDO_0002474,primary hyperoxaluria,http://identifiers.org/hgnc/4570,GRHPR
+http://purl.obolibrary.org/obo/MONDO_0013327,primary hyperoxaluria type 3,http://purl.obolibrary.org/obo/MONDO_0002474,primary hyperoxaluria,http://identifiers.org/hgnc/25155,HOGA1
+http://purl.obolibrary.org/obo/MONDO_0012238,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal dominant 2",http://purl.obolibrary.org/obo/MONDO_0000090,progressive external ophthalmoplegia with mitochondrial DNA deletions,http://identifiers.org/hgnc/10990,SLC25A4
+http://purl.obolibrary.org/obo/MONDO_0012241,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal dominant 3",http://purl.obolibrary.org/obo/MONDO_0000090,progressive external ophthalmoplegia with mitochondrial DNA deletions,http://identifiers.org/hgnc/1160,TWNK
+http://purl.obolibrary.org/obo/MONDO_0012415,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal dominant 4",http://purl.obolibrary.org/obo/MONDO_0000090,progressive external ophthalmoplegia with mitochondrial DNA deletions,http://identifiers.org/hgnc/9180,POLG2
+http://purl.obolibrary.org/obo/MONDO_0013117,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal dominant 5",http://purl.obolibrary.org/obo/MONDO_0000090,progressive external ophthalmoplegia with mitochondrial DNA deletions,http://identifiers.org/hgnc/17296,RRM2B
+http://purl.obolibrary.org/obo/MONDO_0009783,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal recessive 1",http://purl.obolibrary.org/obo/MONDO_0016810,autosomal recessive progressive external ophthalmoplegia,http://identifiers.org/hgnc/9179,POLG
+http://purl.obolibrary.org/obo/MONDO_0014656,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal recessive 2",http://purl.obolibrary.org/obo/MONDO_0000090,progressive external ophthalmoplegia with mitochondrial DNA deletions,http://identifiers.org/hgnc/18466,RNASEH1
+http://purl.obolibrary.org/obo/MONDO_0014898,"progressive external ophthalmoplegia with mitochondrial DNA deletions, autosomal recessive 3; PEOB3",http://purl.obolibrary.org/obo/MONDO_0016810,autosomal recessive progressive external ophthalmoplegia,http://identifiers.org/hgnc/11831,TK2
+http://purl.obolibrary.org/obo/MONDO_0024528,"progressive external ophthalmoplegia with mitochondrial dna deletions, autosomal dominant 1",http://purl.obolibrary.org/obo/MONDO_0008003,autosomal dominant progressive external ophthalmoplegia,http://identifiers.org/hgnc/9179,POLG
+http://purl.obolibrary.org/obo/MONDO_0011474,progressive familial heart block type IB,http://purl.obolibrary.org/obo/MONDO_0019490,progressive familial heart block,http://identifiers.org/hgnc/17993,TRPM4
+http://purl.obolibrary.org/obo/MONDO_0007240,"progressive familial heart block, type 1A",http://purl.obolibrary.org/obo/MONDO_0019490,progressive familial heart block,http://identifiers.org/hgnc/10593,SCN5A
+http://purl.obolibrary.org/obo/MONDO_0011156,progressive familial intrahepatic cholestasis type 2,http://purl.obolibrary.org/obo/MONDO_0015762,progressive familial intrahepatic cholestasis,http://identifiers.org/hgnc/42,ABCB11
+http://purl.obolibrary.org/obo/MONDO_0011214,progressive familial intrahepatic cholestasis type 3,http://purl.obolibrary.org/obo/MONDO_0015762,progressive familial intrahepatic cholestasis,http://identifiers.org/hgnc/45,ABCB4
+http://purl.obolibrary.org/obo/MONDO_0012721,progressive myoclonic epilepsy type 3,http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/21957,KCTD7
+http://purl.obolibrary.org/obo/MONDO_0013451,progressive myoclonic epilepsy type 5,http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/20340,PRICKLE2
+http://purl.obolibrary.org/obo/MONDO_0013526,progressive myoclonic epilepsy type 6,http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/4431,GOSR2
+http://purl.obolibrary.org/obo/MONDO_0014521,progressive myoclonic epilepsy type 7,http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/6233,KCNC1
+http://purl.obolibrary.org/obo/MONDO_0014545,progressive myoclonic epilepsy type 8,http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/14253,CERS1
+http://purl.obolibrary.org/obo/MONDO_0014685,progressive myoclonic epilepsy type 9,http://purl.obolibrary.org/obo/MONDO_0020074,progressive myoclonic epilepsy,http://identifiers.org/hgnc/6638,LMNB2
+http://purl.obolibrary.org/obo/MONDO_0011098,"prostate cancer, hereditary, 1",http://purl.obolibrary.org/obo/MONDO_0023122,familial prostate cancer,http://identifiers.org/hgnc/10050,RNASEL
+http://purl.obolibrary.org/obo/MONDO_0012741,"prostate cancer, hereditary, 12",http://purl.obolibrary.org/obo/MONDO_0023122,familial prostate cancer,http://identifiers.org/hgnc/29144,EHBP1
+http://purl.obolibrary.org/obo/MONDO_0012758,"prostate cancer, hereditary, 13",http://purl.obolibrary.org/obo/MONDO_0023122,familial prostate cancer,http://identifiers.org/hgnc/7372,MSMB
+http://purl.obolibrary.org/obo/MONDO_0013872,"prostate cancer, hereditary, 2",http://purl.obolibrary.org/obo/MONDO_0023122,familial prostate cancer,http://identifiers.org/hgnc/14198,ELAC2
+http://purl.obolibrary.org/obo/MONDO_0013777,pseudohypoaldosteronism type 2B,http://purl.obolibrary.org/obo/MONDO_0019162,pseudohypoaldosteronism type 2,http://identifiers.org/hgnc/14544,WNK4
+http://purl.obolibrary.org/obo/MONDO_0013778,pseudohypoaldosteronism type 2C,http://purl.obolibrary.org/obo/MONDO_0019162,pseudohypoaldosteronism type 2,http://identifiers.org/hgnc/14540,WNK1
+http://purl.obolibrary.org/obo/MONDO_0013781,pseudohypoaldosteronism type 2D,http://purl.obolibrary.org/obo/MONDO_0019162,pseudohypoaldosteronism type 2,http://identifiers.org/hgnc/6354,KLHL3
+http://purl.obolibrary.org/obo/MONDO_0013782,pseudohypoaldosteronism type 2E,http://purl.obolibrary.org/obo/MONDO_0019162,pseudohypoaldosteronism type 2,http://identifiers.org/hgnc/2553,CUL3
+http://purl.obolibrary.org/obo/MONDO_0008334,"psoriasis 1, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0005083,psoriasis,http://identifiers.org/hgnc/4933,HLA-C
+http://purl.obolibrary.org/obo/MONDO_0013554,"psoriasis 13, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0005083,psoriasis,http://identifiers.org/hgnc/1343,TRAF3IP2
+http://purl.obolibrary.org/obo/MONDO_0013626,"psoriasis 14, pustular",http://purl.obolibrary.org/obo/MONDO_0005083,psoriasis,http://identifiers.org/hgnc/15561,IL36RN
+http://purl.obolibrary.org/obo/MONDO_0014494,"psoriasis 15, pustular, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0016597,generalized pustular psoriasis,http://identifiers.org/hgnc/18971,AP1S3
+http://purl.obolibrary.org/obo/MONDO_0011269,psoriasis 2,http://purl.obolibrary.org/obo/MONDO_0005083,psoriasis,http://identifiers.org/hgnc/16446,CARD14
+http://purl.obolibrary.org/obo/MONDO_0013878,"pulmonary fibrosis and/or bone marrow failure, Telomere-related, 1",http://purl.obolibrary.org/obo/MONDO_0000148,"pulmonary fibrosis and/or bone marrow failure, Telomere-related",http://identifiers.org/hgnc/11730,TERT
+http://purl.obolibrary.org/obo/MONDO_0014613,"pulmonary fibrosis and/or bone marrow failure, Telomere-related, 3",http://purl.obolibrary.org/obo/MONDO_0000148,"pulmonary fibrosis and/or bone marrow failure, Telomere-related",http://identifiers.org/hgnc/15888,RTEL1
+http://purl.obolibrary.org/obo/MONDO_0014612,"pulmonary fibrosis and/or bone marrow failure, Telomere-related, 4",http://purl.obolibrary.org/obo/MONDO_0000148,"pulmonary fibrosis and/or bone marrow failure, Telomere-related",http://identifiers.org/hgnc/8609,PARN
+http://purl.obolibrary.org/obo/MONDO_0024533,"pulmonary hypertension, primary, 1",http://purl.obolibrary.org/obo/MONDO_0001999,primary pulmonary hypertension,http://identifiers.org/hgnc/1078,BMPR2
+http://purl.obolibrary.org/obo/MONDO_0014134,"pulmonary hypertension, primary, 2",http://purl.obolibrary.org/obo/MONDO_0001999,primary pulmonary hypertension,http://identifiers.org/hgnc/6774,SMAD9
+http://purl.obolibrary.org/obo/MONDO_0014135,"pulmonary hypertension, primary, 3",http://purl.obolibrary.org/obo/MONDO_0001999,primary pulmonary hypertension,http://identifiers.org/hgnc/1527,CAV1
+http://purl.obolibrary.org/obo/MONDO_0014136,"pulmonary hypertension, primary, 4",http://purl.obolibrary.org/obo/MONDO_0001999,primary pulmonary hypertension,http://identifiers.org/hgnc/6278,KCNK3
+http://purl.obolibrary.org/obo/MONDO_0024558,radioulnar synostosis with amegakaryocytic thrombocytopenia 1,http://purl.obolibrary.org/obo/MONDO_0011555,radio-ulnar synostosis-amegakaryocytic thrombocytopenia syndrome,http://identifiers.org/hgnc/5101,HOXA11
+http://purl.obolibrary.org/obo/MONDO_0014758,radioulnar synostosis with amegakaryocytic thrombocytopenia 2; RUSAT2,http://purl.obolibrary.org/obo/MONDO_0011555,radio-ulnar synostosis-amegakaryocytic thrombocytopenia syndrome,http://identifiers.org/hgnc/3498,MECOM
+http://purl.obolibrary.org/obo/MONDO_0014319,renal hypodysplasia/aplasia 2,http://purl.obolibrary.org/obo/MONDO_0018470,renal agenesis (disease),http://identifiers.org/hgnc/3677,FGF20
+http://purl.obolibrary.org/obo/MONDO_0007937,renal hypomagnesemia 2,http://purl.obolibrary.org/obo/MONDO_0018100,primary hypomagnesemia,http://identifiers.org/hgnc/4026,FXYD2
+http://purl.obolibrary.org/obo/MONDO_0009550,renal hypomagnesemia 3,http://purl.obolibrary.org/obo/MONDO_0018100,primary hypomagnesemia,http://identifiers.org/hgnc/2037,CLDN16
+http://purl.obolibrary.org/obo/MONDO_0012717,renal hypomagnesemia 4,http://purl.obolibrary.org/obo/MONDO_0018100,primary hypomagnesemia,http://identifiers.org/hgnc/3229,EGF
+http://purl.obolibrary.org/obo/MONDO_0008833,renal-hepatic-pancreatic dysplasia 1,http://purl.obolibrary.org/obo/MONDO_0017417,renal-hepatic-pancreatic dysplasia,http://identifiers.org/hgnc/7907,NPHP3
+http://purl.obolibrary.org/obo/MONDO_0014174,renal-hepatic-pancreatic dysplasia 2,http://purl.obolibrary.org/obo/MONDO_0017417,renal-hepatic-pancreatic dysplasia,http://identifiers.org/hgnc/13387,NEK8
+http://purl.obolibrary.org/obo/MONDO_0012507,retinal cone dystrophy 4,http://purl.obolibrary.org/obo/MONDO_0000455,cone dystrophy,http://identifiers.org/hgnc/20202,CACNA2D4
+http://purl.obolibrary.org/obo/MONDO_0008377,retinitis pigmentosa 1,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10263,RP1
+http://purl.obolibrary.org/obo/MONDO_0008379,retinitis pigmentosa 10,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/6052,IMPDH1
+http://purl.obolibrary.org/obo/MONDO_0010828,retinitis pigmentosa 11,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/15446,PRPF31
+http://purl.obolibrary.org/obo/MONDO_0010818,retinitis pigmentosa 12,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/2343,CRB1
+http://purl.obolibrary.org/obo/MONDO_0010806,retinitis pigmentosa 13,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/17340,PRPF8
+http://purl.obolibrary.org/obo/MONDO_0010827,retinitis pigmentosa 14,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/12423,TULP1
+http://purl.obolibrary.org/obo/MONDO_0010945,retinitis pigmentosa 17,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/1375,CA4
+http://purl.obolibrary.org/obo/MONDO_0011075,retinitis pigmentosa 18,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/17348,PRPF3
+http://purl.obolibrary.org/obo/MONDO_0011137,retinitis pigmentosa 19,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/34,ABCA4
+http://purl.obolibrary.org/obo/MONDO_0010723,retinitis pigmentosa 2,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10274,RP2
+http://purl.obolibrary.org/obo/MONDO_0013425,retinitis pigmentosa 20,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10294,RPE65
+http://purl.obolibrary.org/obo/MONDO_0010320,retinitis pigmentosa 23,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/2567,OFD1
+http://purl.obolibrary.org/obo/MONDO_0011272,retinitis pigmentosa 25,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/21555,EYS
+http://purl.obolibrary.org/obo/MONDO_0012024,retinitis pigmentosa 26,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/21699,CERKL
+http://purl.obolibrary.org/obo/MONDO_0013402,retinitis pigmentosa 27,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/8002,NRL
+http://purl.obolibrary.org/obo/MONDO_0011630,retinitis pigmentosa 28,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/25808,FAM161A
+http://purl.obolibrary.org/obo/MONDO_0010227,retinitis pigmentosa 3,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10295,RPGR
+http://purl.obolibrary.org/obo/MONDO_0011935,retinitis pigmentosa 30,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/3960,FSCN2
+http://purl.obolibrary.org/obo/MONDO_0012367,retinitis pigmentosa 31,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/21653,TOPORS
+http://purl.obolibrary.org/obo/MONDO_0012477,retinitis pigmentosa 33,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/30859,SNRNP200
+http://purl.obolibrary.org/obo/MONDO_0012463,retinitis pigmentosa 35,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10729,SEMA4A
+http://purl.obolibrary.org/obo/MONDO_0012523,retinitis pigmentosa 36,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/32528,PRCD
+http://purl.obolibrary.org/obo/MONDO_0012625,retinitis pigmentosa 37,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/7974,NR2E3
+http://purl.obolibrary.org/obo/MONDO_0013469,retinitis pigmentosa 38,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/7027,MERTK
+http://purl.obolibrary.org/obo/MONDO_0013436,retinitis pigmentosa 39,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/12601,USH2A
+http://purl.obolibrary.org/obo/MONDO_0013395,retinitis pigmentosa 4,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10012,RHO
+http://purl.obolibrary.org/obo/MONDO_0013429,retinitis pigmentosa 40,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/8786,PDE6B
+http://purl.obolibrary.org/obo/MONDO_0012796,retinitis pigmentosa 41,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/9454,PROM1
+http://purl.obolibrary.org/obo/MONDO_0013052,retinitis pigmentosa 42,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/15646,KLHL7
+http://purl.obolibrary.org/obo/MONDO_0013437,retinitis pigmentosa 43,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/8785,PDE6A
+http://purl.obolibrary.org/obo/MONDO_0013414,retinitis pigmentosa 44,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/9990,RGR
+http://purl.obolibrary.org/obo/MONDO_0013413,retinitis pigmentosa 45,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/2151,CNGB1
+http://purl.obolibrary.org/obo/MONDO_0012943,retinitis pigmentosa 46,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/5385,IDH3B
+http://purl.obolibrary.org/obo/MONDO_0013407,retinitis pigmentosa 47,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10521,SAG
+http://purl.obolibrary.org/obo/MONDO_0013447,retinitis pigmentosa 48,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/4679,GUCA1B
+http://purl.obolibrary.org/obo/MONDO_0013405,retinitis pigmentosa 49,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/2148,CNGA1
+http://purl.obolibrary.org/obo/MONDO_0013175,retinitis pigmentosa 50,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/12703,BEST1
+http://purl.obolibrary.org/obo/MONDO_0013274,retinitis pigmentosa 51,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/20087,TTC8
+http://purl.obolibrary.org/obo/MONDO_0013263,retinitis pigmentosa 54,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/34383,PCARE
+http://purl.obolibrary.org/obo/MONDO_0013312,retinitis pigmentosa 55,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/13210,ARL6
+http://purl.obolibrary.org/obo/MONDO_0013314,retinitis pigmentosa 56,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/18362,IMPG2
+http://purl.obolibrary.org/obo/MONDO_0013315,retinitis pigmentosa 57,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/8789,PDE6G
+http://purl.obolibrary.org/obo/MONDO_0013328,retinitis pigmentosa 58,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/26498,ZNF513
+http://purl.obolibrary.org/obo/MONDO_0013468,retinitis pigmentosa 59,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/20603,DHDDS
+http://purl.obolibrary.org/obo/MONDO_0013516,retinitis pigmentosa 60,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/15860,PRPF6
+http://purl.obolibrary.org/obo/MONDO_0013610,retinitis pigmentosa 61,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/12605,CLRN1
+http://purl.obolibrary.org/obo/MONDO_0013611,retinitis pigmentosa 62,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/6816,MAK
+http://purl.obolibrary.org/obo/MONDO_0014093,retinitis pigmentosa 66,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/9921,RBP3
+http://purl.obolibrary.org/obo/MONDO_0014256,retinitis pigmentosa 67,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/7745,NEK2
+http://purl.obolibrary.org/obo/MONDO_0014323,retinitis pigmentosa 68,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/29326,SLC7A14
+http://purl.obolibrary.org/obo/MONDO_0014345,retinitis pigmentosa 69,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/15865,KIZ
+http://purl.obolibrary.org/obo/MONDO_0014400,retinitis pigmentosa 70,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/17349,PRPF4
+http://purl.obolibrary.org/obo/MONDO_0014618,retinitis pigmentosa 71,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/30391,IFT172
+http://purl.obolibrary.org/obo/MONDO_0014653,retinitis pigmentosa 72,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/20041,ZNF408
+http://purl.obolibrary.org/obo/MONDO_0014687,retinitis pigmentosa 73,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/26527,HGSNAT
+http://purl.obolibrary.org/obo/MONDO_0014692,retinitis pigmentosa 74,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/967,BBS2
+http://purl.obolibrary.org/obo/MONDO_0014871,retinitis pigmentosa 75,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/26147,AGBL5
+http://purl.obolibrary.org/obo/MONDO_0014929,retinitis pigmentosa 76; RP76,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/19139,POMGNT1
+http://purl.obolibrary.org/obo/MONDO_0015013,retinitis pigmentosa 77; RP77,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/30078,REEP6
+http://purl.obolibrary.org/obo/MONDO_0008378,retinitis pigmentosa 9,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/10288,RP9
+http://purl.obolibrary.org/obo/MONDO_0014186,retinitis pigmentosa with or without situs inversus,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa,http://identifiers.org/hgnc/17146,ARL2BP
+http://purl.obolibrary.org/obo/MONDO_0012252,rhabdoid tumor predisposition syndrome 1,http://purl.obolibrary.org/obo/MONDO_0016473,familial rhabdoid tumor,http://identifiers.org/hgnc/11103,SMARCB1
+http://purl.obolibrary.org/obo/MONDO_0013224,rhabdoid tumor predisposition syndrome 2,http://purl.obolibrary.org/obo/MONDO_0016473,familial rhabdoid tumor,http://identifiers.org/hgnc/11100,SMARCA4
+http://purl.obolibrary.org/obo/MONDO_0008972,rhizomelic chondrodysplasia punctata type 1,http://purl.obolibrary.org/obo/MONDO_0015776,rhizomelic chondrodysplasia punctata,http://identifiers.org/hgnc/8860,PEX7
+http://purl.obolibrary.org/obo/MONDO_0009112,rhizomelic chondrodysplasia punctata type 2,http://purl.obolibrary.org/obo/MONDO_0015776,rhizomelic chondrodysplasia punctata,http://identifiers.org/hgnc/4416,GNPAT
+http://purl.obolibrary.org/obo/MONDO_0010823,rhizomelic chondrodysplasia punctata type 3,http://purl.obolibrary.org/obo/MONDO_0015776,rhizomelic chondrodysplasia punctata,http://identifiers.org/hgnc/327,AGPS
+http://purl.obolibrary.org/obo/MONDO_0014743,rhizomelic chondrodysplasia punctata type 5,http://purl.obolibrary.org/obo/MONDO_0015776,rhizomelic chondrodysplasia punctata,http://identifiers.org/hgnc/9719,PEX5
+http://purl.obolibrary.org/obo/MONDO_0011271,rigid spine muscular dystrophy 1,http://purl.obolibrary.org/obo/MONDO_0019951,rigid spine syndrome,http://identifiers.org/hgnc/15999,SELENON
+http://purl.obolibrary.org/obo/MONDO_0019947,rippling muscle disease 2,http://purl.obolibrary.org/obo/MONDO_0011634,rippling muscle disease,http://identifiers.org/hgnc/1529,CAV3
+http://purl.obolibrary.org/obo/MONDO_0008399,"sarcoidosis, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://identifiers.org/hgnc/4948,HLA-DRB1
+http://purl.obolibrary.org/obo/MONDO_0012888,"sarcoidosis, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://identifiers.org/hgnc/1142,BTNL2
+http://purl.obolibrary.org/obo/MONDO_0010016,sclerosteosis 1,http://purl.obolibrary.org/obo/MONDO_0017838,sclerosteosis,http://identifiers.org/hgnc/13771,SOST
+http://purl.obolibrary.org/obo/MONDO_0013679,sclerosteosis 2,http://purl.obolibrary.org/obo/MONDO_0017838,sclerosteosis,http://identifiers.org/hgnc/6696,LRP4
+http://purl.obolibrary.org/obo/MONDO_0011904,"seizures, benign familial infantile, 3",http://purl.obolibrary.org/obo/MONDO_0017615,benign familial infantile epilepsy,http://identifiers.org/hgnc/10588,SCN2A
+http://purl.obolibrary.org/obo/MONDO_0014903,"seizures, benign familial infantile, 5; BFIS5",http://purl.obolibrary.org/obo/MONDO_0017615,benign familial infantile epilepsy,http://identifiers.org/hgnc/10596,SCN8A
+http://purl.obolibrary.org/obo/MONDO_0007365,"seizures, benign familial neonatal, 1",http://purl.obolibrary.org/obo/MONDO_0016027,benign neonatal seizures,http://identifiers.org/hgnc/6296,KCNQ2
+http://purl.obolibrary.org/obo/MONDO_0007366,"seizures, benign familial neonatal, 2",http://purl.obolibrary.org/obo/MONDO_0016027,benign neonatal seizures,http://identifiers.org/hgnc/6297,KCNQ3
+http://purl.obolibrary.org/obo/MONDO_0011225,severe combined immunodeficiency due to DCLRE1C deficiency,http://purl.obolibrary.org/obo/MONDO_0015974,severe combined immunodeficiency (disease),http://identifiers.org/hgnc/17642,DCLRE1C
+http://purl.obolibrary.org/obo/MONDO_0012312,short QT syndrome type 1,http://purl.obolibrary.org/obo/MONDO_0000453,short QT syndrome,http://identifiers.org/hgnc/6251,KCNH2
+http://purl.obolibrary.org/obo/MONDO_0012313,short QT syndrome type 2,http://purl.obolibrary.org/obo/MONDO_0000453,short QT syndrome,http://identifiers.org/hgnc/6294,KCNQ1
+http://purl.obolibrary.org/obo/MONDO_0012314,short QT syndrome type 3,http://purl.obolibrary.org/obo/MONDO_0000453,short QT syndrome,http://identifiers.org/hgnc/6263,KCNJ2
+http://purl.obolibrary.org/obo/MONDO_0009738,sialidosis type 2,http://purl.obolibrary.org/obo/MONDO_0017734,sialidosis,http://identifiers.org/hgnc/7758,NEU1
+http://purl.obolibrary.org/obo/MONDO_0024562,sick sinus syndrome 1,http://purl.obolibrary.org/obo/MONDO_0001823,sick sinus syndrome,http://identifiers.org/hgnc/10593,SCN5A
+http://purl.obolibrary.org/obo/MONDO_0008102,"sick sinus syndrome 2, autosomal dominant",http://purl.obolibrary.org/obo/MONDO_0001823,sick sinus syndrome,http://identifiers.org/hgnc/16882,HCN4
+http://purl.obolibrary.org/obo/MONDO_0013568,"sick sinus syndrome 3, susceptibility to",http://purl.obolibrary.org/obo/MONDO_0012061,familial sick sinus syndrome,http://identifiers.org/hgnc/7576,MYH6
+http://purl.obolibrary.org/obo/MONDO_0014755,"skin creases, congenital symmetric circumferential, 2; CSCSC2",http://purl.obolibrary.org/obo/MONDO_0007990,multiple benign circumferential skin creases on limbs,http://identifiers.org/hgnc/6891,MAPRE2
+http://purl.obolibrary.org/obo/MONDO_0007164,spastic ataxia 1,http://purl.obolibrary.org/obo/MONDO_0017846,autosomal dominant spastic ataxia,http://identifiers.org/hgnc/12642,VAMP1
+http://purl.obolibrary.org/obo/MONDO_0012651,spastic ataxia 2,http://purl.obolibrary.org/obo/MONDO_0017845,spastic ataxia,http://identifiers.org/hgnc/6317,KIF1C
+http://purl.obolibrary.org/obo/MONDO_0012664,spastic ataxia 3,http://purl.obolibrary.org/obo/MONDO_0017847,autosomal recessive spastic ataxia,http://identifiers.org/hgnc/25133,MARS2
+http://purl.obolibrary.org/obo/MONDO_0013354,spastic ataxia 4,http://purl.obolibrary.org/obo/MONDO_0017847,autosomal recessive spastic ataxia,http://identifiers.org/hgnc/25532,MTPAP
+http://purl.obolibrary.org/obo/MONDO_0013776,spastic ataxia 5,http://purl.obolibrary.org/obo/MONDO_0017847,autosomal recessive spastic ataxia,http://identifiers.org/hgnc/315,AFG3L2
+http://purl.obolibrary.org/obo/MONDO_0014975,"spastic paraplegia 78, autosomal recessive; SPG78",http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia,http://identifiers.org/hgnc/30213,ATP13A2
+http://purl.obolibrary.org/obo/MONDO_0044207,specific granule deficiency 1,http://purl.obolibrary.org/obo/MONDO_0009506,specific granule deficiency,http://identifiers.org/hgnc/1836,CEBPE
+http://purl.obolibrary.org/obo/MONDO_0013901,spermatogenic failure 10,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/26348,SEPT12
+http://purl.obolibrary.org/obo/MONDO_0014037,spermatogenic failure 11,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/18829,KLHL10
+http://purl.obolibrary.org/obo/MONDO_0014172,spermatogenic failure 12,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/23044,NANOS1
+http://purl.obolibrary.org/obo/MONDO_0014365,spermatogenic failure 13,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/11538,TAF4B
+http://purl.obolibrary.org/obo/MONDO_0014366,spermatogenic failure 14,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/20997,ZMYND15
+http://purl.obolibrary.org/obo/MONDO_0014847,spermatogenic failure 15; SPGF15,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/28852,SYCE1
+http://purl.obolibrary.org/obo/MONDO_0014961,spermatogenic failure 16; SPGF16,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/16252,SUN5
+http://purl.obolibrary.org/obo/MONDO_0014970,spermatogenic failure 17; SPGF17,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/19218,PLCZ1
+http://purl.obolibrary.org/obo/MONDO_0011720,spermatogenic failure 3,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/14468,SLC26A8
+http://purl.obolibrary.org/obo/MONDO_0010052,spermatogenic failure 4,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/18130,SYCP3
+http://purl.obolibrary.org/obo/MONDO_0007060,spermatogenic failure 6,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/29935,SPATA16
+http://purl.obolibrary.org/obo/MONDO_0013504,spermatogenic failure 8,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/7983,NR5A1
+http://purl.obolibrary.org/obo/MONDO_0013505,spermatogenic failure 9,http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/19414,DPY19L2
+http://purl.obolibrary.org/obo/MONDO_0010647,"spermatogenic failure, X-linked, 2",http://purl.obolibrary.org/obo/MONDO_0004983,azoospermia,http://identifiers.org/hgnc/11733,TEX11
+http://purl.obolibrary.org/obo/MONDO_0014806,spinal muscular atrophy with congenital bone fractures 1,http://purl.obolibrary.org/obo/MONDO_0000209,prenatal-onset spinal muscular atrophy with congenital bone fractures,http://identifiers.org/hgnc/12310,TRIP4
+http://purl.obolibrary.org/obo/MONDO_0014807,spinal muscular atrophy with congenital bone fractures 2,http://purl.obolibrary.org/obo/MONDO_0000209,prenatal-onset spinal muscular atrophy with congenital bone fractures,http://identifiers.org/hgnc/24268,ASCC1
+http://purl.obolibrary.org/obo/MONDO_0014867,spinocerebellar ataxia 43; SCA43,http://purl.obolibrary.org/obo/MONDO_0020380,autosomal dominant cerebellar ataxia,http://identifiers.org/hgnc/7154,MME
+http://purl.obolibrary.org/obo/MONDO_0008119,spinocerebellar ataxia type 1,http://purl.obolibrary.org/obo/MONDO_0019792,autosomal dominant cerebellar ataxia type I,http://identifiers.org/hgnc/10548,ATXN1
+http://purl.obolibrary.org/obo/MONDO_0008458,spinocerebellar ataxia type 2,http://purl.obolibrary.org/obo/MONDO_0019792,autosomal dominant cerebellar ataxia type I,http://identifiers.org/hgnc/10555,ATXN2
+http://purl.obolibrary.org/obo/MONDO_0008457,spinocerebellar ataxia type 6,http://purl.obolibrary.org/obo/MONDO_0019793,autosomal dominant cerebellar ataxia type III,http://identifiers.org/hgnc/1388,CACNA1A
+http://purl.obolibrary.org/obo/MONDO_0008120,spinocerebellar ataxia type 7,http://purl.obolibrary.org/obo/MONDO_0016163,autosomal dominant cerebellar ataxia type II,http://identifiers.org/hgnc/10560,ATXN7
+http://purl.obolibrary.org/obo/MONDO_0014845,"spinocerebellar ataxia, autosomal recessive 22; SCAR22",http://purl.obolibrary.org/obo/MONDO_0015244,autosomal recessive cerebellar ataxia,http://identifiers.org/hgnc/28385,VWA3B
+http://purl.obolibrary.org/obo/MONDO_0014934,"spinocerebellar ataxia, autosomal recessive 24; SCAR24",http://purl.obolibrary.org/obo/MONDO_0020380,autosomal dominant cerebellar ataxia,http://identifiers.org/hgnc/23230,UBA5
+http://purl.obolibrary.org/obo/MONDO_0011535,split hand-foot malformation 4,http://purl.obolibrary.org/obo/MONDO_0016576,split hand-foot malformation,http://identifiers.org/hgnc/15979,TP63
+http://purl.obolibrary.org/obo/MONDO_0009157,split hand-foot malformation 6,http://purl.obolibrary.org/obo/MONDO_0016576,split hand-foot malformation,http://identifiers.org/hgnc/12775,WNT10B
+http://purl.obolibrary.org/obo/MONDO_0007126,"spondyloarthropathy, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0024512,"spondyloarthropathy, susceptibility to",http://identifiers.org/hgnc/4932,HLA-B
+http://purl.obolibrary.org/obo/MONDO_0012349,"spondylocostal dysostosis 3, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0010180,autosomal recessive spondylocostal dysostosis,http://identifiers.org/hgnc/6560,LFNG
+http://purl.obolibrary.org/obo/MONDO_0013366,"spondylocostal dysostosis 4, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0010180,autosomal recessive spondylocostal dysostosis,http://identifiers.org/hgnc/15977,HES7
+http://purl.obolibrary.org/obo/MONDO_0007389,spondylocostal dysostosis 5,http://purl.obolibrary.org/obo/MONDO_0000359,spondylocostal dysostosis,http://identifiers.org/hgnc/11605,TBX6
+http://purl.obolibrary.org/obo/MONDO_0014694,"spondylocostal dysostosis 6, autosomal recessive",http://purl.obolibrary.org/obo/MONDO_0010180,autosomal recessive spondylocostal dysostosis,http://identifiers.org/hgnc/21390,RIPPLY2
+http://purl.obolibrary.org/obo/MONDO_0010075,"spondyloepimetaphyseal dysplasia with joint laxity, type 1, with or without fractures",http://purl.obolibrary.org/obo/MONDO_0019675,spondyloepimetaphyseal dysplasia with joint laxity,http://identifiers.org/hgnc/17978,B3GALT6
+http://purl.obolibrary.org/obo/MONDO_0014835,"striatal degeneration, autosomal dominant 2; ADSD2",http://purl.obolibrary.org/obo/MONDO_0000211,"striatal degeneration, autosomal dominant",http://identifiers.org/hgnc/8772,PDE10A
+http://purl.obolibrary.org/obo/MONDO_0013712,"surfactant metabolism dysfunction, pulmonary, 5",http://purl.obolibrary.org/obo/MONDO_0012580,hereditary pulmonary alveolar proteinosis,http://identifiers.org/hgnc/2436,CSF2RB
+http://purl.obolibrary.org/obo/MONDO_0014125,"symphalangism, proximal, 1B",http://purl.obolibrary.org/obo/MONDO_0008511,proximal symphalangism (disease),http://identifiers.org/hgnc/4220,GDF5
+http://purl.obolibrary.org/obo/MONDO_0008514,syndactyly type 3,http://purl.obolibrary.org/obo/MONDO_0019530,non-syndromic syndactyly,http://identifiers.org/hgnc/4274,GJA1
+http://purl.obolibrary.org/obo/MONDO_0008515,syndactyly type 4,http://purl.obolibrary.org/obo/MONDO_0019530,non-syndromic syndactyly,http://identifiers.org/hgnc/13243,LMBR1
+http://purl.obolibrary.org/obo/MONDO_0010669,syndactyly type 8,http://purl.obolibrary.org/obo/MONDO_0019530,non-syndromic syndactyly,http://identifiers.org/hgnc/3672,FGF16
+http://purl.obolibrary.org/obo/MONDO_0010398,syndromic X-linked intellectual disability 14,http://purl.obolibrary.org/obo/MONDO_0020119,X-linked syndromic intellectual disability,http://identifiers.org/hgnc/20439,UPF3B
+http://purl.obolibrary.org/obo/MONDO_0010501,syndromic X-linked intellectual disability 34,http://purl.obolibrary.org/obo/MONDO_0020119,X-linked syndromic intellectual disability,http://identifiers.org/hgnc/7871,NONO
+http://purl.obolibrary.org/obo/MONDO_0012413,syndromic microphthalmia type 5,http://purl.obolibrary.org/obo/MONDO_0016073,syndromic microphthalmia,http://identifiers.org/hgnc/8522,OTX2
+http://purl.obolibrary.org/obo/MONDO_0008513,synpolydactyly type 1,http://purl.obolibrary.org/obo/MONDO_0000722,non-syndromic synpolydactyly,http://identifiers.org/hgnc/5136,HOXD13
+http://purl.obolibrary.org/obo/MONDO_0011984,synpolydactyly type 2,http://purl.obolibrary.org/obo/MONDO_0000722,non-syndromic synpolydactyly,http://identifiers.org/hgnc/3600,FBLN1
+http://purl.obolibrary.org/obo/MONDO_0011138,"systemic lupus erythematosus, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0007915,systemic lupus erythematosus (disease),http://identifiers.org/hgnc/11851,TLR5
+http://purl.obolibrary.org/obo/MONDO_0012834,"systemic lupus erythematosus, susceptibility to, 10",http://purl.obolibrary.org/obo/MONDO_0007915,systemic lupus erythematosus (disease),http://identifiers.org/hgnc/6120,IRF5
+http://purl.obolibrary.org/obo/MONDO_0012835,"systemic lupus erythematosus, susceptibility to, 11",http://purl.obolibrary.org/obo/MONDO_0007915,systemic lupus erythematosus (disease),http://identifiers.org/hgnc/11365,STAT4
+http://purl.obolibrary.org/obo/MONDO_0012584,"systemic lupus erythematosus, susceptibility to, 9",http://purl.obolibrary.org/obo/MONDO_0007915,systemic lupus erythematosus (disease),http://identifiers.org/hgnc/2336,CR2
+http://purl.obolibrary.org/obo/MONDO_0010880,"telangiectasia, hereditary hemorrhagic, type 2",http://purl.obolibrary.org/obo/MONDO_0019180,hereditary hemorrhagic telangiectasia,http://identifiers.org/hgnc/175,ACVRL1
+http://purl.obolibrary.org/obo/MONDO_0014217,"telangiectasia, hereditary hemorrhagic, type 5",http://purl.obolibrary.org/obo/MONDO_0019180,hereditary hemorrhagic telangiectasia,http://identifiers.org/hgnc/4217,GDF2
+http://purl.obolibrary.org/obo/MONDO_0010117,three M syndrome 1,http://purl.obolibrary.org/obo/MONDO_0007477,3-M syndrome,http://identifiers.org/hgnc/21024,CUL7
+http://purl.obolibrary.org/obo/MONDO_0013039,three M syndrome 2,http://purl.obolibrary.org/obo/MONDO_0007477,3-M syndrome,http://identifiers.org/hgnc/29092,OBSL1
+http://purl.obolibrary.org/obo/MONDO_0013627,three M syndrome 3,http://purl.obolibrary.org/obo/MONDO_0007477,3-M syndrome,http://identifiers.org/hgnc/25367,CCDC8
+http://purl.obolibrary.org/obo/MONDO_0011173,thrombocythemia 2,http://purl.obolibrary.org/obo/MONDO_0005029,essential thrombocythemia,http://identifiers.org/hgnc/7217,MPL
+http://purl.obolibrary.org/obo/MONDO_0013794,thrombocythemia 3,http://purl.obolibrary.org/obo/MONDO_0005029,essential thrombocythemia,http://identifiers.org/hgnc/6192,JAK2
+http://purl.obolibrary.org/obo/MONDO_0012775,thrombocytopenia 4,http://purl.obolibrary.org/obo/MONDO_0002049,thrombocytopenia,http://identifiers.org/hgnc/19986,CYCS
+http://purl.obolibrary.org/obo/MONDO_0014536,thrombocytopenia 5,http://purl.obolibrary.org/obo/MONDO_0002049,thrombocytopenia,http://identifiers.org/hgnc/3495,ETV6
+http://purl.obolibrary.org/obo/MONDO_0014681,"thyroid cancer, nonmedullary, 4",http://purl.obolibrary.org/obo/MONDO_0000201,"thyroid cancer, nonmedullary",http://identifiers.org/hgnc/3806,FOXE1
+http://purl.obolibrary.org/obo/MONDO_0014682,"thyroid cancer, nonmedullary, 5",http://purl.obolibrary.org/obo/MONDO_0000201,"thyroid cancer, nonmedullary",http://identifiers.org/hgnc/4798,HABP2
+http://purl.obolibrary.org/obo/MONDO_0010133,thyroid dyshormonogenesis 2A,http://purl.obolibrary.org/obo/MONDO_0010132,familial thyroid dyshormonogenesis,http://identifiers.org/hgnc/12015,TPO
+http://purl.obolibrary.org/obo/MONDO_0010135,thyroid dyshormonogenesis 3,http://purl.obolibrary.org/obo/MONDO_0010132,familial thyroid dyshormonogenesis,http://identifiers.org/hgnc/11764,TG
+http://purl.obolibrary.org/obo/MONDO_0010136,thyroid dyshormonogenesis 4,http://purl.obolibrary.org/obo/MONDO_0010132,familial thyroid dyshormonogenesis,http://identifiers.org/hgnc/21071,IYD
+http://purl.obolibrary.org/obo/MONDO_0010137,thyroid dyshormonogenesis 5,http://purl.obolibrary.org/obo/MONDO_0010132,familial thyroid dyshormonogenesis,http://identifiers.org/hgnc/32698,DUOXA2
+http://purl.obolibrary.org/obo/MONDO_0011792,thyroid dyshormonogenesis 6,http://purl.obolibrary.org/obo/MONDO_0010132,familial thyroid dyshormonogenesis,http://identifiers.org/hgnc/13273,DUOX2
+http://purl.obolibrary.org/obo/MONDO_0008570,"thyrotoxic periodic paralysis, susceptibility to, 1",http://purl.obolibrary.org/obo/MONDO_0019201,thyrotoxic periodic paralysis,http://identifiers.org/hgnc/1397,CACNA1S
+http://purl.obolibrary.org/obo/MONDO_0013193,"thyrotoxic periodic paralysis, susceptibility to, 2",http://purl.obolibrary.org/obo/MONDO_0019201,thyrotoxic periodic paralysis,http://identifiers.org/hgnc/39080,KCNJ18
+http://purl.obolibrary.org/obo/MONDO_0007129,"tooth agenesis, selective, 1",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/7391,MSX1
+http://purl.obolibrary.org/obo/MONDO_0011477,"tooth agenesis, selective, 3",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/8623,PAX9
+http://purl.obolibrary.org/obo/MONDO_0007881,"tooth agenesis, selective, 4",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/13829,WNT10A
+http://purl.obolibrary.org/obo/MONDO_0014749,"tooth agenesis, selective, 7; STHAG7",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/6698,LRP6
+http://purl.obolibrary.org/obo/MONDO_0014901,"tooth agenesis, selective, 8; STHAG8",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/12775,WNT10B
+http://purl.obolibrary.org/obo/MONDO_0014999,"tooth agenesis, selective, 9; STHAG9",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/17655,GREM2
+http://purl.obolibrary.org/obo/MONDO_0010741,"tooth agenesis, selective, X-linked, 1",http://purl.obolibrary.org/obo/MONDO_0005486,tooth agenesis,http://identifiers.org/hgnc/3157,EDA
+http://purl.obolibrary.org/obo/MONDO_0009141,torsion dystonia 2,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder,http://identifiers.org/hgnc/5144,HPCA
+http://purl.obolibrary.org/obo/MONDO_0011264,torsion dystonia 6,http://purl.obolibrary.org/obo/MONDO_0018303,generalized isolated dystonia,http://identifiers.org/hgnc/20856,THAP1
+http://purl.obolibrary.org/obo/MONDO_0008590,"tremor, hereditary essential, 1",http://purl.obolibrary.org/obo/MONDO_0003233,essential tremor,http://identifiers.org/hgnc/3024,DRD3
+http://purl.obolibrary.org/obo/MONDO_0013888,"tremor, hereditary essential, 4",http://purl.obolibrary.org/obo/MONDO_0003233,essential tremor,http://identifiers.org/hgnc/4010,FUS
+http://purl.obolibrary.org/obo/MONDO_0014756,"tremor, hereditary essential, 5; ETM5",http://purl.obolibrary.org/obo/MONDO_0003233,essential tremor,http://identifiers.org/hgnc/29945,TENM4
+http://purl.obolibrary.org/obo/MONDO_0024541,trichohepatoenteric syndrome 1,http://purl.obolibrary.org/obo/MONDO_0009105,tricho-hepato-enteric syndrome,http://identifiers.org/hgnc/23639,TTC37
+http://purl.obolibrary.org/obo/MONDO_0013818,trichohepatoenteric syndrome 2,http://purl.obolibrary.org/obo/MONDO_0009105,tricho-hepato-enteric syndrome,http://identifiers.org/hgnc/10898,SKIV2L
+http://purl.obolibrary.org/obo/MONDO_0021013,"trichothiodystrophy 4, nonphotosensitive",http://purl.obolibrary.org/obo/MONDO_0009317,nonphotosensitive trichothiodystrophy,http://identifiers.org/hgnc/16002,MPLKIP
+http://purl.obolibrary.org/obo/MONDO_0010495,"trichothiodystrophy 5, nonphotosensitive",http://purl.obolibrary.org/obo/MONDO_0009317,nonphotosensitive trichothiodystrophy,http://identifiers.org/hgnc/12974,RNF113A
+http://purl.obolibrary.org/obo/MONDO_0014841,"trichothiodystrophy 6, nonphotosensitive; TTD6",http://purl.obolibrary.org/obo/MONDO_0009317,nonphotosensitive trichothiodystrophy,http://identifiers.org/hgnc/4651,GTF2E2
+http://purl.obolibrary.org/obo/MONDO_0008603,trigonocephaly 1,http://purl.obolibrary.org/obo/MONDO_0018065,isolated trigonocephaly,http://identifiers.org/hgnc/3688,FGFR1
+http://purl.obolibrary.org/obo/MONDO_0013774,trigonocephaly 2,http://purl.obolibrary.org/obo/MONDO_0018065,isolated trigonocephaly,http://identifiers.org/hgnc/23399,FREM1
+http://purl.obolibrary.org/obo/MONDO_0008612,tuberous sclerosis 1,http://purl.obolibrary.org/obo/MONDO_0001734,tuberous sclerosis,http://identifiers.org/hgnc/12362,TSC1
+http://purl.obolibrary.org/obo/MONDO_0011168,type 1 diabetes mellitus 10,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus,http://identifiers.org/hgnc/6008,IL2RA
+http://purl.obolibrary.org/obo/MONDO_0011068,type 1 diabetes mellitus 12,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus,http://identifiers.org/hgnc/2505,CTLA4
+http://purl.obolibrary.org/obo/MONDO_0007454,type 1 diabetes mellitus 2,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus,http://identifiers.org/hgnc/6081,INS
+http://purl.obolibrary.org/obo/MONDO_0012919,type 1 diabetes mellitus 20,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus,http://identifiers.org/hgnc/11621,HNF1A
+http://purl.obolibrary.org/obo/MONDO_0012921,type 1 diabetes mellitus 22,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus,http://identifiers.org/hgnc/1606,CCR5
+http://purl.obolibrary.org/obo/MONDO_0010863,type 1 diabetes mellitus 5,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus,http://identifiers.org/hgnc/21181,SUMO4
+http://purl.obolibrary.org/obo/MONDO_0013421,type II complement component 8 deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1353,C8B
+http://purl.obolibrary.org/obo/MONDO_0013422,type i complement component 8 deficiency,http://purl.obolibrary.org/obo/MONDO_0000015,classic complement early component deficiency,http://identifiers.org/hgnc/1352,C8A
+http://purl.obolibrary.org/obo/MONDO_0014989,uncombable hair syndrome 2; UHS2,http://purl.obolibrary.org/obo/MONDO_0008621,uncombable hair syndrome,http://identifiers.org/hgnc/11779,TGM3
+http://purl.obolibrary.org/obo/MONDO_0014990,uncombable hair syndrome 3; UHS3,http://purl.obolibrary.org/obo/MONDO_0008621,uncombable hair syndrome,http://identifiers.org/hgnc/11791,TCHH
+http://purl.obolibrary.org/obo/MONDO_0014049,urofacial syndrome 2,http://purl.obolibrary.org/obo/MONDO_0000463,Ochoa syndrome,http://identifiers.org/hgnc/20889,LRIG2
+http://purl.obolibrary.org/obo/MONDO_0011070,van Maldergem syndrome 1,http://purl.obolibrary.org/obo/MONDO_0017813,van Maldergem syndrome,http://identifiers.org/hgnc/13681,DCHS1
+http://purl.obolibrary.org/obo/MONDO_0014242,van Maldergem syndrome 2,http://purl.obolibrary.org/obo/MONDO_0017813,van Maldergem syndrome,http://identifiers.org/hgnc/23109,FAT4
+http://purl.obolibrary.org/obo/MONDO_0007333,van der Woude syndrome 1,http://purl.obolibrary.org/obo/MONDO_0019508,van der Woude syndrome,http://identifiers.org/hgnc/6121,IRF6
+http://purl.obolibrary.org/obo/MONDO_0011712,van der Woude syndrome 2,http://purl.obolibrary.org/obo/MONDO_0019508,van der Woude syndrome,http://identifiers.org/hgnc/25839,GRHL3
+http://purl.obolibrary.org/obo/MONDO_0013063,"ventricular fibrillation, paroxysmal familial, 2",http://purl.obolibrary.org/obo/MONDO_0000190,ventricular fibrillation (disease),http://identifiers.org/hgnc/3010,DPP6
+http://purl.obolibrary.org/obo/MONDO_0013746,ventricular septal defect 1,http://purl.obolibrary.org/obo/MONDO_0002070,ventricular septal defect (disease),http://identifiers.org/hgnc/4173,GATA4
+http://purl.obolibrary.org/obo/MONDO_0013748,ventricular septal defect 2,http://purl.obolibrary.org/obo/MONDO_0002070,ventricular septal defect (disease),http://identifiers.org/hgnc/1987,CITED2
+http://purl.obolibrary.org/obo/MONDO_0013749,ventricular septal defect 3,http://purl.obolibrary.org/obo/MONDO_0002070,ventricular septal defect (disease),http://identifiers.org/hgnc/2488,NKX2-5
+http://purl.obolibrary.org/obo/MONDO_0012573,vesicoureteral reflux 2,http://purl.obolibrary.org/obo/MONDO_0006007,vesicoureteral reflux (disease),http://identifiers.org/hgnc/10250,ROBO2
+http://purl.obolibrary.org/obo/MONDO_0013356,vesicoureteral reflux 3,http://purl.obolibrary.org/obo/MONDO_0006007,vesicoureteral reflux (disease),http://identifiers.org/hgnc/18122,SOX17
+http://purl.obolibrary.org/obo/MONDO_0014422,vesicoureteral reflux 8,http://purl.obolibrary.org/obo/MONDO_0006007,vesicoureteral reflux (disease),http://identifiers.org/hgnc/11976,TNXB
+http://purl.obolibrary.org/obo/MONDO_0010810,"vitamin D hydroxylation-deficient rickets, type 1B",http://purl.obolibrary.org/obo/MONDO_0009924,"vitamin D-dependent rickets, type 1",http://identifiers.org/hgnc/20580,CYP2R1
+http://purl.obolibrary.org/obo/MONDO_0010186,"vitamin D-dependent rickets, type 2A",http://purl.obolibrary.org/obo/MONDO_0019642,"vitamin D-dependent rickets, type 2",http://identifiers.org/hgnc/12679,VDR
+http://purl.obolibrary.org/obo/MONDO_0010187,"vitamin K-dependent clotting factors, combined deficiency of, type 1",http://purl.obolibrary.org/obo/MONDO_0000184,congenital vitamin K-dependent coagulation factors combined deficiency,http://identifiers.org/hgnc/4247,GGCX
+http://purl.obolibrary.org/obo/MONDO_0011837,"vitamin K-dependent clotting factors, combined deficiency of, type 2",http://purl.obolibrary.org/obo/MONDO_0000184,congenital vitamin K-dependent coagulation factors combined deficiency,http://identifiers.org/hgnc/23663,VKORC1
+http://purl.obolibrary.org/obo/MONDO_0008676,white sponge nevus 1,http://purl.obolibrary.org/obo/MONDO_0015748,hereditary mucosal leukokeratosis,http://identifiers.org/hgnc/6441,KRT4
+http://purl.obolibrary.org/obo/MONDO_0014765,"woolly hair, autosomal recessive 3",http://purl.obolibrary.org/obo/MONDO_0008686,woolly hair (disease),http://identifiers.org/hgnc/30839,KRT25
+http://purl.obolibrary.org/obo/MONDO_0010210,xeroderma pigmentosum group A,http://purl.obolibrary.org/obo/MONDO_0019600,xeroderma pigmentosum,http://identifiers.org/hgnc/12814,XPA
+http://purl.obolibrary.org/obo/MONDO_0012531,xeroderma pigmentosum group B,http://purl.obolibrary.org/obo/MONDO_0019600,xeroderma pigmentosum,http://identifiers.org/hgnc/3435,ERCC3
+http://purl.obolibrary.org/obo/MONDO_0010212,xeroderma pigmentosum group D,http://purl.obolibrary.org/obo/MONDO_0019600,xeroderma pigmentosum,http://identifiers.org/hgnc/3434,ERCC2
+http://purl.obolibrary.org/obo/MONDO_0010215,xeroderma pigmentosum group F,http://purl.obolibrary.org/obo/MONDO_0019600,xeroderma pigmentosum,http://identifiers.org/hgnc/3436,ERCC4
+http://purl.obolibrary.org/obo/MONDO_0010216,xeroderma pigmentosum group G,http://purl.obolibrary.org/obo/MONDO_0019600,xeroderma pigmentosum,http://identifiers.org/hgnc/3437,ERCC5

--- a/src/patterns/disease_series_by_gene.yaml
+++ b/src/patterns/disease_series_by_gene.yaml
@@ -1,7 +1,7 @@
 pattern_name: disease_series_by_gene
 
 description: >-
-  Examples: Bardet-Biedl type N is defined by gene involved
+  Examples: Bardet-Biedl type N is defined by gene involved.
   
 classes:
   disease: MONDO:0000001

--- a/src/patterns/disrupts_process.csv
+++ b/src/patterns/disrupts_process.csv
@@ -1,0 +1,57 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0012996,AGAT deficiency,http://purl.obolibrary.org/obo/GO_0015068,glycine amidinotransferase activity
+http://purl.obolibrary.org/obo/MONDO_0021190,DNA repair disease,http://purl.obolibrary.org/obo/GO_0006281,DNA repair
+http://purl.obolibrary.org/obo/MONDO_0018274,GM3 synthase deficiency,http://purl.obolibrary.org/obo/GO_0047291,"lactosylceramide alpha-2,3-sialyltransferase activity"
+http://purl.obolibrary.org/obo/MONDO_0021060,RASopathy,http://purl.obolibrary.org/obo/GO_0007265,Ras protein signal transduction
+http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease,http://purl.obolibrary.org/obo/GO_0016068,type I hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0017779,alpha-N-acetylgalactosaminidase deficiency,http://purl.obolibrary.org/obo/GO_0008456,alpha-N-acetylgalactosaminidase activity
+http://purl.obolibrary.org/obo/MONDO_0037871,amino acid metabolism disease,http://purl.obolibrary.org/obo/GO_0006520,cellular amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0024422,auditory perceptual disorders,http://purl.obolibrary.org/obo/GO_0007605,sensory perception of sound
+http://purl.obolibrary.org/obo/MONDO_0022606,branchial arch disease,http://purl.obolibrary.org/obo/GO_0060037,pharyngeal system development
+http://purl.obolibrary.org/obo/MONDO_0037792,carbohydrate metabolism disease,http://purl.obolibrary.org/obo/GO_0005975,carbohydrate metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045015,carbohydrate transport disease,http://purl.obolibrary.org/obo/GO_0008643,carbohydrate transport
+http://purl.obolibrary.org/obo/MONDO_0021016,channelopathy,http://purl.obolibrary.org/obo/GO_0005216,ion channel activity
+http://purl.obolibrary.org/obo/MONDO_0045017,cholesterol biosynthetic process disease,http://purl.obolibrary.org/obo/GO_0006695,cholesterol biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0045016,cholesterol catabolic process disease,http://purl.obolibrary.org/obo/GO_0006707,cholesterol catabolic process
+http://purl.obolibrary.org/obo/MONDO_0045008,cholesterol metabolism disease,http://purl.obolibrary.org/obo/GO_0008203,cholesterol metabolic process
+http://purl.obolibrary.org/obo/MONDO_0003832,complement deficiency,http://purl.obolibrary.org/obo/GO_0006956,complement activation
+http://purl.obolibrary.org/obo/MONDO_0024239,congenital anomaly of cardiovascular system,http://purl.obolibrary.org/obo/GO_0072358,cardiovascular system development
+http://purl.obolibrary.org/obo/MONDO_0019512,congenital heart malformation,http://purl.obolibrary.org/obo/GO_0007507,heart development
+http://purl.obolibrary.org/obo/MONDO_0045018,creatine biosynthetic process disease,http://purl.obolibrary.org/obo/GO_0006601,creatine biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0022918,cytokine deficiency,http://purl.obolibrary.org/obo/GO_0005125,cytokine activity
+http://purl.obolibrary.org/obo/MONDO_0022919,cytokine receptor deficiency,http://purl.obolibrary.org/obo/GO_0004896,cytokine receptor activity
+http://purl.obolibrary.org/obo/MONDO_0022953,delta-1-pyrroline-5-carboxylate dehydrogenase deficiency,http://purl.obolibrary.org/obo/GO_0003842,1-pyrroline-5-carboxylate dehydrogenase activity
+http://purl.obolibrary.org/obo/MONDO_0019755,developmental defect during embryogenesis,http://purl.obolibrary.org/obo/GO_0048598,embryonic morphogenesis
+http://purl.obolibrary.org/obo/MONDO_0009862,dihydropteridine reductase deficiency,http://purl.obolibrary.org/obo/GO_0004155,"6,7-dihydropteridine reductase activity"
+http://purl.obolibrary.org/obo/MONDO_0011610,dimethylglycine dehydrogenase deficiency,http://purl.obolibrary.org/obo/GO_0047865,dimethylglycine dehydrogenase activity
+http://purl.obolibrary.org/obo/MONDO_0024321,disorder of GPI anchor biosynthesis,http://purl.obolibrary.org/obo/GO_0006506,GPI anchor biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0042970,disorder of glutamate decarboxylase,http://purl.obolibrary.org/obo/GO_0004351,glutamate decarboxylase activity
+http://purl.obolibrary.org/obo/MONDO_0024322,disorder of glycosylation,http://purl.obolibrary.org/obo/GO_0070085,glycosylation
+http://purl.obolibrary.org/obo/MONDO_0044209,disorder of lectin complement activation pathway,http://purl.obolibrary.org/obo/GO_0001867,"complement activation, lectin pathway"
+http://purl.obolibrary.org/obo/MONDO_0045022,disorder of organic acid metabolism,http://purl.obolibrary.org/obo/GO_0006082,organic acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017740,disorder of protein N-glycosylation,http://purl.obolibrary.org/obo/GO_0006487,protein N-linked glycosylation
+http://purl.obolibrary.org/obo/MONDO_0017741,disorder of protein O-glycosylation,http://purl.obolibrary.org/obo/GO_0006493,protein O-linked glycosylation
+http://purl.obolibrary.org/obo/MONDO_0037807,glycerol metabolism disease,http://purl.obolibrary.org/obo/GO_0006071,glycerol metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045020,glycine metabolism disease,http://purl.obolibrary.org/obo/GO_0006544,glycine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045010,glycoprotein metabolism disease,http://purl.obolibrary.org/obo/GO_0009100,glycoprotein metabolic process
+http://purl.obolibrary.org/obo/MONDO_0012999,guanidinoacetate methyltransferase deficiency,http://purl.obolibrary.org/obo/GO_0030731,guanidinoacetate N-methyltransferase activity
+http://purl.obolibrary.org/obo/MONDO_0004738,histidine metabolism disease,http://purl.obolibrary.org/obo/GO_0006547,histidine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0021189,intestinal motility disease,http://purl.obolibrary.org/obo/GO_0120054,intestinal motility
+http://purl.obolibrary.org/obo/MONDO_0100004,mast cell activation syndrome,http://purl.obolibrary.org/obo/GO_0045576,mast cell activation
+http://purl.obolibrary.org/obo/MONDO_0005084,mental disorder,http://purl.obolibrary.org/obo/MF_0000020,mental process
+http://purl.obolibrary.org/obo/MONDO_0005066,metabolic disease,http://purl.obolibrary.org/obo/GO_0008152,metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017059,neural tube closure defect,http://purl.obolibrary.org/obo/GO_0001843,neural tube closure
+http://purl.obolibrary.org/obo/MONDO_0021635,neurocristopathy,http://purl.obolibrary.org/obo/GO_0014032,neural crest cell development
+http://purl.obolibrary.org/obo/MONDO_0037821,porphyrin metabolism disease,http://purl.obolibrary.org/obo/GO_0006778,porphyrin-containing compound metabolic process
+http://purl.obolibrary.org/obo/MONDO_0037829,purine metabolism disease,http://purl.obolibrary.org/obo/GO_0006144,purine nucleobase metabolic process
+http://purl.obolibrary.org/obo/MONDO_0037937,pyrimidine metabolism disease,http://purl.obolibrary.org/obo/GO_0006206,pyrimidine nucleobase metabolic process
+http://purl.obolibrary.org/obo/MONDO_0006510,renal tubular transport disease,http://purl.obolibrary.org/obo/GO_0070293,renal absorption
+http://purl.obolibrary.org/obo/MONDO_0008891,riboflavin transporter deficiency,http://purl.obolibrary.org/obo/GO_0032217,riboflavin transmembrane transporter activity
+http://purl.obolibrary.org/obo/MONDO_0002145,sex differentiation disease,http://purl.obolibrary.org/obo/GO_0007548,sex differentiation
+http://purl.obolibrary.org/obo/MONDO_0045012,steroid metabolism disease,http://purl.obolibrary.org/obo/GO_0008202,steroid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0056803,sulfur metabolism disease,http://purl.obolibrary.org/obo/GO_0006790,sulfur compound metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045014,tetrahydrobiopterin metabolic process disease,http://purl.obolibrary.org/obo/GO_0046146,tetrahydrobiopterin metabolic process
+http://purl.obolibrary.org/obo/MONDO_0025512,type II hypersensitivity reaction disease,http://purl.obolibrary.org/obo/GO_0002445,type II hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0007004,type III hypersensitivity disease,http://purl.obolibrary.org/obo/GO_0001802,type III hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0002459,type IV hypersensitivity disease,http://purl.obolibrary.org/obo/GO_0001806,type IV hypersensitivity
+http://purl.obolibrary.org/obo/MONDO_0037870,valine metabolism disease,http://purl.obolibrary.org/obo/GO_0006573,valine metabolic process

--- a/src/patterns/environmental_stimulus.csv
+++ b/src/patterns/environmental_stimulus.csv
@@ -1,5 +1,9 @@
 iri,iri label,disease,disease label,stimulus,stimulus label
-MONDO:0016466,asbestosis,MONDO:0015926,pneumoconiosis,ENVO:02000106,asbestos dust
-MONDO:0001540,bagassosis,MONDO:0004553,extrinsic allergic alveolitis,ENVO:00002872,bagasse
-MONDO:0006688,byssinosis,MONDO:0015926,pneumoconiosis,ENVO:02000108,cotton dust
-MONDO:0001000,mixed mineral dust pneumoconiosis,MONDO:0015926,pneumoconiosis,ENVO:02000100,mineral dust
+http://purl.obolibrary.org/obo/MONDO_0006654,anthracosis,http://purl.obolibrary.org/obo/MONDO_0015926,pneumoconiosis,http://purl.obolibrary.org/obo/ENVO_02000099,coal dust
+http://purl.obolibrary.org/obo/MONDO_0016466,asbestosis,http://purl.obolibrary.org/obo/MONDO_0015926,pneumoconiosis,http://purl.obolibrary.org/obo/ENVO_02000106,asbestos dust
+http://purl.obolibrary.org/obo/MONDO_0001540,bagassosis,http://purl.obolibrary.org/obo/MONDO_0004553,extrinsic allergic alveolitis,http://purl.obolibrary.org/obo/ENVO_00002872,bagasse
+http://purl.obolibrary.org/obo/MONDO_0006688,byssinosis,http://purl.obolibrary.org/obo/MONDO_0015926,pneumoconiosis,http://purl.obolibrary.org/obo/ENVO_02000108,cotton dust
+http://purl.obolibrary.org/obo/MONDO_0002497,food allergy,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease,http://purl.obolibrary.org/obo/FOODON_00002403,food material
+http://purl.obolibrary.org/obo/MONDO_0001000,mixed mineral dust pneumoconiosis,http://purl.obolibrary.org/obo/MONDO_0015926,pneumoconiosis,http://purl.obolibrary.org/obo/ENVO_02000100,mineral dust
+http://purl.obolibrary.org/obo/MONDO_0005425,podoconiosis,http://purl.obolibrary.org/obo/MONDO_0005424,elephantiasis,http://purl.obolibrary.org/obo/ENVO_00001998,soil
+http://purl.obolibrary.org/obo/MONDO_0007021,wheat allergic disease,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease,http://purl.obolibrary.org/obo/FOODON_00001141,wheat based food product

--- a/src/patterns/genetic.csv
+++ b/src/patterns/genetic.csv
@@ -1,22 +1,36 @@
 iri,iri label,disease,disease label
-MONDO:0021034,genetic alopecia,MONDO:0004907,alopecia
-MONDO:0015509,genetic biliary tract disease,MONDO:0004868,biliary tract disease
-MONDO:0015110,genetic cardiac rhythm disease,MONDO:0007263,cardiac rhythm disease
-MONDO:0017129,genetic cardiac tumor,MONDO:0001340,heart cancer
-MONDO:0015547,genetic dementia,MONDO:0001627,dementia
-MONDO:0021026,genetic epidermal appendage anomaly,MONDO:0019277,epidermal appendage anomaly
-MONDO:0021027,genetic hair anomaly,MONDO:0019278,hair anomaly
-MONDO:0015541,genetic hemophagocytic lymphohistiocytosis,MONDO:0015540,hemophagocytic syndrome
-MONDO:0018300,genetic hyperaldosteronism,MONDO:0003009,hyperaldosteronism
-MONDO:0016166,genetic hyperparathyroidism,MONDO:0001741,hyperparathyroidism
-MONDO:0015512,genetic hypertension,MONDO:0005044,hypertension
-MONDO:0016165,genetic hypoparathyroidism,MONDO:0001220,hypoparathyroidism
-MONDO:0017143,genetic infertility,MONDO:0005047,infertility
-MONDO:0020087,genetic lipodystrophy,MONDO:0006573,lipodystrophy (disease)
-MONDO:0020242,genetic macular dystrophy,MONDO:0000054,macular dystrophy (disease)
-MONDO:0021028,genetic nail anomaly,MONDO:0019283,nail anomaly
-MONDO:0015952,genetic neurodegenerative disease,MONDO:0005559,neurodegenerative disease
-MONDO:0019182,genetic obesity,MONDO:0011122,obesity (disease)
-MONDO:0020127,genetic peripheral neuropathy,MONDO:0005244,peripheral neuropathy
-MONDO:0021029,genetic sebaceous gland anomaly,MONDO:0019286,sebaceous gland anomaly
-MONDO:0017127,genetic soft tissue tumor,MONDO:0002616,mesenchymal cell neoplasm
+http://purl.obolibrary.org/obo/MONDO_0016072,anomaly of puberty or/and menstrual cycle of genetic origin,http://purl.obolibrary.org/obo/MONDO_0015860,anomaly of puberty or/and menstrual cycle
+http://purl.obolibrary.org/obo/MONDO_0018384,avascular necrosis of genetic origin,http://purl.obolibrary.org/obo/MONDO_0018373,avascular necrosis
+http://purl.obolibrary.org/obo/MONDO_0013099,"combined pituitary hormone deficiencies, genetic form",http://purl.obolibrary.org/obo/MONDO_0005152,hypopituitarism
+http://purl.obolibrary.org/obo/MONDO_0018454,dysostosis of genetic origin,http://purl.obolibrary.org/obo/MONDO_0018234,dysostosis
+http://purl.obolibrary.org/obo/MONDO_0007781,"essential hypertension, genetic",http://purl.obolibrary.org/obo/MONDO_0001134,essential hypertension
+http://purl.obolibrary.org/obo/MONDO_0020088,familial partial lipodystrophy,http://purl.obolibrary.org/obo/MONDO_0027767,partial lipodystrophy
+http://purl.obolibrary.org/obo/MONDO_0021034,genetic alopecia,http://purl.obolibrary.org/obo/MONDO_0004907,alopecia
+http://purl.obolibrary.org/obo/MONDO_0015509,genetic biliary tract disease,http://purl.obolibrary.org/obo/MONDO_0004868,biliary tract disease
+http://purl.obolibrary.org/obo/MONDO_0015110,genetic cardiac rhythm disease,http://purl.obolibrary.org/obo/MONDO_0007263,cardiac rhythm disease
+http://purl.obolibrary.org/obo/MONDO_0015547,genetic dementia,http://purl.obolibrary.org/obo/MONDO_0001627,dementia
+http://purl.obolibrary.org/obo/MONDO_0021026,genetic epidermal appendage anomaly,http://purl.obolibrary.org/obo/MONDO_0019277,epidermal appendage anomaly
+http://purl.obolibrary.org/obo/MONDO_0021027,genetic hair anomaly,http://purl.obolibrary.org/obo/MONDO_0019278,hair anomaly
+http://purl.obolibrary.org/obo/MONDO_0015541,genetic hemophagocytic lymphohistiocytosis,http://purl.obolibrary.org/obo/MONDO_0015540,hemophagocytic syndrome
+http://purl.obolibrary.org/obo/MONDO_0018300,genetic hyperaldosteronism,http://purl.obolibrary.org/obo/MONDO_0003009,hyperaldosteronism
+http://purl.obolibrary.org/obo/MONDO_0016166,genetic hyperparathyroidism,http://purl.obolibrary.org/obo/MONDO_0001741,hyperparathyroidism
+http://purl.obolibrary.org/obo/MONDO_0015512,genetic hypertension,http://purl.obolibrary.org/obo/MONDO_0005044,hypertensive disorder
+http://purl.obolibrary.org/obo/MONDO_0016165,genetic hypoparathyroidism,http://purl.obolibrary.org/obo/MONDO_0001220,hypoparathyroidism
+http://purl.obolibrary.org/obo/MONDO_0020087,genetic lipodystrophy,http://purl.obolibrary.org/obo/MONDO_0006573,lipodystrophy (disease)
+http://purl.obolibrary.org/obo/MONDO_0021028,genetic nail anomaly,http://purl.obolibrary.org/obo/MONDO_0019283,nail anomaly
+http://purl.obolibrary.org/obo/MONDO_0019117,genetic nervous system disorder,http://purl.obolibrary.org/obo/MONDO_0005071,nervous system disorder
+http://purl.obolibrary.org/obo/MONDO_0015952,genetic neurodegenerative disease,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease
+http://purl.obolibrary.org/obo/MONDO_0021037,genetic neurodegenerative disease with dementia,http://purl.obolibrary.org/obo/MONDO_0020136,neurodegenerative disease with dementia
+http://purl.obolibrary.org/obo/MONDO_0019182,genetic obesity,http://purl.obolibrary.org/obo/MONDO_0011122,obesity (disease)
+http://purl.obolibrary.org/obo/MONDO_0018751,genetic otorhinolaryngologic disease,http://purl.obolibrary.org/obo/MONDO_0024623,otorhinolaryngologic disease
+http://purl.obolibrary.org/obo/MONDO_0020127,genetic peripheral neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy
+http://purl.obolibrary.org/obo/MONDO_0021029,genetic sebaceous gland anomaly,http://purl.obolibrary.org/obo/MONDO_0019286,sebaceous gland anomaly
+http://purl.obolibrary.org/obo/MONDO_0024255,genetic skin disease,http://purl.obolibrary.org/obo/MONDO_0005093,skin disease
+http://purl.obolibrary.org/obo/MONDO_0016229,genetic vascular anomaly,http://purl.obolibrary.org/obo/MONDO_0019063,vascular anomaly
+http://purl.obolibrary.org/obo/MONDO_0018385,osteochondrosis of genetic origin,http://purl.obolibrary.org/obo/MONDO_0018381,osteochondrosis
+http://purl.obolibrary.org/obo/MONDO_0018383,osteonecrosis of genetic origin,http://purl.obolibrary.org/obo/MONDO_0005380,osteonecrosis
+http://purl.obolibrary.org/obo/MONDO_0018411,rare female infertility due to hypothalamic-pituitary-gonadal axis disorder of genetic origin,http://purl.obolibrary.org/obo/MONDO_0018397,rare female infertility due to hypothalamic-pituitary-gonadal axis disorder
+http://purl.obolibrary.org/obo/MONDO_0018729,rare genetic vascular tumor,http://purl.obolibrary.org/obo/MONDO_0016228,rare vascular tumor
+http://purl.obolibrary.org/obo/MONDO_0018730,rare genetic venous malformation,http://purl.obolibrary.org/obo/MONDO_0016232,rare venous malformation
+http://purl.obolibrary.org/obo/MONDO_0018405,rare male infertility due to hypothalamic-pituitary-gonadal axis disorder of genetic origin,http://purl.obolibrary.org/obo/MONDO_0018386,rare male infertility due to hypothalamic-pituitary-gonadal axis disorder
+http://purl.obolibrary.org/obo/MONDO_0009970,renal tubular dysgenesis of genetic origin,http://purl.obolibrary.org/obo/MONDO_0017609,renal tubular dysgenesis

--- a/src/patterns/hereditary.csv
+++ b/src/patterns/hereditary.csv
@@ -1,3 +1,144 @@
 iri,iri label,disease,disease label
-MONDO:0003847,inherited genetic disease,MONDO:0000001,disease
-MONDO:0015947,inherited ichthyosis,MONDO:0019269,ichthyosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0007573,"acute erythroleukemia, familial",http://purl.obolibrary.org/obo/MONDO_0017858,acute erythroid leukemia
+http://purl.obolibrary.org/obo/MONDO_0008734,"adrenocortical carcinoma, hereditary",http://purl.obolibrary.org/obo/MONDO_0006639,adrenal cortex carcinoma
+http://purl.obolibrary.org/obo/MONDO_0013743,autosomal systemic lupus erythematosus,http://purl.obolibrary.org/obo/MONDO_0007915,systemic lupus erythematosus (disease)
+http://purl.obolibrary.org/obo/MONDO_0007329,"cirrhosis, familial",http://purl.obolibrary.org/obo/MONDO_0005155,cirrhosis of liver
+http://purl.obolibrary.org/obo/MONDO_0007344,"cluster headache, familial",http://purl.obolibrary.org/obo/MONDO_0043537,cluster headache syndrome
+http://purl.obolibrary.org/obo/MONDO_0009210,congenital factor V deficiency,http://purl.obolibrary.org/obo/MONDO_0020586,factor V deficiency
+http://purl.obolibrary.org/obo/MONDO_0012897,congenital factor XI deficiency,http://purl.obolibrary.org/obo/MONDO_0020587,factor XI deficiency
+http://purl.obolibrary.org/obo/MONDO_0006536,congenital generalized lipodystrophy (disease),http://purl.obolibrary.org/obo/MONDO_0027766,generalized lipodystrophy
+http://purl.obolibrary.org/obo/MONDO_0020398,congenital mitral stenosis (disease),http://purl.obolibrary.org/obo/MONDO_0005852,mitral valve stenosis
+http://purl.obolibrary.org/obo/MONDO_0013361,congenital prothrombin deficiency,http://purl.obolibrary.org/obo/MONDO_0024307,prothrombin deficiency
+http://purl.obolibrary.org/obo/MONDO_0010122,congenital thrombotic thrombocytopenic purpura,http://purl.obolibrary.org/obo/MONDO_0018896,thrombotic thrombocytopenic purpura
+http://purl.obolibrary.org/obo/MONDO_0011024,"dermatitis herpetiformis, familial",http://purl.obolibrary.org/obo/MONDO_0015614,dermatitis herpetiformis
+http://purl.obolibrary.org/obo/MONDO_0007563,"epistaxis, hereditary",http://purl.obolibrary.org/obo/MONDO_0005305,epistaxis
+http://purl.obolibrary.org/obo/MONDO_0007031,familial abdominal aortic aneurysm,http://purl.obolibrary.org/obo/MONDO_0005350,abdominal aortic aneurysm
+http://purl.obolibrary.org/obo/MONDO_0043003,familial acanthosis nigricans,http://purl.obolibrary.org/obo/MONDO_0007035,acanthosis nigricans (disease)
+http://purl.obolibrary.org/obo/MONDO_0024516,familial acne inversa,http://purl.obolibrary.org/obo/MONDO_0006559,hidradenitis suppurativa
+http://purl.obolibrary.org/obo/MONDO_0005144,familial amyotrophic lateral sclerosis,http://purl.obolibrary.org/obo/MONDO_0004976,amyotrophic lateral sclerosis
+http://purl.obolibrary.org/obo/MONDO_0018054,familial atrial fibrillation,http://purl.obolibrary.org/obo/MONDO_0004981,atrial fibrillation (disease)
+http://purl.obolibrary.org/obo/MONDO_0005217,familial cardiomyopathy,http://purl.obolibrary.org/obo/MONDO_0004994,cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0007291,familial cerebral cavernous malformation,http://purl.obolibrary.org/obo/MONDO_0000820,cerebral cavernous malformation
+http://purl.obolibrary.org/obo/MONDO_0018212,familial cervical artery dissection,http://purl.obolibrary.org/obo/MONDO_0006061,cervical artery dissection
+http://purl.obolibrary.org/obo/MONDO_0018827,familial chilblain lupus,http://purl.obolibrary.org/obo/MONDO_0019557,chilblain lupus
+http://purl.obolibrary.org/obo/MONDO_0023113,familial colorectal cancer,http://purl.obolibrary.org/obo/MONDO_0005575,colorectal cancer
+http://purl.obolibrary.org/obo/MONDO_0007626,familial congenital palsy of trochlear nerve,http://purl.obolibrary.org/obo/MONDO_0001146,fourth cranial nerve palsy
+http://purl.obolibrary.org/obo/MONDO_0024462,familial cutaneous melanoma,http://purl.obolibrary.org/obo/MONDO_0005012,cutaneous melanoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0019741,familial cystic renal disease,http://purl.obolibrary.org/obo/MONDO_0002473,cystic kidney disease
+http://purl.obolibrary.org/obo/MONDO_0016333,familial dilated cardiomyopathy,http://purl.obolibrary.org/obo/MONDO_0005021,dilated cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0004424,familial glomangioma,http://purl.obolibrary.org/obo/MONDO_0002299,glomangioma
+http://purl.obolibrary.org/obo/MONDO_0000700,familial hemiplegic migraine,http://purl.obolibrary.org/obo/MONDO_0023310,hemiplegic migraine
+http://purl.obolibrary.org/obo/MONDO_0003689,familial hemolytic anemia,http://purl.obolibrary.org/obo/MONDO_0003664,hemolytic anemia
+http://purl.obolibrary.org/obo/MONDO_0016525,familial hyperaldosteronism,http://purl.obolibrary.org/obo/MONDO_0003009,hyperaldosteronism
+http://purl.obolibrary.org/obo/MONDO_0017182,familial hyperinsulinism,http://purl.obolibrary.org/obo/MONDO_0002177,hyperinsulinism (disease)
+http://purl.obolibrary.org/obo/MONDO_0001336,familial hyperlipidemia,http://purl.obolibrary.org/obo/MONDO_0021187,hyperlipidemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0014250,familial hyperprolactinemia,http://purl.obolibrary.org/obo/MONDO_0005804,hyperprolactinemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0024573,familial hypertrophic cardiomyopathy,http://purl.obolibrary.org/obo/MONDO_0005045,hypertrophic cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0044816,familial idiopathic torsion dystonia,http://purl.obolibrary.org/obo/MONDO_0044811,idiopathic torsion dystonia
+http://purl.obolibrary.org/obo/MONDO_0010080,familial infantile bilateral striatal necrosis,http://purl.obolibrary.org/obo/MONDO_0015518,infantile bilateral striatal necrosis
+http://purl.obolibrary.org/obo/MONDO_0017290,familial intrahepatic cholestasis,http://purl.obolibrary.org/obo/MONDO_0019072,intrahepatic cholestasis
+http://purl.obolibrary.org/obo/MONDO_0018851,familial keratoacanthoma,http://purl.obolibrary.org/obo/MONDO_0002527,keratoacanthoma
+http://purl.obolibrary.org/obo/MONDO_0023616,familial leiomyomatosis,http://purl.obolibrary.org/obo/MONDO_0003295,leiomyomatosis
+http://purl.obolibrary.org/obo/MONDO_0019171,familial long QT syndrome,http://purl.obolibrary.org/obo/MONDO_0002442,long QT syndrome
+http://purl.obolibrary.org/obo/MONDO_0007958,familial medullary thyroid carcinoma,http://purl.obolibrary.org/obo/MONDO_0015277,medullary thyroid gland carcinoma
+http://purl.obolibrary.org/obo/MONDO_0018961,familial melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0011789,familial meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease)
+http://purl.obolibrary.org/obo/MONDO_0008004,familial mitral valve prolapse,http://purl.obolibrary.org/obo/MONDO_0004910,mitral valve prolapse (disease)
+http://purl.obolibrary.org/obo/MONDO_0007681,familial multinodular goiter,http://purl.obolibrary.org/obo/MONDO_0000334,multinodular goiter
+http://purl.obolibrary.org/obo/MONDO_0002350,familial nephrotic syndrome,http://purl.obolibrary.org/obo/MONDO_0005377,nephrotic syndrome
+http://purl.obolibrary.org/obo/MONDO_0007660,familial ossifying fibroma,http://purl.obolibrary.org/obo/MONDO_0002119,ossifying fibroma (disease)
+http://purl.obolibrary.org/obo/MONDO_0042973,familial osteosclerosis,http://purl.obolibrary.org/obo/MONDO_0002933,osteosclerosis
+http://purl.obolibrary.org/obo/MONDO_0016248,familial ovarian cancer,http://purl.obolibrary.org/obo/MONDO_0008170,ovarian cancer
+http://purl.obolibrary.org/obo/MONDO_0004033,familial ovarian carcinoma,http://purl.obolibrary.org/obo/MONDO_0005140,ovarian carcinoma
+http://purl.obolibrary.org/obo/MONDO_0015278,familial pancreatic carcinoma,http://purl.obolibrary.org/obo/MONDO_0005192,exocrine pancreatic carcinoma
+http://purl.obolibrary.org/obo/MONDO_0020523,familial parathyroid adenoma,http://purl.obolibrary.org/obo/MONDO_0006890,parathyroid gland adenoma
+http://purl.obolibrary.org/obo/MONDO_0017704,familial partial epilepsy,http://purl.obolibrary.org/obo/MONDO_0005384,partial epilepsy
+http://purl.obolibrary.org/obo/MONDO_0000995,familial periodic paralysis,http://purl.obolibrary.org/obo/MONDO_0016122,periodic paralysis (disease)
+http://purl.obolibrary.org/obo/MONDO_0024351,familial pityriasis rubra pilaris,http://purl.obolibrary.org/obo/MONDO_0008251,pityriasis rubra pilaris
+http://purl.obolibrary.org/obo/MONDO_0001115,familial polycythemia,http://purl.obolibrary.org/obo/MONDO_0005571,polycythemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0020496,familial porencephaly,http://purl.obolibrary.org/obo/MONDO_0017410,porencephaly
+http://purl.obolibrary.org/obo/MONDO_0008296,familial porphyria cutanea tarda,http://purl.obolibrary.org/obo/MONDO_0015104,porphyria cutanea tarda
+http://purl.obolibrary.org/obo/MONDO_0016365,familial primary hyperparathyroidism,http://purl.obolibrary.org/obo/MONDO_0010837,primary hyperparathyroidism (disease)
+http://purl.obolibrary.org/obo/MONDO_0007101,familial primary localized cutaneous amyloidosis,http://purl.obolibrary.org/obo/MONDO_0015301,primary cutaneous amyloidosis
+http://purl.obolibrary.org/obo/MONDO_0023122,familial prostate cancer,http://purl.obolibrary.org/obo/MONDO_0008315,prostate cancer
+http://purl.obolibrary.org/obo/MONDO_0016340,familial restrictive cardiomyopathy,http://purl.obolibrary.org/obo/MONDO_0005201,restrictive cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0016473,familial rhabdoid tumor,http://purl.obolibrary.org/obo/MONDO_0002728,rhabdoid tumor
+http://purl.obolibrary.org/obo/MONDO_0018829,familial schizencephaly,http://purl.obolibrary.org/obo/MONDO_0010011,schizencephaly
+http://purl.obolibrary.org/obo/MONDO_0012061,familial sick sinus syndrome,http://purl.obolibrary.org/obo/MONDO_0001823,sick sinus syndrome
+http://purl.obolibrary.org/obo/MONDO_0018257,familial syringomyelia,http://purl.obolibrary.org/obo/MONDO_0017987,syringomyelia
+http://purl.obolibrary.org/obo/MONDO_0019111,familial thrombocytosis,http://purl.obolibrary.org/obo/MONDO_0002249,thrombocytosis disease
+http://purl.obolibrary.org/obo/MONDO_0008565,familial thyroglossal duct cyst,http://purl.obolibrary.org/obo/MONDO_0006460,thyroglossal duct cyst
+http://purl.obolibrary.org/obo/MONDO_0017329,familial vesicoureteral reflux,http://purl.obolibrary.org/obo/MONDO_0006007,vesicoureteral reflux (disease)
+http://purl.obolibrary.org/obo/MONDO_0017143,genetic infertility,http://purl.obolibrary.org/obo/MONDO_0005047,infertility disorder
+http://purl.obolibrary.org/obo/MONDO_0043009,genetic lethal multiple congenital anomalies/dysmorphic syndrome,http://purl.obolibrary.org/obo/MONDO_0018731,lethal multiple congenital anomalies/dysmorphic syndrome
+http://purl.obolibrary.org/obo/MONDO_0024257,genetic motor neuron disease,http://purl.obolibrary.org/obo/MONDO_0020128,motor neuron disease
+http://purl.obolibrary.org/obo/MONDO_0043005,genetic multiple congenital anomalies/dysmorphic syndrome,http://purl.obolibrary.org/obo/MONDO_0019042,multiple congenital anomalies/dysmorphic syndrome
+http://purl.obolibrary.org/obo/MONDO_0043008,genetic multiple congenital anomalies/dysmorphic syndrome without intellectual disability,http://purl.obolibrary.org/obo/MONDO_0015161,multiple congenital anomalies/dysmorphic syndrome without intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0043007,genetic multiple congenital anomalies/dysmorphic syndrome-variable intellectual disability syndrome,http://purl.obolibrary.org/obo/MONDO_0015160,multiple congenital anomalies/dysmorphic syndrome-variable intellectual disability syndrome
+http://purl.obolibrary.org/obo/MONDO_0017133,genetic systemic or rheumatologic disease,http://purl.obolibrary.org/obo/MONDO_0020012,systemic or rheumatic disease
+http://purl.obolibrary.org/obo/MONDO_0044331,genetic transient congenital hypothyroidism,http://purl.obolibrary.org/obo/MONDO_0015792,transient congenital hypothyroidism
+http://purl.obolibrary.org/obo/MONDO_0010601,"gynecomastia, familial",http://purl.obolibrary.org/obo/MONDO_0001571,gynecomastia
+http://purl.obolibrary.org/obo/MONDO_0003321,hereditary Wilms' tumor,http://purl.obolibrary.org/obo/MONDO_0006058,Wilms tumor
+http://purl.obolibrary.org/obo/MONDO_0018634,hereditary amyloidosis,http://purl.obolibrary.org/obo/MONDO_0019065,amyloidosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0019623,hereditary angioedema,http://purl.obolibrary.org/obo/MONDO_0010481,angioedema
+http://purl.obolibrary.org/obo/MONDO_0016419,hereditary breast carcinoma,http://purl.obolibrary.org/obo/MONDO_0004989,breast carcinoma
+http://purl.obolibrary.org/obo/MONDO_0008185,hereditary chronic pancreatitis,http://purl.obolibrary.org/obo/MONDO_0005003,chronic pancreatitis
+http://purl.obolibrary.org/obo/MONDO_0018492,hereditary clear cell renal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005005,clear cell renal carcinoma
+http://purl.obolibrary.org/obo/MONDO_0007648,hereditary diffuse gastric adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0005017,diffuse gastric adenocarcinoma
+http://purl.obolibrary.org/obo/MONDO_0004166,hereditary fallopian tube carcinoma,http://purl.obolibrary.org/obo/MONDO_0006206,fallopian tube carcinoma
+http://purl.obolibrary.org/obo/MONDO_0018502,hereditary gastric cancer,http://purl.obolibrary.org/obo/MONDO_0001056,gastric cancer
+http://purl.obolibrary.org/obo/MONDO_0018174,hereditary glaucoma,http://purl.obolibrary.org/obo/MONDO_0005041,glaucoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0002408,hereditary hyperbilirubinemia,http://purl.obolibrary.org/obo/MONDO_0024288,hyperbilirubinemia
+http://purl.obolibrary.org/obo/MONDO_0021022,hereditary hyperekplexia,http://purl.obolibrary.org/obo/MONDO_0017658,hyperekplexia
+http://purl.obolibrary.org/obo/MONDO_0000044,hereditary hypophosphatemic rickets,http://purl.obolibrary.org/obo/MONDO_0024300,hypophosphatemic rickets
+http://purl.obolibrary.org/obo/MONDO_0003824,hereditary kidney oncocytoma,http://purl.obolibrary.org/obo/MONDO_0003825,kidney oncocytoma
+http://purl.obolibrary.org/obo/MONDO_0019313,hereditary lymphedema,http://purl.obolibrary.org/obo/MONDO_0019297,lymphedema
+http://purl.obolibrary.org/obo/MONDO_0018963,hereditary methemoglobinemia,http://purl.obolibrary.org/obo/MONDO_0001117,methemoglobinemia
+http://purl.obolibrary.org/obo/MONDO_0015356,hereditary neoplastic syndrome,http://purl.obolibrary.org/obo/MONDO_0021058,neoplastic syndrome
+http://purl.obolibrary.org/obo/MONDO_0005334,hereditary nephritis,http://purl.obolibrary.org/obo/MONDO_0001166,nephritis
+http://purl.obolibrary.org/obo/MONDO_0018698,hereditary neuroendocrine tumor of small intestine,http://purl.obolibrary.org/obo/MONDO_0018510,small intestine neuroendocrine neoplasm
+http://purl.obolibrary.org/obo/MONDO_0004587,hereditary night blindness,http://purl.obolibrary.org/obo/MONDO_0004588,night blindness
+http://purl.obolibrary.org/obo/MONDO_0043878,hereditary optic atrophy,http://purl.obolibrary.org/obo/MONDO_0003608,optic atrophy
+http://purl.obolibrary.org/obo/MONDO_0019272,hereditary palmoplantar keratoderma,http://purl.obolibrary.org/obo/MONDO_0006590,palmoplantar keratosis
+http://purl.obolibrary.org/obo/MONDO_0003789,hereditary papillary renal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0017884,papillary renal cell carcinoma
+http://purl.obolibrary.org/obo/MONDO_0017953,hereditary periodic fever syndrome,http://purl.obolibrary.org/obo/MONDO_0015137,periodic fever syndrome
+http://purl.obolibrary.org/obo/MONDO_0020573,hereditary predisposition to disease,http://purl.obolibrary.org/obo/MONDO_0042489,disease susceptibility
+http://purl.obolibrary.org/obo/MONDO_0012580,hereditary pulmonary alveolar proteinosis,http://purl.obolibrary.org/obo/MONDO_0001437,pulmonary alveolar proteinosis
+http://purl.obolibrary.org/obo/MONDO_0003008,hereditary renal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005086,renal cell carcinoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0018160,hereditary retinoblastoma,http://purl.obolibrary.org/obo/MONDO_0008380,retinoblastoma
+http://purl.obolibrary.org/obo/MONDO_0015364,hereditary sensory and autonomic neuropathy,http://purl.obolibrary.org/obo/MONDO_0002321,sensory peripheral neuropathy
+http://purl.obolibrary.org/obo/MONDO_0019565,hereditary von Willebrand disease,http://purl.obolibrary.org/obo/MONDO_0024574,von Willebrand disease (hereditary or acquired)
+http://purl.obolibrary.org/obo/MONDO_0018106,hereditary xanthinuria,http://purl.obolibrary.org/obo/MONDO_0000721,xanthinuria
+http://purl.obolibrary.org/obo/MONDO_0017148,heritable pulmonary arterial hypertension,http://purl.obolibrary.org/obo/MONDO_0015924,pulmonary arterial hypertension
+http://purl.obolibrary.org/obo/MONDO_0011371,"hydroa vacciniforme, familial",http://purl.obolibrary.org/obo/MONDO_0018024,hydroa vacciniforme
+http://purl.obolibrary.org/obo/MONDO_0007776,"hypersensitivity pneumonitis, familial",http://purl.obolibrary.org/obo/MONDO_0017853,hypersensitivity pneumonitis
+http://purl.obolibrary.org/obo/MONDO_0007788,"hypertriglyceridemia, familial",http://purl.obolibrary.org/obo/MONDO_0005347,hypertriglyceridemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0017755,inborn disorder of bilirubin metabolism,http://purl.obolibrary.org/obo/MONDO_0024431,bilirubin metabolism disease
+http://purl.obolibrary.org/obo/MONDO_0019052,inborn errors of metabolism,http://purl.obolibrary.org/obo/MONDO_0005066,metabolic disease
+http://purl.obolibrary.org/obo/MONDO_0007403,inherited Creutzfeldt-Jakob disease,http://purl.obolibrary.org/obo/MONDO_0005357,Creutzfeldt Jacob disease
+http://purl.obolibrary.org/obo/MONDO_0017893,inherited acute myeloid leukemia,http://purl.obolibrary.org/obo/MONDO_0018874,acute myeloid leukemia
+http://purl.obolibrary.org/obo/MONDO_0001713,inherited aplastic anemia,http://purl.obolibrary.org/obo/MONDO_0015909,aplastic anemia
+http://purl.obolibrary.org/obo/MONDO_0037940,inherited auditory system disease,http://purl.obolibrary.org/obo/MONDO_0002409,auditory system disease
+http://purl.obolibrary.org/obo/MONDO_0021181,inherited blood coagulation disorder,http://purl.obolibrary.org/obo/MONDO_0001531,blood coagulation disease
+http://purl.obolibrary.org/obo/MONDO_0017129,inherited cardiac tumor,http://purl.obolibrary.org/obo/MONDO_0021209,heart neoplasm
+http://purl.obolibrary.org/obo/MONDO_0044807,inherited dystonia,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder
+http://purl.obolibrary.org/obo/MONDO_0019276,inherited epidermolysis bullosa,http://purl.obolibrary.org/obo/MONDO_0006541,epidermolysis bullosa
+http://purl.obolibrary.org/obo/MONDO_0003847,inherited genetic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0019050,inherited hemoglobinopathy,http://purl.obolibrary.org/obo/MONDO_0044348,hemoglobinopathy
+http://purl.obolibrary.org/obo/MONDO_0015947,inherited ichthyosis,http://purl.obolibrary.org/obo/MONDO_0019269,ichthyosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0042966,inherited mitral valve disease,http://purl.obolibrary.org/obo/MONDO_0003767,mitral valve disease
+http://purl.obolibrary.org/obo/MONDO_0024237,inherited neurodegenerative disorder,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease
+http://purl.obolibrary.org/obo/MONDO_0025511,inherited neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm
+http://purl.obolibrary.org/obo/MONDO_0019142,inherited porphyria,http://purl.obolibrary.org/obo/MONDO_0037939,porphyria
+http://purl.obolibrary.org/obo/MONDO_0012901,inherited prekallikrein deficiency,http://purl.obolibrary.org/obo/MONDO_0044744,prekallikrein deficiency
+http://purl.obolibrary.org/obo/MONDO_0019852,inherited primary ovarian failure,http://purl.obolibrary.org/obo/MONDO_0005387,primary ovarian failure
+http://purl.obolibrary.org/obo/MONDO_0017234,inherited prion disease,http://purl.obolibrary.org/obo/MONDO_0005429,prion disease
+http://purl.obolibrary.org/obo/MONDO_0009925,inherited pseudoxanthoma elasticum,http://purl.obolibrary.org/obo/MONDO_0024308,pseudoxanthoma elasticum (inherited or acquired)
+http://purl.obolibrary.org/obo/MONDO_0023224,inherited reflex epilepsy,http://purl.obolibrary.org/obo/MONDO_0017768,reflex epilepsy
+http://purl.obolibrary.org/obo/MONDO_0019118,inherited retinal dystrophy,http://purl.obolibrary.org/obo/MONDO_0004580,retinal degeneration
+http://purl.obolibrary.org/obo/MONDO_0017127,inherited soft tissue tumor,http://purl.obolibrary.org/obo/MONDO_0002616,mesenchymal cell neoplasm
+http://purl.obolibrary.org/obo/MONDO_0007902,"lichen planus, familial",http://purl.obolibrary.org/obo/MONDO_0006572,lichen planus
+http://purl.obolibrary.org/obo/MONDO_0011260,"pancreatic lymphoma, familial",http://purl.obolibrary.org/obo/MONDO_0002114,pancreas lymphoma
+http://purl.obolibrary.org/obo/MONDO_0012484,"prosopagnosia, hereditary",http://purl.obolibrary.org/obo/MONDO_0003227,prosopagnosia (disease)
+http://purl.obolibrary.org/obo/MONDO_0010127,"thymoma, familial",http://purl.obolibrary.org/obo/MONDO_0006456,thymoma (disease)
+http://purl.obolibrary.org/obo/MONDO_0008648,"ventricular tachycardia, familial",http://purl.obolibrary.org/obo/MONDO_0005477,ventricular tachycardia

--- a/src/patterns/inborn_metabolic.csv
+++ b/src/patterns/inborn_metabolic.csv
@@ -1,24 +1,51 @@
 iri,iri label,process,process label
-MONDO:0021130,disorder of sphingolipid biosynthesis,GO:0030148,sphingolipid biosynthetic process
-MONDO:0019225,gluconeogenesis disorder,GO:0006094,gluconeogenesis
-MONDO:0019226,glucose transport disorder,GO:0015758,glucose transport
-MONDO:0019214,inborn carbohydrate metabolic disorder,GO:0005975,carbohydrate metabolic process
-MONDO:0019218,inborn disorder of bile acid synthesis,GO:0006699,bile acid biosynthetic process
-MONDO:0019242,inborn disorder of branched-chain amino acid metabolism,GO:0009081,branched-chain amino acid metabolic process
-MONDO:0019243,inborn disorder of energy metabolism,GO:0006091,generation of precursor metabolites and energy
-MONDO:0019224,inborn disorder of gamma-aminobutyric acid metabolism,GO:0009448,gamma-aminobutyric acid metabolic process
-MONDO:0019227,inborn disorder of glycerol metabolism,GO:0006071,glycerol metabolic process
-MONDO:0019228,inborn disorder of histidine metabolism,GO:0006547,histidine metabolic process
-MONDO:0019236,inborn disorder of purine metabolism,GO:0006144,purine nucleobase metabolic process
-MONDO:0019237,inborn disorder of pyridoxine metabolism,GO:0008614,pyridoxine metabolic process
-MONDO:0019238,inborn disorder of pyrimidine metabolism,GO:0006206,pyrimidine nucleobase metabolic process
-MONDO:0000422,inborn glycogen metabolism disorder,GO:0005977,glycogen metabolic process
-MONDO:0000421,inborn serine deficiency,GO:0006564,L-serine biosynthetic process
-MONDO:0000424,inborn vitamin B12 deficiency (disease),GO:0009235,cobalamin metabolic process
-MONDO:0019245,lipid storage disorder,GO:0019915,lipid storage
-MONDO:0018121,mitochondrial DNA maintenance syndrome,GO:0000002,mitochondrial genome maintenance
-MONDO:0016789,pyruvate metabolism disorder,GO:0006090,pyruvate metabolic process
-MONDO:0019240,sterol biosynthesis disorder,GO:0016126,sterol biosynthetic process
-MONDO:0019256,sterol metabolism disorder,GO:0016125,sterol metabolic process
-MONDO:0016790,tricarboxylic acid cycle disorder,GO:0006099,tricarboxylic acid cycle
-MONDO:0000155,triglyceride storage disease,GO:0030730,sequestering of triglyceride
+http://purl.obolibrary.org/obo/MONDO_0009825,5-oxoprolinase deficiency (disease),http://purl.obolibrary.org/obo/GO_0017168,5-oxoprolinase (ATP-hydrolyzing) activity
+http://purl.obolibrary.org/obo/MONDO_0007068,adenylosuccinate lyase deficiency,http://purl.obolibrary.org/obo/GO_0070626,(S)-2-(5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamido)succinate AMP-lyase (fumarate-forming) activity
+http://purl.obolibrary.org/obo/MONDO_0017762,disorder of copper metabolism,http://purl.obolibrary.org/obo/GO_0006878,cellular copper ion homeostasis
+http://purl.obolibrary.org/obo/MONDO_0017765,disorder of magnesium transport,http://purl.obolibrary.org/obo/GO_0015693,magnesium ion transport
+http://purl.obolibrary.org/obo/MONDO_0000351,disorder of methionine catabolism,http://purl.obolibrary.org/obo/GO_0009087,methionine catabolic process
+http://purl.obolibrary.org/obo/MONDO_0017687,disorder of neutral amino acid transport,http://purl.obolibrary.org/obo/GO_0015804,neutral amino acid transport
+http://purl.obolibrary.org/obo/MONDO_0021130,disorder of sphingolipid biosynthesis,http://purl.obolibrary.org/obo/GO_0030148,sphingolipid biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0009285,gamma-glutamyl transpeptidase deficiency,http://purl.obolibrary.org/obo/GO_0036374,glutathione hydrolase activity
+http://purl.obolibrary.org/obo/MONDO_0009259,gamma-glutamylcysteine synthetase deficiency,http://purl.obolibrary.org/obo/GO_0004357,glutamate-cysteine ligase activity
+http://purl.obolibrary.org/obo/MONDO_0019225,gluconeogenesis disorder,http://purl.obolibrary.org/obo/GO_0006094,gluconeogenesis
+http://purl.obolibrary.org/obo/MONDO_0005775,glucosephosphate dehydrogenase deficiency,http://purl.obolibrary.org/obo/GO_0004345,glucose-6-phosphate dehydrogenase activity
+http://purl.obolibrary.org/obo/MONDO_0002412,glycogen storage disease,http://purl.obolibrary.org/obo/GO_0005977,glycogen metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017686,inborn aminoacylase deficiency,http://purl.obolibrary.org/obo/GO_0004046,aminoacylase activity
+http://purl.obolibrary.org/obo/MONDO_0019214,inborn carbohydrate metabolic disorder,http://purl.obolibrary.org/obo/GO_0005975,carbohydrate metabolic process
+http://purl.obolibrary.org/obo/MONDO_0037938,inborn disorder of aspartate family metabolism,http://purl.obolibrary.org/obo/GO_0009066,aspartate family amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019218,inborn disorder of bile acid synthesis,http://purl.obolibrary.org/obo/GO_0006699,bile acid biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0019242,inborn disorder of branched-chain amino acid metabolism,http://purl.obolibrary.org/obo/GO_0009081,branched-chain amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019243,inborn disorder of energy metabolism,http://purl.obolibrary.org/obo/GO_0006091,generation of precursor metabolites and energy
+http://purl.obolibrary.org/obo/MONDO_0019224,inborn disorder of gamma-aminobutyric acid metabolism,http://purl.obolibrary.org/obo/GO_0009448,gamma-aminobutyric acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019227,inborn disorder of glycerol metabolism,http://purl.obolibrary.org/obo/GO_0006071,glycerol metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019228,inborn disorder of histidine metabolism,http://purl.obolibrary.org/obo/GO_0006547,histidine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019229,inborn disorder of ketolysis,http://purl.obolibrary.org/obo/GO_0046952,ketone body catabolic process
+http://purl.obolibrary.org/obo/MONDO_0019222,inborn disorder of methionine cycle and sulfur amino acid metabolism,http://purl.obolibrary.org/obo/GO_0000096,sulfur amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017356,inborn disorder of ornithine metabolism,http://purl.obolibrary.org/obo/GO_0006591,ornithine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017754,inborn disorder of porphyrin metabolism,http://purl.obolibrary.org/obo/GO_0006778,porphyrin-containing compound metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017355,inborn disorder of proline metabolism,http://purl.obolibrary.org/obo/GO_0006560,proline metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019236,inborn disorder of purine metabolism,http://purl.obolibrary.org/obo/GO_0006144,purine nucleobase metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019237,inborn disorder of pyridoxine metabolism,http://purl.obolibrary.org/obo/GO_0008614,pyridoxine metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019238,inborn disorder of pyrimidine metabolism,http://purl.obolibrary.org/obo/GO_0006206,pyrimidine nucleobase metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019239,inborn disorder of serine family metabolism,http://purl.obolibrary.org/obo/GO_0009069,serine family amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017350,inborn disorder of tryptophan metabolism,http://purl.obolibrary.org/obo/GO_0006568,tryptophan metabolic process
+http://purl.obolibrary.org/obo/MONDO_0010613,inborn glycerol kinase deficiency,http://purl.obolibrary.org/obo/GO_0004370,glycerol kinase activity
+http://purl.obolibrary.org/obo/MONDO_0000421,inborn serine deficiency,http://purl.obolibrary.org/obo/GO_0006564,L-serine biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0000424,inborn vitamin B12 deficiency (disease),http://purl.obolibrary.org/obo/GO_0009235,cobalamin metabolic process
+http://purl.obolibrary.org/obo/MONDO_0005528,inborn vitamin metabolic disorder,http://purl.obolibrary.org/obo/GO_0006766,vitamin metabolic process
+http://purl.obolibrary.org/obo/MONDO_0004736,inherited amino acid metabolic disorder,http://purl.obolibrary.org/obo/GO_0006520,cellular amino acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0040566,inherited glutathione metabolism disease,http://purl.obolibrary.org/obo/GO_0006749,glutathione metabolic process
+http://purl.obolibrary.org/obo/MONDO_0017909,inherited glutathione synthetase deficiency,http://purl.obolibrary.org/obo/GO_0004363,glutathione synthase activity
+http://purl.obolibrary.org/obo/MONDO_0018424,inherited lipoic acid biosynthesis defect,http://purl.obolibrary.org/obo/GO_0009107,lipoate biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0000688,inherited organic acidemia,http://purl.obolibrary.org/obo/GO_0006082,organic acid metabolic process
+http://purl.obolibrary.org/obo/MONDO_0045046,inherited thyroid metabolism disease,http://purl.obolibrary.org/obo/GO_0042403,thyroid hormone metabolic process
+http://purl.obolibrary.org/obo/MONDO_0020531,long chain acyl-CoA dehydrogenase deficiency,http://purl.obolibrary.org/obo/GO_0004466,long-chain-acyl-CoA dehydrogenase activity
+http://purl.obolibrary.org/obo/MONDO_0019245,lysosomal lipid storage disorder,http://purl.obolibrary.org/obo/GO_0019915,lipid storage
+http://purl.obolibrary.org/obo/MONDO_0018121,mitochondrial DNA maintenance syndrome,http://purl.obolibrary.org/obo/GO_0000002,mitochondrial genome maintenance
+http://purl.obolibrary.org/obo/MONDO_0016789,pyruvate metabolism disorder,http://purl.obolibrary.org/obo/GO_0006090,pyruvate metabolic process
+http://purl.obolibrary.org/obo/MONDO_0019240,sterol biosynthesis disorder,http://purl.obolibrary.org/obo/GO_0016126,sterol biosynthetic process
+http://purl.obolibrary.org/obo/MONDO_0019256,sterol metabolism disorder,http://purl.obolibrary.org/obo/GO_0016125,sterol metabolic process
+http://purl.obolibrary.org/obo/MONDO_0012503,thiopurine S-methyltransferase deficiency,http://purl.obolibrary.org/obo/GO_0008119,thiopurine S-methyltransferase activity
+http://purl.obolibrary.org/obo/MONDO_0016790,tricarboxylic acid cycle disorder,http://purl.obolibrary.org/obo/GO_0006099,tricarboxylic acid cycle
+http://purl.obolibrary.org/obo/MONDO_0000155,triglyceride storage disease,http://purl.obolibrary.org/obo/GO_0030730,sequestering of triglyceride

--- a/src/patterns/infantile.csv
+++ b/src/patterns/infantile.csv
@@ -1,0 +1,6 @@
+iri,iri label,disease,disease label
+http://purl.obolibrary.org/obo/MONDO_0000212,"hypercalcemia, infantile",http://purl.obolibrary.org/obo/MONDO_0001566,hypercalcemia disease
+http://purl.obolibrary.org/obo/MONDO_0043555,infantile diarrhea,http://purl.obolibrary.org/obo/MONDO_0001673,diarrheal disease
+http://purl.obolibrary.org/obo/MONDO_0020071,infantile epilepsy syndrome,http://purl.obolibrary.org/obo/MONDO_0015650,epilepsy syndrome
+http://purl.obolibrary.org/obo/MONDO_0017354,infantile glycine encephalopathy,http://purl.obolibrary.org/obo/MONDO_0011612,glycine encephalopathy
+http://purl.obolibrary.org/obo/MONDO_0019190,juvenile polyposis of infancy,http://purl.obolibrary.org/obo/MONDO_0017380,juvenile polyposis syndrome

--- a/src/patterns/infectious_disease_by_agent.csv
+++ b/src/patterns/infectious_disease_by_agent.csv
@@ -1,20 +1,202 @@
 iri,iri label,agent,agent label
-MONDO:0003471,Pediculus humanus capitis infestation,NCBITaxon:121226,Pediculus humanus capitis
-MONDO:0003482,Pediculus humanus corporis infestation,NCBITaxon:121224,Pediculus humanus corporis
-MONDO:0001794,Pthirus pubis infestation,NCBITaxon:121228,Pthirus pubis
-MONDO:0001026,bacterial infectious disease,NCBITaxon:2,Bacteria
-MONDO:0001532,capillariasis,NCBITaxon:119095,Capillaria
-MONDO:0002041,fungal infectious disease,NCBITaxon:4751,Fungi
-MONDO:0004277,gonorrhea,NCBITaxon:485,Neisseria gonorrhoeae
-MONDO:0004662,heterophyiasis,NCBITaxon:104454,Heterophyes
-MONDO:0003472,lice infestation,NCBITaxon:121225,Pediculus humanus
-MONDO:0005373,meningococcal infection,NCBITaxon:487,Neisseria meningitidis
-MONDO:0004666,metagonimiasis,NCBITaxon:84529,Metagonimus yokogawai
-MONDO:0002594,monkeypox,NCBITaxon:10244,Monkeypox virus
-MONDO:0000290,primary amebic meningoencephalitis,NCBITaxon:5763,Naegleria fowleri
-MONDO:0001577,respiratory syncytial virus infectious disease,NCBITaxon:11250,Human respiratory syncytial virus
-MONDO:0000827,salmonellosis,NCBITaxon:590,Salmonella
-MONDO:0000367,taeniasis,NCBITaxon:6202,Taenia
-MONDO:0002154,trichomoniasis,NCBITaxon:5721,Trichomonas
-MONDO:0001246,typhus,NCBITaxon:780,Rickettsia
-MONDO:0005108,viral disease,NCBITaxon:10239,Viruses
+http://purl.obolibrary.org/obo/MONDO_0006635,Acinetobacter infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_469,Acinetobacter
+http://purl.obolibrary.org/obo/MONDO_0006636,Actinobacillus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_713,Actinobacillus
+http://purl.obolibrary.org/obo/MONDO_0006921,Actinomycetales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_2037,Actinomycetales
+http://purl.obolibrary.org/obo/MONDO_0005117,Aeromonas hydrophila infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_644,Aeromonas hydrophila
+http://purl.obolibrary.org/obo/MONDO_0001262,African histoplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_149546,Histoplasma capsulatum var. duboisii
+http://purl.obolibrary.org/obo/MONDO_0000310,Alkhurma hemorrhagic fever,http://purl.obolibrary.org/obo/NCBITaxon_172148,Alkhumra hemorrhagic fever virus
+http://purl.obolibrary.org/obo/MONDO_0005643,Alphavirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11019,Alphavirus
+http://purl.obolibrary.org/obo/MONDO_0006922,Anaplasmataceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_942,Anaplasmataceae
+http://purl.obolibrary.org/obo/MONDO_0005650,Arenaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11617,Arenaviridae
+http://purl.obolibrary.org/obo/MONDO_0005652,Arterivirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11046,Arterivirus
+http://purl.obolibrary.org/obo/MONDO_0005656,Ascaridida infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6249,Ascaridida
+http://purl.obolibrary.org/obo/MONDO_0006923,Bacillaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_186817,Bacillaceae
+http://purl.obolibrary.org/obo/MONDO_0006705,Bacteroidaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_815,Bacteroidaceae
+http://purl.obolibrary.org/obo/MONDO_0006671,Bacteroides infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_816,Bacteroides
+http://purl.obolibrary.org/obo/MONDO_0000343,Barmah forest virus disease,http://purl.obolibrary.org/obo/NCBITaxon_11020,Barmah Forest virus
+http://purl.obolibrary.org/obo/MONDO_0006924,Bartonellaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_772,Bartonellaceae
+http://purl.obolibrary.org/obo/MONDO_0006706,Bifidobacteriales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_85004,Bifidobacteriales
+http://purl.obolibrary.org/obo/MONDO_0001353,Bordetella parapertussis infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_519,Bordetella parapertussis
+http://purl.obolibrary.org/obo/MONDO_0006681,Borrelia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_138,Borrelia
+http://purl.obolibrary.org/obo/MONDO_0001190,Brucella suis brucellosis,http://purl.obolibrary.org/obo/NCBITaxon_29461,Brucella suis
+http://purl.obolibrary.org/obo/MONDO_0021641,Bunyaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11571,Bunyaviridae
+http://purl.obolibrary.org/obo/MONDO_0000327,Buruli ulcer disease,http://purl.obolibrary.org/obo/NCBITaxon_1809,Mycobacterium ulcerans
+http://purl.obolibrary.org/obo/MONDO_0042488,Cestode infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6199,Cestoda
+http://purl.obolibrary.org/obo/MONDO_0001444,Chagas disease,http://purl.obolibrary.org/obo/NCBITaxon_5693,Trypanosoma cruzi
+http://purl.obolibrary.org/obo/MONDO_0006697,Chlamydophila infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_83553,Chlamydophila
+http://purl.obolibrary.org/obo/MONDO_0005704,Ciliophora infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_5878,Ciliophora
+http://purl.obolibrary.org/obo/MONDO_0005708,Colorado tick fever,http://purl.obolibrary.org/obo/NCBITaxon_46839,Colorado tick fever virus
+http://purl.obolibrary.org/obo/MONDO_0006708,Desulfovibrionaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_194924,Desulfovibrionaceae
+http://purl.obolibrary.org/obo/MONDO_0005730,Dictyocaulus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_29171,Dictyocaulus
+http://purl.obolibrary.org/obo/MONDO_0005120,Drosophila C virus infection,http://purl.obolibrary.org/obo/NCBITaxon_64279,Drosophila C virus
+http://purl.obolibrary.org/obo/MONDO_0005737,Ebola hemorrhagic fever,http://purl.obolibrary.org/obo/NCBITaxon_186536,Ebolavirus
+http://purl.obolibrary.org/obo/MONDO_0005740,Echovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_33758,Echovirus
+http://purl.obolibrary.org/obo/MONDO_0005745,Enoplea infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_119088,Enoplea
+http://purl.obolibrary.org/obo/MONDO_0005121,Enterococcus faecalis infection,http://purl.obolibrary.org/obo/NCBITaxon_1351,Enterococcus faecalis
+http://purl.obolibrary.org/obo/MONDO_0005111,Epstein-Barr virus infection,http://purl.obolibrary.org/obo/NCBITaxon_10376,Human gammaherpesvirus 4
+http://purl.obolibrary.org/obo/MONDO_0006751,Erysipelothrix infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1647,Erysipelothrix
+http://purl.obolibrary.org/obo/MONDO_0006752,Erysipelothrix rhusiopathiae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1648,Erysipelothrix rhusiopathiae
+http://purl.obolibrary.org/obo/MONDO_0005762,Filoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11266,Filoviridae
+http://purl.obolibrary.org/obo/MONDO_0005763,Flaviviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11050,Flaviviridae
+http://purl.obolibrary.org/obo/MONDO_0006925,Fusobacteriaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_203492,Fusobacteriaceae
+http://purl.obolibrary.org/obo/MONDO_0006765,Fusobacterium infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_848,Fusobacterium
+http://purl.obolibrary.org/obo/MONDO_0005109,HIV infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_12721,Human immunodeficiency virus
+http://purl.obolibrary.org/obo/MONDO_0005780,Hantavirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11598,Hantavirus
+http://purl.obolibrary.org/obo/MONDO_0006781,Helicobacter pylori infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_210,Helicobacter pylori
+http://purl.obolibrary.org/obo/MONDO_0017942,Hendra virus infection,http://purl.obolibrary.org/obo/NCBITaxon_63330,Hendra henipavirus
+http://purl.obolibrary.org/obo/MONDO_0005785,Henipavirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_260964,Henipavirus
+http://purl.obolibrary.org/obo/MONDO_0005786,Hepadnaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10404,Hepadnaviridae
+http://purl.obolibrary.org/obo/MONDO_0005794,Herpesviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10292,Herpesviridae
+http://purl.obolibrary.org/obo/MONDO_0002099,Histoplasma capsulatum infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_5037,Histoplasma capsulatum
+http://purl.obolibrary.org/obo/MONDO_0030603,Klebsiella infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_570,Klebsiella
+http://purl.obolibrary.org/obo/MONDO_0017881,Kyasanur forest disease,http://purl.obolibrary.org/obo/NCBITaxon_33743,Kyasanur forest disease virus
+http://purl.obolibrary.org/obo/MONDO_0019632,Lyme disease,http://purl.obolibrary.org/obo/NCBITaxon_139,Borreliella burgdorferi
+http://purl.obolibrary.org/obo/MONDO_0005856,Mononegavirales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11157,Mononegavirales
+http://purl.obolibrary.org/obo/MONDO_0006878,Moraxellaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_468,Moraxellaceae
+http://purl.obolibrary.org/obo/MONDO_0005857,Morbillivirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11229,Morbillivirus
+http://purl.obolibrary.org/obo/MONDO_0001137,Murray valley encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11079,Murray Valley encephalitis virus
+http://purl.obolibrary.org/obo/MONDO_0005871,Nematoda infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6231,Nematoda
+http://purl.obolibrary.org/obo/MONDO_0024416,Neorickettsia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_33993,Neorickettsia
+http://purl.obolibrary.org/obo/MONDO_0005876,Nidovirales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_76804,Nidovirales
+http://purl.obolibrary.org/obo/MONDO_0000342,O'nyong'nyong fever,http://purl.obolibrary.org/obo/NCBITaxon_11027,O'nyong-nyong virus
+http://purl.obolibrary.org/obo/MONDO_0000345,Oropouche fever,http://purl.obolibrary.org/obo/NCBITaxon_118655,Oropouche virus
+http://purl.obolibrary.org/obo/MONDO_0018984,Oroya fever,http://purl.obolibrary.org/obo/NCBITaxon_774,Bartonella bacilliformis
+http://purl.obolibrary.org/obo/MONDO_0005889,Orthomyxoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11308,Orthomyxoviridae
+http://purl.obolibrary.org/obo/MONDO_0005896,Paramyxoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11158,Paramyxoviridae
+http://purl.obolibrary.org/obo/MONDO_0025371,Parvoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10780,Parvoviridae
+http://purl.obolibrary.org/obo/MONDO_0005122,Pectobacterium carotovorum infection,http://purl.obolibrary.org/obo/NCBITaxon_122277,Pectobacterium
+http://purl.obolibrary.org/obo/MONDO_0024412,Peptostreptococcus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1257,Peptostreptococcus
+http://purl.obolibrary.org/obo/MONDO_0005909,Pestivirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11095,Pestivirus
+http://purl.obolibrary.org/obo/MONDO_0000276,Powassan encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11083,Powassan virus
+http://purl.obolibrary.org/obo/MONDO_0006929,Proteus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_583,Proteus <enterobacteria>
+http://purl.obolibrary.org/obo/MONDO_0005141,Pseudomonas infection,http://purl.obolibrary.org/obo/NCBITaxon_286,Pseudomonas
+http://purl.obolibrary.org/obo/MONDO_0019186,Q fever,http://purl.obolibrary.org/obo/NCBITaxon_777,Coxiella burnetii
+http://purl.obolibrary.org/obo/MONDO_0000331,Rickettsia helvetica spotted fever,http://purl.obolibrary.org/obo/NCBITaxon_35789,Rickettsia helvetica
+http://purl.obolibrary.org/obo/MONDO_0006927,Rickettsiaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_775,Rickettsiaceae
+http://purl.obolibrary.org/obo/MONDO_0005949,Roseolovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_40272,Roseolovirus
+http://purl.obolibrary.org/obo/MONDO_0000344,Ross river fever,http://purl.obolibrary.org/obo/NCBITaxon_11029,Ross River virus
+http://purl.obolibrary.org/obo/MONDO_0005194,Rotavirus infection,http://purl.obolibrary.org/obo/NCBITaxon_10912,Rotavirus
+http://purl.obolibrary.org/obo/MONDO_0044351,Schistosoma intercalatum infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6187,Schistosoma intercalatum
+http://purl.obolibrary.org/obo/MONDO_0044344,Schistosoma japonicum infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6182,Schistosoma japonicum
+http://purl.obolibrary.org/obo/MONDO_0044345,Schistosoma mansoni infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6183,Schistosoma mansoni
+http://purl.obolibrary.org/obo/MONDO_0005985,Togaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11018,Togaviridae
+http://purl.obolibrary.org/obo/MONDO_0005986,Torovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11155,Torovirus
+http://purl.obolibrary.org/obo/MONDO_0007000,Treponema infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_157,Treponema
+http://purl.obolibrary.org/obo/MONDO_0042458,Trichinella spiralis infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6334,Trichinella spiralis
+http://purl.obolibrary.org/obo/MONDO_0030906,Trichomonas tenax infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_43075,Trichomonas tenax
+http://purl.obolibrary.org/obo/MONDO_0007007,Ureaplasma urethritis,http://purl.obolibrary.org/obo/NCBITaxon_2129,Ureaplasma
+http://purl.obolibrary.org/obo/MONDO_0006005,Venezuelan equine encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11036,Venezuelan equine encephalitis virus
+http://purl.obolibrary.org/obo/MONDO_0002282,West Nile fever,http://purl.obolibrary.org/obo/NCBITaxon_11082,West Nile virus
+http://purl.obolibrary.org/obo/MONDO_0005116,Whipple disease,http://purl.obolibrary.org/obo/NCBITaxon_2039,Tropheryma whipplei
+http://purl.obolibrary.org/obo/MONDO_0018661,Zika virus disease,http://purl.obolibrary.org/obo/NCBITaxon_64320,Zika virus
+http://purl.obolibrary.org/obo/MONDO_0000295,acanthocephaliasis,http://purl.obolibrary.org/obo/NCBITaxon_10232,Acanthocephala
+http://purl.obolibrary.org/obo/MONDO_0043479,adenoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10508,Adenoviridae
+http://purl.obolibrary.org/obo/MONDO_0005641,aleutian mink disease,http://purl.obolibrary.org/obo/NCBITaxon_28314,Aleutian mink disease virus
+http://purl.obolibrary.org/obo/MONDO_0017282,alveolar echinococcosis,http://purl.obolibrary.org/obo/NCBITaxon_6211,Echinococcus multilocularis
+http://purl.obolibrary.org/obo/MONDO_0025303,anaplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_768,Anaplasma
+http://purl.obolibrary.org/obo/MONDO_0005645,ancylostomiasis,http://purl.obolibrary.org/obo/NCBITaxon_29169,Ancylostoma
+http://purl.obolibrary.org/obo/MONDO_0005119,anthrax infection,http://purl.obolibrary.org/obo/NCBITaxon_1392,Bacillus anthracis
+http://purl.obolibrary.org/obo/MONDO_0005654,ascariasis,http://purl.obolibrary.org/obo/NCBITaxon_6252,Ascaris lumbricoides
+http://purl.obolibrary.org/obo/MONDO_0005655,ascaridiasis,http://purl.obolibrary.org/obo/NCBITaxon_46684,Ascaridia
+http://purl.obolibrary.org/obo/MONDO_0005661,babesiosis,http://purl.obolibrary.org/obo/NCBITaxon_5864,Babesia
+http://purl.obolibrary.org/obo/MONDO_0005113,bacterial infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria
+http://purl.obolibrary.org/obo/MONDO_0005664,bartonellosis,http://purl.obolibrary.org/obo/NCBITaxon_773,Bartonella
+http://purl.obolibrary.org/obo/MONDO_0000302,basidiobolomycosis,http://purl.obolibrary.org/obo/NCBITaxon_4859,Basidiobolus
+http://purl.obolibrary.org/obo/MONDO_0000297,baylisascariasis,http://purl.obolibrary.org/obo/NCBITaxon_6259,Baylisascaris procyonis
+http://purl.obolibrary.org/obo/MONDO_0001714,bejel,http://purl.obolibrary.org/obo/NCBITaxon_53436,Treponema pallidum subsp. endemicum
+http://purl.obolibrary.org/obo/MONDO_0005672,blastomycosis,http://purl.obolibrary.org/obo/NCBITaxon_5039,Blastomyces dermatitidis
+http://purl.obolibrary.org/obo/MONDO_0037872,bordetellosis,http://purl.obolibrary.org/obo/NCBITaxon_517,Bordetella
+http://purl.obolibrary.org/obo/MONDO_0043953,burkholderia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_32008,Burkholderia
+http://purl.obolibrary.org/obo/MONDO_0017941,chikungunya,http://purl.obolibrary.org/obo/NCBITaxon_37124,Chikungunya virus
+http://purl.obolibrary.org/obo/MONDO_0021697,chlamydia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_810,Chlamydia
+http://purl.obolibrary.org/obo/MONDO_0005701,chlamydia trachomatis infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_813,Chlamydia trachomatis
+http://purl.obolibrary.org/obo/MONDO_0015766,cholera,http://purl.obolibrary.org/obo/NCBITaxon_666,Vibrio cholerae
+http://purl.obolibrary.org/obo/MONDO_0005706,coccidioidomycosis,http://purl.obolibrary.org/obo/NCBITaxon_5501,Coccidioides immitis
+http://purl.obolibrary.org/obo/MONDO_0005724,cryptococcosis,http://purl.obolibrary.org/obo/NCBITaxon_5207,Cryptococcus neoformans
+http://purl.obolibrary.org/obo/MONDO_0015474,cryptosporidiosis,http://purl.obolibrary.org/obo/NCBITaxon_5806,Cryptosporidium
+http://purl.obolibrary.org/obo/MONDO_0005725,cyclosporiasis,http://purl.obolibrary.org/obo/NCBITaxon_44417,Cyclospora
+http://purl.obolibrary.org/obo/MONDO_0016212,cyclosporosis,http://purl.obolibrary.org/obo/NCBITaxon_88456,Cyclospora cayetanensis
+http://purl.obolibrary.org/obo/MONDO_0017280,demodicidosis,http://purl.obolibrary.org/obo/NCBITaxon_188544,Demodex
+http://purl.obolibrary.org/obo/MONDO_0005502,dengue disease,http://purl.obolibrary.org/obo/NCBITaxon_12637,Dengue virus
+http://purl.obolibrary.org/obo/MONDO_0005729,dicrocoeliasis,http://purl.obolibrary.org/obo/NCBITaxon_57077,Dicrocoelium
+http://purl.obolibrary.org/obo/MONDO_0024608,dientamoebiasis,http://purl.obolibrary.org/obo/NCBITaxon_43351,Dientamoeba
+http://purl.obolibrary.org/obo/MONDO_0000298,dioctophymiasis,http://purl.obolibrary.org/obo/NCBITaxon_513045,Dioctophyme renale
+http://purl.obolibrary.org/obo/MONDO_0005731,dipetalonemiasis,http://purl.obolibrary.org/obo/NCBITaxon_42231,Mansonella perstans
+http://purl.obolibrary.org/obo/MONDO_0015260,diphyllobothriasis,http://purl.obolibrary.org/obo/NCBITaxon_28844,Diphyllobothrium
+http://purl.obolibrary.org/obo/MONDO_0015636,dirofilariasis,http://purl.obolibrary.org/obo/NCBITaxon_6286,Dirofilaria
+http://purl.obolibrary.org/obo/MONDO_0016472,dracunculiasis,http://purl.obolibrary.org/obo/NCBITaxon_318479,Dracunculus medinensis
+http://purl.obolibrary.org/obo/MONDO_0005738,echinococcosis,http://purl.obolibrary.org/obo/NCBITaxon_6209,Echinococcus
+http://purl.obolibrary.org/obo/MONDO_0044346,echinococcus granulosus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6210,Echinococcus granulosus
+http://purl.obolibrary.org/obo/MONDO_0005739,echinostomiasis,http://purl.obolibrary.org/obo/NCBITaxon_404429,Echinostomatoidea
+http://purl.obolibrary.org/obo/MONDO_0005746,enterobiasis,http://purl.obolibrary.org/obo/NCBITaxon_51028,Enterobius vermicularis
+http://purl.obolibrary.org/obo/MONDO_0005747,enterovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_12059,Enterovirus
+http://purl.obolibrary.org/obo/MONDO_0002041,fungal infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi
+http://purl.obolibrary.org/obo/MONDO_0016426,fusariosis,http://purl.obolibrary.org/obo/NCBITaxon_5506,Fusarium
+http://purl.obolibrary.org/obo/MONDO_0005774,glanders,http://purl.obolibrary.org/obo/NCBITaxon_13373,Burkholderia mallei
+http://purl.obolibrary.org/obo/MONDO_0006926,haemophilus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_724,Haemophilus
+http://purl.obolibrary.org/obo/MONDO_0004609,herpes simplex infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus
+http://purl.obolibrary.org/obo/MONDO_0001191,hirudiniasis,http://purl.obolibrary.org/obo/NCBITaxon_55824,Hirudinea
+http://purl.obolibrary.org/obo/MONDO_0018312,histoplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_5036,Histoplasma
+http://purl.obolibrary.org/obo/MONDO_0005801,human T-lymphotropic virus 1 infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11908,Human T-lymphotropic virus 1
+http://purl.obolibrary.org/obo/MONDO_0005187,human herpesvirus 8 infection,http://purl.obolibrary.org/obo/NCBITaxon_37296,Human gammaherpesvirus 8
+http://purl.obolibrary.org/obo/MONDO_0005161,human papilloma virus infection,http://purl.obolibrary.org/obo/NCBITaxon_10566,Human papillomavirus
+http://purl.obolibrary.org/obo/MONDO_0005805,hypodermyiasis,http://purl.obolibrary.org/obo/NCBITaxon_7387,Oestridae
+http://purl.obolibrary.org/obo/MONDO_0024410,infection caused by Bifidobacterium,http://purl.obolibrary.org/obo/NCBITaxon_1678,Bifidobacterium
+http://purl.obolibrary.org/obo/MONDO_0005550,infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1,root
+http://purl.obolibrary.org/obo/MONDO_0018769,isosporiasis,http://purl.obolibrary.org/obo/NCBITaxon_482538,Cystoisospora belli
+http://purl.obolibrary.org/obo/MONDO_0005124,leprosy,http://purl.obolibrary.org/obo/NCBITaxon_1769,Mycobacterium leprae
+http://purl.obolibrary.org/obo/MONDO_0005825,leptospirosis,http://purl.obolibrary.org/obo/NCBITaxon_171,Leptospira
+http://purl.obolibrary.org/obo/MONDO_0005828,listeriosis,http://purl.obolibrary.org/obo/NCBITaxon_1639,Listeria monocytogenes
+http://purl.obolibrary.org/obo/MONDO_0004619,measles,http://purl.obolibrary.org/obo/NCBITaxon_11234,Measles morbillivirus
+http://purl.obolibrary.org/obo/MONDO_0017775,melioidosis,http://purl.obolibrary.org/obo/NCBITaxon_28450,Burkholderia pseudomallei
+http://purl.obolibrary.org/obo/MONDO_0000294,mesocestoidiasis,http://purl.obolibrary.org/obo/NCBITaxon_53467,Mesocestoides
+http://purl.obolibrary.org/obo/MONDO_0005846,microsporidiosis,http://purl.obolibrary.org/obo/NCBITaxon_6029,Microsporidia
+http://purl.obolibrary.org/obo/MONDO_0000989,mumps infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11161,Mumps virus
+http://purl.obolibrary.org/obo/MONDO_0005866,mycobacterium avium complex disease,http://purl.obolibrary.org/obo/NCBITaxon_37162,Mycobacterium avium complex
+http://purl.obolibrary.org/obo/MONDO_0017832,mycobacterium xenopi infection,http://purl.obolibrary.org/obo/NCBITaxon_1789,Mycobacterium xenopi
+http://purl.obolibrary.org/obo/MONDO_0017776,nocardiosis,http://purl.obolibrary.org/obo/NCBITaxon_1817,Nocardia
+http://purl.obolibrary.org/obo/MONDO_0005880,oesophagostomiasis,http://purl.obolibrary.org/obo/NCBITaxon_52564,Oesophagostomum
+http://purl.obolibrary.org/obo/MONDO_0005895,paragonimiasis,http://purl.obolibrary.org/obo/NCBITaxon_34504,Paragonimus westermani
+http://purl.obolibrary.org/obo/MONDO_0042974,parainfluenza virus type 3 infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11216,Human respirovirus 3
+http://purl.obolibrary.org/obo/MONDO_0000307,parasitic Ichthyosporea infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_127916,Ichthyosporea
+http://purl.obolibrary.org/obo/MONDO_0005901,pasteurellosis,http://purl.obolibrary.org/obo/NCBITaxon_745,Pasteurella
+http://purl.obolibrary.org/obo/MONDO_0000304,penicilliosis,http://purl.obolibrary.org/obo/NCBITaxon_37727,Talaromyces marneffei
+http://purl.obolibrary.org/obo/MONDO_0005077,pertussis,http://purl.obolibrary.org/obo/NCBITaxon_520,Bordetella pertussis
+http://purl.obolibrary.org/obo/MONDO_0005908,peste des petits ruminants infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_31604,Small ruminant morbillivirus
+http://purl.obolibrary.org/obo/MONDO_0000292,philophthalmiasis,http://purl.obolibrary.org/obo/NCBITaxon_685953,Philophthalmus
+http://purl.obolibrary.org/obo/MONDO_0005114,pneumococcal infection,http://purl.obolibrary.org/obo/NCBITaxon_1313,Streptococcus pneumoniae
+http://purl.obolibrary.org/obo/MONDO_0024618,poliovirus infection,http://purl.obolibrary.org/obo/NCBITaxon_138950,Enterovirus C
+http://purl.obolibrary.org/obo/MONDO_0005946,rhinosporidiosis,http://purl.obolibrary.org/obo/NCBITaxon_90339,Rhinosporidium seeberi
+http://purl.obolibrary.org/obo/MONDO_0006956,rickettsiosis,http://purl.obolibrary.org/obo/NCBITaxon_780,Rickettsia
+http://purl.obolibrary.org/obo/MONDO_0004656,rubella,http://purl.obolibrary.org/obo/NCBITaxon_11041,Rubella virus
+http://purl.obolibrary.org/obo/MONDO_0004525,scabies,http://purl.obolibrary.org/obo/NCBITaxon_52283,Sarcoptes scabiei
+http://purl.obolibrary.org/obo/MONDO_0005954,screw worm infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_115425,Cochliomyia hominivorax
+http://purl.obolibrary.org/obo/MONDO_0000332,sennetsu fever,http://purl.obolibrary.org/obo/NCBITaxon_951,Neorickettsia sennetsu
+http://purl.obolibrary.org/obo/MONDO_0005957,setariasis,http://purl.obolibrary.org/obo/NCBITaxon_48796,Setaria <nematode>
+http://purl.obolibrary.org/obo/MONDO_0005091,severe acute respiratory syndrome,http://purl.obolibrary.org/obo/NCBITaxon_227859,SARS coronavirus
+http://purl.obolibrary.org/obo/MONDO_0005163,simian immunodeficiency virus infection,http://purl.obolibrary.org/obo/NCBITaxon_11723,Simian immunodeficiency virus
+http://purl.obolibrary.org/obo/MONDO_0004651,smallpox,http://purl.obolibrary.org/obo/NCBITaxon_10255,Variola virus
+http://purl.obolibrary.org/obo/MONDO_0005963,sparganosis,http://purl.obolibrary.org/obo/NCBITaxon_46580,Spirometra
+http://purl.obolibrary.org/obo/MONDO_0021680,streptococcal infection,http://purl.obolibrary.org/obo/NCBITaxon_1301,Streptococcus
+http://purl.obolibrary.org/obo/MONDO_0005976,syphilis,http://purl.obolibrary.org/obo/NCBITaxon_160,Treponema pallidum
+http://purl.obolibrary.org/obo/MONDO_0000299,thelaziasis,http://purl.obolibrary.org/obo/NCBITaxon_103826,Thelazia
+http://purl.obolibrary.org/obo/MONDO_0005980,tick infestation,http://purl.obolibrary.org/obo/NCBITaxon_297308,Ixodoidea
+http://purl.obolibrary.org/obo/MONDO_0005982,tinea infection,http://purl.obolibrary.org/obo/NCBITaxon_41013,Tinea
+http://purl.obolibrary.org/obo/MONDO_0005987,toxascariasis,http://purl.obolibrary.org/obo/NCBITaxon_59263,Toxascaris
+http://purl.obolibrary.org/obo/MONDO_0005988,toxocariasis,http://purl.obolibrary.org/obo/NCBITaxon_6264,Toxocara
+http://purl.obolibrary.org/obo/MONDO_0005989,toxoplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_5811,Toxoplasma gondii
+http://purl.obolibrary.org/obo/MONDO_0005991,trench fever,http://purl.obolibrary.org/obo/NCBITaxon_803,Bartonella quintana
+http://purl.obolibrary.org/obo/MONDO_0005992,trichinosis,http://purl.obolibrary.org/obo/NCBITaxon_6333,Trichinella
+http://purl.obolibrary.org/obo/MONDO_0000306,trichosporonosis,http://purl.obolibrary.org/obo/NCBITaxon_5552,Trichosporon
+http://purl.obolibrary.org/obo/MONDO_0005994,trichostrongyloidiasis,http://purl.obolibrary.org/obo/NCBITaxon_6314,Trichostrongyloidea
+http://purl.obolibrary.org/obo/MONDO_0005995,trichostrongylosis,http://purl.obolibrary.org/obo/NCBITaxon_6318,Trichostrongylus
+http://purl.obolibrary.org/obo/MONDO_0005996,trichuriasis,http://purl.obolibrary.org/obo/NCBITaxon_36087,Trichuris trichiura
+http://purl.obolibrary.org/obo/MONDO_0005998,trombiculiasis,http://purl.obolibrary.org/obo/NCBITaxon_92251,Trombiculidae
+http://purl.obolibrary.org/obo/MONDO_0000940,trypanosomiasis,http://purl.obolibrary.org/obo/NCBITaxon_5690,Trypanosoma
+http://purl.obolibrary.org/obo/MONDO_0018077,tularemia,http://purl.obolibrary.org/obo/NCBITaxon_263,Francisella tularensis
+http://purl.obolibrary.org/obo/MONDO_0007014,vibrio infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_662,Vibrio
+http://purl.obolibrary.org/obo/MONDO_0043297,vibrio vulnificus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_672,Vibrio vulnificus
+http://purl.obolibrary.org/obo/MONDO_0005108,viral infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses
+http://purl.obolibrary.org/obo/MONDO_0006013,visna disease,http://purl.obolibrary.org/obo/NCBITaxon_11741,Visna/maedi virus
+http://purl.obolibrary.org/obo/MONDO_0006019,yaws,http://purl.obolibrary.org/obo/NCBITaxon_168,Treponema pallidum subsp. pertenue
+http://purl.obolibrary.org/obo/MONDO_0020502,yellow fever,http://purl.obolibrary.org/obo/NCBITaxon_11089,Yellow fever virus

--- a/src/patterns/inflammatory_disease_by_site.csv
+++ b/src/patterns/inflammatory_disease_by_site.csv
@@ -1,29 +1,114 @@
 iri,iri label,location,location label
-MONDO:0000261,adenoiditis,UBERON:0001732,pharyngeal tonsil
-MONDO:0015304,arachnoiditis,UBERON:0002362,arachnoid mater
-MONDO:0005578,arthritis,UBERON:0000982,skeletal joint
-MONDO:0000409,chorioamnionitis,UBERON:0005630,fetal membrane
-MONDO:0002406,dermatitis,UBERON:0000014,zone of skin
-MONDO:0000918,endometritis,UBERON:0001295,endometrium
-MONDO:0000888,gastrointestinal mucositis,UBERON:0004786,gastrointestinal system mucosa
-MONDO:0001873,geniculate ganglionitis,UBERON:0001700,geniculate ganglion
-MONDO:0021156,hypophysitis,UBERON:0000007,pituitary gland
-MONDO:0002052,lymphadenitis (disease),UBERON:0000029,lymph node
-MONDO:0006849,mastitis,UBERON:0000310,breast
-MONDO:0000748,mastoiditis (disease),UBERON:0011220,mastoid process of temporal bone
-MONDO:0021108,meningitis (disease),UBERON:0002360,meninx
-MONDO:0001040,nasopharyngitis,UBERON:0001728,nasopharynx
-MONDO:0000958,neuroretinitis,UBERON:0000966,retina
-MONDO:0006882,orchitis (disease),UBERON:0000473,testis
-MONDO:0005076,periodontitis,UBERON:0001758,periodontium
-MONDO:0001109,petrositis,UBERON:0001694,petrous part of temporal bone
-MONDO:0002258,pharyngitis,UBERON:0000341,throat
-MONDO:0006918,posterior uveitis,UBERON:0019207,chorioretinal region
-MONDO:0000497,pyometritis,UBERON:0001296,myometrium
-MONDO:0003014,rhinitis,UBERON:0001826,nasal cavity mucosa
-MONDO:0003619,salpingitis,UBERON:0003889,fallopian tube
-MONDO:0004855,tenosynovitis,UBERON:0000304,tendon sheath
-MONDO:0004126,thyroiditis (disease),UBERON:0002046,thyroid gland
-MONDO:0001039,tonsillitis,UBERON:0002372,tonsil
-MONDO:0020283,uveitis (disease),UBERON:0001768,uvea
-MONDO:0000739,uvulitis,UBERON:0001734,palatine uvula
+http://purl.obolibrary.org/obo/MONDO_0004551,Meckel diverticulitis,http://purl.obolibrary.org/obo/UBERON_0003705,Meckel's diverticulum
+http://purl.obolibrary.org/obo/MONDO_0019838,adenohypophysitis,http://purl.obolibrary.org/obo/UBERON_0002196,adenohypophysis
+http://purl.obolibrary.org/obo/MONDO_0000261,adenoiditis,http://purl.obolibrary.org/obo/UBERON_0001732,pharyngeal tonsil
+http://purl.obolibrary.org/obo/MONDO_0006656,aortitis,http://purl.obolibrary.org/obo/UBERON_0000947,aorta
+http://purl.obolibrary.org/obo/MONDO_0005649,appendicitis,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0015304,arachnoiditis,http://purl.obolibrary.org/obo/UBERON_0002362,arachnoid mater
+http://purl.obolibrary.org/obo/MONDO_0043494,arteritis,http://purl.obolibrary.org/obo/UBERON_0001637,artery
+http://purl.obolibrary.org/obo/MONDO_0005578,arthritis,http://purl.obolibrary.org/obo/UBERON_0000982,skeletal joint
+http://purl.obolibrary.org/obo/MONDO_0006672,balanitis,http://purl.obolibrary.org/obo/UBERON_0001299,glans penis
+http://purl.obolibrary.org/obo/MONDO_0004785,blepharitis,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0015144,brain inflammatory disease,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0003781,bronchitis,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0002471,bursitis,http://purl.obolibrary.org/obo/UBERON_0003668,synovial bursa
+http://purl.obolibrary.org/obo/MONDO_0001277,cerebral arteritis,http://purl.obolibrary.org/obo/UBERON_0004449,cerebral artery
+http://purl.obolibrary.org/obo/MONDO_0002645,cerebritis,http://purl.obolibrary.org/obo/UBERON_0001869,cerebral hemisphere
+http://purl.obolibrary.org/obo/MONDO_0004789,cholangitis,http://purl.obolibrary.org/obo/UBERON_0001173,biliary tree
+http://purl.obolibrary.org/obo/MONDO_0002155,cholecystitis,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0000409,chorioamnionitis,http://purl.obolibrary.org/obo/UBERON_0005630,fetal membrane
+http://purl.obolibrary.org/obo/MONDO_0005292,colitis (disease),http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003799,conjunctivitis (disease),http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0006032,cystitis,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0004804,dacryoadenitis,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0004926,dacryocystitis,http://purl.obolibrary.org/obo/UBERON_0001351,lacrimal sac
+http://purl.obolibrary.org/obo/MONDO_0002406,dermatitis,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0006728,discitis,http://purl.obolibrary.org/obo/UBERON_0001066,intervertebral disk
+http://purl.obolibrary.org/obo/MONDO_0005533,distal colitis,http://purl.obolibrary.org/obo/UBERON_0008971,left colon
+http://purl.obolibrary.org/obo/MONDO_0004235,diverticulitis,http://purl.obolibrary.org/obo/UBERON_0009854,digestive tract diverticulum
+http://purl.obolibrary.org/obo/MONDO_0004627,duodenitis,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0005156,encephalomyelitis,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0043576,endarteritis,http://purl.obolibrary.org/obo/UBERON_0005740,tunica intima of artery
+http://purl.obolibrary.org/obo/MONDO_0005025,endocarditis (disease),http://purl.obolibrary.org/obo/UBERON_0002165,endocardium
+http://purl.obolibrary.org/obo/MONDO_0003632,endocervicitis,http://purl.obolibrary.org/obo/UBERON_0000458,endocervix
+http://purl.obolibrary.org/obo/MONDO_0000918,endometritis,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0015292,endotheliitis,http://purl.obolibrary.org/obo/UBERON_0001986,endothelium
+http://purl.obolibrary.org/obo/MONDO_0043579,enteritis,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0024419,enthesitis,http://purl.obolibrary.org/obo/UBERON_0035845,enthesis
+http://purl.obolibrary.org/obo/MONDO_0001875,epicondylitis,http://purl.obolibrary.org/obo/UBERON_0006807,ectepicondyle of humerus
+http://purl.obolibrary.org/obo/MONDO_0005753,epiglottitis,http://purl.obolibrary.org/obo/UBERON_0004982,mucosa of epiglottis
+http://purl.obolibrary.org/obo/MONDO_0001409,esophagitis (disease),http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004830,fasciitis (disease),http://purl.obolibrary.org/obo/UBERON_0008982,fascia
+http://purl.obolibrary.org/obo/MONDO_0004966,gastritis (disease),http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0002269,gastroenteritis,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0000888,gastrointestinal mucositis,http://purl.obolibrary.org/obo/UBERON_0004786,gastrointestinal system mucosa
+http://purl.obolibrary.org/obo/MONDO_0001873,geniculate ganglionitis,http://purl.obolibrary.org/obo/UBERON_0001700,geniculate ganglion
+http://purl.obolibrary.org/obo/MONDO_0002508,gingivitis,http://purl.obolibrary.org/obo/UBERON_0001828,gingiva
+http://purl.obolibrary.org/obo/MONDO_0006771,glossitis,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0002260,hidradenitis,http://purl.obolibrary.org/obo/UBERON_0000382,apocrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0021156,hypophysitis,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0024636,inflammation of heart layer,http://purl.obolibrary.org/obo/UBERON_0005983,heart layer
+http://purl.obolibrary.org/obo/MONDO_0021166,inflammatory disease,http://purl.obolibrary.org/obo/UBERON_0000061,anatomical structure
+http://purl.obolibrary.org/obo/MONDO_0006814,iritis (disease),http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0008054,juvenile dermatomyositis,http://purl.obolibrary.org/obo/UBERON_2001089,myoseptum
+http://purl.obolibrary.org/obo/MONDO_0003085,keratitis,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0002008,labyrinthitis,http://purl.obolibrary.org/obo/UBERON_0001846,internal ear
+http://purl.obolibrary.org/obo/MONDO_0002647,laryngitis,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0000029,lymph node
+http://purl.obolibrary.org/obo/MONDO_0005832,lymphangitis,http://purl.obolibrary.org/obo/UBERON_0001473,lymphatic vessel
+http://purl.obolibrary.org/obo/MONDO_0006849,mastitis,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0000748,mastoiditis (disease),http://purl.obolibrary.org/obo/UBERON_0011220,mastoid process of temporal bone
+http://purl.obolibrary.org/obo/MONDO_0021108,meningitis (disease),http://purl.obolibrary.org/obo/UBERON_0002360,meninx
+http://purl.obolibrary.org/obo/MONDO_0020579,mucositis,http://purl.obolibrary.org/obo/UBERON_0000344,mucosa
+http://purl.obolibrary.org/obo/MONDO_0002565,myelitis,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0004496,myocarditis,http://purl.obolibrary.org/obo/UBERON_0002349,myocardium
+http://purl.obolibrary.org/obo/MONDO_0021167,myositis,http://purl.obolibrary.org/obo/UBERON_0002385,muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0001040,nasopharyngitis,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0001166,nephritis,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0006877,oophoritis,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006879,optic papillitis,http://purl.obolibrary.org/obo/UBERON_0001783,optic disc
+http://purl.obolibrary.org/obo/MONDO_0006882,orchitis (disease),http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0005441,otitis media (disease),http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0002172,otosalpingitis,http://purl.obolibrary.org/obo/UBERON_0002393,pharyngotympanic tube
+http://purl.obolibrary.org/obo/MONDO_0004982,pancreatitis,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0006591,panniculitis,http://purl.obolibrary.org/obo/UBERON_0002190,subcutaneous adipose tissue
+http://purl.obolibrary.org/obo/MONDO_0006887,parametritis,http://purl.obolibrary.org/obo/UBERON_0010391,parametrium
+http://purl.obolibrary.org/obo/MONDO_0005900,parotitis,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0011644,pars planitis,http://purl.obolibrary.org/obo/UBERON_0034936,pars plana of ciliary body
+http://purl.obolibrary.org/obo/MONDO_0005904,pericarditis (disease),http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0006900,perinephritis,http://purl.obolibrary.org/obo/UBERON_0005406,perirenal fat
+http://purl.obolibrary.org/obo/MONDO_0005076,periodontitis,http://purl.obolibrary.org/obo/UBERON_0001758,periodontium
+http://purl.obolibrary.org/obo/MONDO_0004934,periostitis (disease),http://purl.obolibrary.org/obo/UBERON_0002515,periosteum
+http://purl.obolibrary.org/obo/MONDO_0004522,peritonitis,http://purl.obolibrary.org/obo/UBERON_0002358,peritoneum
+http://purl.obolibrary.org/obo/MONDO_0001109,petrositis,http://purl.obolibrary.org/obo/UBERON_0001694,petrous part of temporal bone
+http://purl.obolibrary.org/obo/MONDO_0002258,pharyngitis,http://purl.obolibrary.org/obo/UBERON_0000341,throat
+http://purl.obolibrary.org/obo/MONDO_0004625,phlebitis,http://purl.obolibrary.org/obo/UBERON_0001638,vein
+http://purl.obolibrary.org/obo/MONDO_0043905,pneumonitis,http://purl.obolibrary.org/obo/UBERON_0008946,lung parenchyma
+http://purl.obolibrary.org/obo/MONDO_0006918,posterior uveitis,http://purl.obolibrary.org/obo/UBERON_0019207,chorioretinal region
+http://purl.obolibrary.org/obo/MONDO_0021164,posthitis,http://purl.obolibrary.org/obo/UBERON_0001332,prepuce of penis
+http://purl.obolibrary.org/obo/MONDO_0005538,proctitis,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0024278,proctocolitis,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0005280,prostatitis (disease),http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0000497,pyometritis,http://purl.obolibrary.org/obo/UBERON_0001296,myometrium
+http://purl.obolibrary.org/obo/MONDO_0002708,retinitis,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0003014,rhinitis,http://purl.obolibrary.org/obo/UBERON_0001826,nasal cavity mucosa
+http://purl.obolibrary.org/obo/MONDO_0003619,salpingitis,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0043786,serositis,http://purl.obolibrary.org/obo/UBERON_0000042,serous membrane
+http://purl.obolibrary.org/obo/MONDO_0003937,spondylitis,http://purl.obolibrary.org/obo/UBERON_0002412,vertebra
+http://purl.obolibrary.org/obo/MONDO_0004842,stomatitis,http://purl.obolibrary.org/obo/UBERON_0003729,mouth mucosa
+http://purl.obolibrary.org/obo/MONDO_0002400,synovitis (disease),http://purl.obolibrary.org/obo/UBERON_0002018,synovial membrane of synovial joint
+http://purl.obolibrary.org/obo/MONDO_0008538,temporal arteritis,http://purl.obolibrary.org/obo/UBERON_0001632,temporal artery
+http://purl.obolibrary.org/obo/MONDO_0004857,tendinitis,http://purl.obolibrary.org/obo/UBERON_0000043,tendon
+http://purl.obolibrary.org/obo/MONDO_0004855,tenosynovitis,http://purl.obolibrary.org/obo/UBERON_0000304,tendon sheath
+http://purl.obolibrary.org/obo/MONDO_0004126,thyroiditis (disease),http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0001039,tonsillitis,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0005990,tracheitis,http://purl.obolibrary.org/obo/UBERON_0000379,tracheal mucosa
+http://purl.obolibrary.org/obo/MONDO_0001732,trigonitis,http://purl.obolibrary.org/obo/UBERON_0001257,trigone of urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0024616,tympanitis,http://purl.obolibrary.org/obo/UBERON_0002364,tympanic membrane
+http://purl.obolibrary.org/obo/MONDO_0005297,urethritis (disease),http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0020283,uveitis (disease),http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0000739,uvulitis,http://purl.obolibrary.org/obo/UBERON_0001734,palatine uvula
+http://purl.obolibrary.org/obo/MONDO_0002234,vaginitis (disease),http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0004767,vesiculitis,http://purl.obolibrary.org/obo/UBERON_0000998,seminal vesicle
+http://purl.obolibrary.org/obo/MONDO_0007018,vulvitis,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/isolated.csv
+++ b/src/patterns/isolated.csv
@@ -1,24 +1,41 @@
 iri,iri label,disease,disease label
-MONDO:0016520,isolated Klippel-Feil syndrome,MONDO:0001029,Klippel-Feil syndrome
-MONDO:0016462,isolated agammaglobulinemia,MONDO:0015977,agammaglobulinemia
-MONDO:0016764,isolated anophthalmia-microphthalmia syndrome,MONDO:0020147,anophthalmia-microphthalmia syndrome
-MONDO:0018916,isolated anorectal malformation,MONDO:0019938,anorectal malformation
-MONDO:0016043,isolated cleft lip,MONDO:0004747,cleft lip (disease)
-MONDO:0007336,isolated cleft palate,MONDO:0016064,cleft palate
-MONDO:0019627,isolated congenital alacrima,MONDO:0020194,congenital alacrima
-MONDO:0020463,isolated congenital ectropion,MONDO:0020161,congenital ectropion
-MONDO:0016553,isolated congenital hypogonadotropic hypogonadism,MONDO:0015770,congenital hypogonadotropic hypogonadism
-MONDO:0015337,isolated craniosynostosis,MONDO:0015469,craniosynostosis
-MONDO:0007410,isolated cryptophthalmia,MONDO:0020153,cryptophthalmia
-MONDO:0017667,isolated diffuse palmoplantar keratoderma,MONDO:0017666,diffuse palmoplantar keratoderma
-MONDO:0015494,isolated dystonia,MONDO:0003441,dystonia (disease)
-MONDO:0017673,isolated focal palmoplantar keratoderma,MONDO:0017672,focal palmoplantar keratoderma
-MONDO:0017089,isolated megalencephaly,MONDO:0016608,megalencephaly (disease)
-MONDO:0019284,isolated nail anomaly,MONDO:0019283,nail anomaly
-MONDO:0015634,isolated osteopoikilosis,MONDO:0001414,osteopoikilosis (disease)
-MONDO:0008265,isolated polycystic liver disease,MONDO:0000447,polycystic liver disease (disease)
-MONDO:0016518,isolated punctate palmoplantar keratoderma,MONDO:0017675,punctate palmoplantar keratoderma
-MONDO:0019351,isolated spina bifida,MONDO:0008449,spina bifida (disease)
-MONDO:0018065,isolated trigonocephaly,MONDO:0000156,trigonocephaly
-MONDO:0000509,non-syndromic intellectual disability,MONDO:0001071,intellectual disability
-MONDO:0019497,nonsyndromic deafness,MONDO:0005365,hearing loss
+http://purl.obolibrary.org/obo/MONDO_0017262,inherited non-syndromic ichthyosis,http://purl.obolibrary.org/obo/MONDO_0015947,inherited ichthyosis
+http://purl.obolibrary.org/obo/MONDO_0016520,isolated Klippel-Feil syndrome,http://purl.obolibrary.org/obo/MONDO_0001029,Klippel-Feil syndrome
+http://purl.obolibrary.org/obo/MONDO_0016462,isolated agammaglobulinemia,http://purl.obolibrary.org/obo/MONDO_0015977,agammaglobulinemia
+http://purl.obolibrary.org/obo/MONDO_0007119,isolated aniridia,http://purl.obolibrary.org/obo/MONDO_0019172,aniridia
+http://purl.obolibrary.org/obo/MONDO_0016764,isolated anophthalmia-microphthalmia syndrome,http://purl.obolibrary.org/obo/MONDO_0020147,anophthalmia-microphthalmia syndrome
+http://purl.obolibrary.org/obo/MONDO_0018916,isolated anorectal malformation,http://purl.obolibrary.org/obo/MONDO_0019938,anorectal malformation
+http://purl.obolibrary.org/obo/MONDO_0016043,isolated cleft lip,http://purl.obolibrary.org/obo/MONDO_0004747,cleft lip (disease)
+http://purl.obolibrary.org/obo/MONDO_0007336,isolated cleft palate,http://purl.obolibrary.org/obo/MONDO_0016064,cleft palate
+http://purl.obolibrary.org/obo/MONDO_0019627,isolated congenital alacrima,http://purl.obolibrary.org/obo/MONDO_0020194,congenital alacrima
+http://purl.obolibrary.org/obo/MONDO_0020463,isolated congenital ectropion,http://purl.obolibrary.org/obo/MONDO_0020161,congenital ectropion
+http://purl.obolibrary.org/obo/MONDO_0018840,isolated congenital hepatic fibrosis,http://purl.obolibrary.org/obo/MONDO_0022263,congenital hepatic fibrosis
+http://purl.obolibrary.org/obo/MONDO_0016553,isolated congenital hypogonadotropic hypogonadism,http://purl.obolibrary.org/obo/MONDO_0015770,congenital hypogonadotropic hypogonadism
+http://purl.obolibrary.org/obo/MONDO_0015337,isolated craniosynostosis,http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis
+http://purl.obolibrary.org/obo/MONDO_0007410,isolated cryptophthalmia,http://purl.obolibrary.org/obo/MONDO_0020153,cryptophthalmia
+http://purl.obolibrary.org/obo/MONDO_0017667,isolated diffuse palmoplantar keratoderma,http://purl.obolibrary.org/obo/MONDO_0017666,diffuse palmoplantar keratoderma
+http://purl.obolibrary.org/obo/MONDO_0015494,isolated dystonia,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder
+http://purl.obolibrary.org/obo/MONDO_0015998,isolated ectopia lentis,http://purl.obolibrary.org/obo/MONDO_0020236,lens position anomaly
+http://purl.obolibrary.org/obo/MONDO_0017673,isolated focal palmoplantar keratoderma,http://purl.obolibrary.org/obo/MONDO_0017672,focal palmoplantar keratoderma
+http://purl.obolibrary.org/obo/MONDO_0018459,isolated glycerol kinase deficiency,http://purl.obolibrary.org/obo/MONDO_0010613,inborn glycerol kinase deficiency
+http://purl.obolibrary.org/obo/MONDO_0017089,isolated megalencephaly,http://purl.obolibrary.org/obo/MONDO_0016608,megalencephaly (disease)
+http://purl.obolibrary.org/obo/MONDO_0000062,isolated microphthalmia,http://purl.obolibrary.org/obo/MONDO_0021129,microphthalmia
+http://purl.obolibrary.org/obo/MONDO_0015634,isolated osteopoikilosis,http://purl.obolibrary.org/obo/MONDO_0001414,osteopoikilosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0008265,isolated polycystic liver disease,http://purl.obolibrary.org/obo/MONDO_0000447,congenital polycystic liver disease
+http://purl.obolibrary.org/obo/MONDO_0016518,isolated punctate palmoplantar keratoderma,http://purl.obolibrary.org/obo/MONDO_0017675,punctate palmoplantar keratoderma
+http://purl.obolibrary.org/obo/MONDO_0019351,isolated spina bifida,http://purl.obolibrary.org/obo/MONDO_0008449,spina bifida (disease)
+http://purl.obolibrary.org/obo/MONDO_0018065,isolated trigonocephaly,http://purl.obolibrary.org/obo/MONDO_0000156,trigonocephaly
+http://purl.obolibrary.org/obo/MONDO_0015219,non-syndromic central nervous system malformation,http://purl.obolibrary.org/obo/MONDO_0020022,central nervous system malformation
+http://purl.obolibrary.org/obo/MONDO_0015217,non-syndromic developmental defect of the eye,http://purl.obolibrary.org/obo/MONDO_0020145,developmental defect of the eye
+http://purl.obolibrary.org/obo/MONDO_0015215,non-syndromic diaphragmatic or abdominal wall malformation,http://purl.obolibrary.org/obo/MONDO_0020021,diaphragmatic or abdominal wall malformation
+http://purl.obolibrary.org/obo/MONDO_0015207,non-syndromic esophageal malformation,http://purl.obolibrary.org/obo/MONDO_0019513,esophageal malformation
+http://purl.obolibrary.org/obo/MONDO_0015209,non-syndromic gastroduodenal malformation,http://purl.obolibrary.org/obo/MONDO_0019998,gastroduodenal malformation
+http://purl.obolibrary.org/obo/MONDO_0000509,non-syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0001071,intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0015211,non-syndromic intestinal malformation,http://purl.obolibrary.org/obo/MONDO_0019999,intestinal malformation
+http://purl.obolibrary.org/obo/MONDO_0017173,non-syndromic male infertility due to sperm motility disorder,http://purl.obolibrary.org/obo/MONDO_0018395,male infertility due to sperm motility disorder
+http://purl.obolibrary.org/obo/MONDO_0011348,non-syndromic polydactyly,http://purl.obolibrary.org/obo/MONDO_0021003,polydactyly (disease)
+http://purl.obolibrary.org/obo/MONDO_0019720,non-syndromic renal or urinary tract malformation,http://purl.obolibrary.org/obo/MONDO_0019719,congenital anomaly of kidney and urinary tract
+http://purl.obolibrary.org/obo/MONDO_0015221,non-syndromic respiratory or mediastinal malformation,http://purl.obolibrary.org/obo/MONDO_0020023,respiratory or mediastinal malformation
+http://purl.obolibrary.org/obo/MONDO_0000722,non-syndromic synpolydactyly,http://purl.obolibrary.org/obo/MONDO_0021651,synpolydactyly
+http://purl.obolibrary.org/obo/MONDO_0015619,non-syndromic urogenital tract malformation,http://purl.obolibrary.org/obo/MONDO_0019356,urogenital tract malformation
+http://purl.obolibrary.org/obo/MONDO_0015829,non-syndromic uterovaginal malformation,http://purl.obolibrary.org/obo/MONDO_0015828,uterovaginal malformation

--- a/src/patterns/leiomyosarcoma.csv
+++ b/src/patterns/leiomyosarcoma.csv
@@ -1,0 +1,30 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0003358,anus leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0002624,bone leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0003371,breast leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003349,central nervous system leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003351,colon leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003362,cutaneous leiomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003365,esophagus leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0003377,extrahepatic bile duct leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002159,fallopian tube leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0003364,gallbladder leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003367,gastric leiomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003353,heart leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0003373,kidney leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0003374,laryngeal leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0016283,leiomyosarcoma of the cervix uteri,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0016262,leiomyosarcoma of the corpus uteri,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003378,liver leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0003357,lung leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003376,mediastinum leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003355,ovary leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003368,prostate leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0004207,pulmonary artery leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002012,pulmonary artery
+http://purl.obolibrary.org/obo/MONDO_0004206,pulmonary vein leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002016,pulmonary vein
+http://purl.obolibrary.org/obo/MONDO_0003379,rectum leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0003370,retroperitoneal leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0003360,small intestine leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0004208,superior vena cava leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001585,anterior vena cava
+http://purl.obolibrary.org/obo/MONDO_0003369,vagina leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0003372,vulvar leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/lipoma.csv
+++ b/src/patterns/lipoma.csv
@@ -1,0 +1,29 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0000974,axillary lipoma,http://purl.obolibrary.org/obo/UBERON_0009472,axilla
+http://purl.obolibrary.org/obo/MONDO_0000970,breast lipoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003844,central nervous system lipoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003843,cerebral hemisphere lipoma,http://purl.obolibrary.org/obo/UBERON_0001869,cerebral hemisphere
+http://purl.obolibrary.org/obo/MONDO_0000971,chest wall lipoma,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0003885,colorectal lipoma,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0003845,corpus callosum lipoma,http://purl.obolibrary.org/obo/UBERON_0002336,corpus callosum
+http://purl.obolibrary.org/obo/MONDO_0003840,epicardium lipoma,http://purl.obolibrary.org/obo/UBERON_0002348,epicardium
+http://purl.obolibrary.org/obo/MONDO_0000963,esophageal lipoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0000973,external ear lipoma,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0000978,extrahepatic bile duct lipoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0000972,gallbladder lipoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003841,heart lipoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0003984,internal auditory canal lipoma,http://purl.obolibrary.org/obo/UBERON_0011859,internal acoustic meatus
+http://purl.obolibrary.org/obo/MONDO_0000968,kidney lipoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0001091,lipoma of colon,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0021630,lipoma of face,http://purl.obolibrary.org/obo/UBERON_0001456,face
+http://purl.obolibrary.org/obo/MONDO_0000975,lipoma of spermatic cord,http://purl.obolibrary.org/obo/UBERON_0005352,spermatic cord
+http://purl.obolibrary.org/obo/MONDO_0021437,lipoma of stomach,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003884,lipoma of the rectum,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0000965,liver lipoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0004077,lumbosacral lipoma,http://purl.obolibrary.org/obo/UBERON_0006075,sacral region of vertebral column
+http://purl.obolibrary.org/obo/MONDO_0000969,pleural lipoma,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0000964,skin lipoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0001790,spinal cord lipoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0004076,tendon sheath lipoma,http://purl.obolibrary.org/obo/UBERON_0000304,tendon sheath
+http://purl.obolibrary.org/obo/MONDO_0002163,thymus lipoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0044885,tonsillar lipoma,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil

--- a/src/patterns/location.csv
+++ b/src/patterns/location.csv
@@ -1,1489 +1,952 @@
 iri,iri label,disease,disease label,location,location label
-MONDO:0009050,ACTH-secreting pituitary adenoma,MONDO:0004972,adenoma,CL:0002309,corticotroph
-MONDO:0000444,ARC syndrome,MONDO:0002254,syndromic disease,CL:0000669,pericyte cell
-MONDO:0003853,Bartholin's gland adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000460,major vestibular gland
-MONDO:0003187,Bartholin's gland adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0003419,Bartholin's gland adenoma,MONDO:0004972,adenoma,UBERON:0000460,major vestibular gland
-MONDO:0003909,Bartholin's gland adenomyoma,MONDO:0005635,adenomyoma,UBERON:0000460,major vestibular gland
-MONDO:0003555,Bartholin's gland adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0002193,Bartholin's gland benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000460,major vestibular gland
-MONDO:0002829,Bartholin's gland carcinoma,MONDO:0004993,carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0004120,Bartholin's gland small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0004053,Bartholin's gland squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0002828,Bartholin's gland transitional cell carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0000460,major vestibular gland
-MONDO:0002625,Ewing sarcoma of bone,MONDO:0012817,Ewing sarcoma,UBERON:0002481,bone tissue
-MONDO:0021123,Ewing sarcoma/peripheral primitive neuroectodermal tumor of bone,MONDO:0021038,Ewing sarcoma/peripheral primitive neuroectodermal tumor,UBERON:0002481,bone tissue
-MONDO:0004313,Gasserian ganglion meningioma,MONDO:0016642,meningioma (disease),UBERON:3011045,gasserian ganglion
-MONDO:0018017,Goblet cell carcinoma,MONDO:0004993,carcinoma,CL:0000160,goblet cell
-MONDO:0019480,Langerhans cell sarcoma,MONDO:0005089,sarcoma,CL:0000453,Langerhans cell
-MONDO:0003975,Littre gland carcinoma,MONDO:0004993,carcinoma,UBERON:0010186,male urethral gland
-MONDO:0006576,Ludwig's angina,MONDO:0005230,cellulitis (disease),UBERON:0003679,mouth floor
-MONDO:0007650,MALT lymphoma,MONDO:0005062,lymphoma,UBERON:0001961,mucosa-associated lymphoid tissue
-MONDO:0020541,Maligant granulosa cell tumor of ovary,MONDO:0004992,cancer,CL:0000501,granulosa cell
-MONDO:0000954,Meckel diverticulum cancer,MONDO:0004992,cancer,UBERON:0003705,Meckel's diverticulum
-MONDO:0021082,Meckel diverticulum neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0003705,Meckel's diverticulum
-MONDO:0004173,Skene gland carcinoma,MONDO:0004993,carcinoma,UBERON:0010145,paraurethral gland
-MONDO:0003539,T-cell adult acute lymphocytic leukemia,MONDO:0003541,adult acute lymphocytic leukemia,CL:0000084,T cell
-MONDO:0005525,T-cell leukemia,MONDO:0005059,leukemia (disease),CL:0000084,T cell
-MONDO:0008805,Takayasu's arteritis,MONDO:0002254,syndromic disease,UBERON:0004363,pharyngeal arch artery
-MONDO:0001858,Tietze's syndrome,MONDO:0002254,syndromic disease,UBERON:0002293,costochondral joint
-MONDO:0021049,Vulvar Neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000997,mammalian vulva
-MONDO:0004685,Waldeyer's ring cancer,MONDO:0004992,cancer,UBERON:0001735,tonsillar ring
-MONDO:0003410,Wolffian duct adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0003074,mesonephric duct
-MONDO:0002364,Wolffian duct adenoma,MONDO:0004972,adenoma,UBERON:0003074,mesonephric duct
-MONDO:0001884,abducens nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001646,abducens nerve
-MONDO:0007033,abducens nerve palsy,MONDO:0002782,cranial nerve palsy,UBERON:0001646,abducens nerve
-MONDO:0002636,accessory nerve disease,MONDO:0000001,disease,UBERON:0002019,accessory XI nerve
-MONDO:0004965,acinar cell carcinoma,MONDO:0004993,carcinoma,CL:0000622,acinar cell
-MONDO:0004343,acinar cell cystadenocarcinoma,MONDO:0005596,cystadenocarcinoma,CL:0000622,acinar cell
-MONDO:0003624,acinic cell breast carcinoma,MONDO:0004989,breast carcinoma,CL:0000622,acinar cell
-MONDO:0010643,acute leukemia (disease),MONDO:0005059,leukemia (disease),CL:0000034,stem cell
-MONDO:0016275,adenocarcinoma of cervix uteri,MONDO:0004970,adenocarcinoma,UBERON:0000002,uterine cervix
-MONDO:0016287,adenoid basal carcinoma of the cervix uteri,MONDO:0002951,skin adenoid basal cell carcinoma,UBERON:0000002,uterine cervix
-MONDO:0016286,adenoid cystic carcinoma of the cervix uteri,MONDO:0004971,adenoid cystic carcinoma,UBERON:0000002,uterine cervix
-MONDO:0016271,adenoid cystic carcinoma of the corpus uteri,MONDO:0004971,adenoid cystic carcinoma,UBERON:0009853,body of uterus
-MONDO:0003487,adenoid squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001732,pharyngeal tonsil
-MONDO:0003237,adenomyoma of uterine corpus,MONDO:0005635,adenomyoma,UBERON:0009853,body of uterus
-MONDO:0016279,adenosarcoma of the cervix uteri,MONDO:0005636,adenosarcoma,UBERON:0000002,uterine cervix
-MONDO:0003549,adenosquamous bile duct carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0002394,bile duct
-MONDO:0002814,adrenal carcinoma,MONDO:0004993,carcinoma,UBERON:0002369,adrenal gland
-MONDO:0003924,adrenal cortex adenoma,MONDO:0004972,adenoma,UBERON:0001235,adrenal cortex
-MONDO:0002816,adrenal cortex disease,MONDO:0000001,disease,UBERON:0001235,adrenal cortex
-MONDO:0002817,adrenal gland cancer,MONDO:0004992,cancer,UBERON:0002369,adrenal gland
-MONDO:0005495,adrenal gland disease,MONDO:0000001,disease,UBERON:0002369,adrenal gland
-MONDO:0004477,adrenal gland ganglioneuroblastoma,MONDO:0005035,ganglioneuroblastoma (disease),UBERON:0002369,adrenal gland
-MONDO:0006076,adrenal gland neuroblastoma,MONDO:0005072,neuroblastoma,UBERON:0002369,adrenal gland
-MONDO:0003606,adrenal medulla cancer,MONDO:0004992,cancer,UBERON:0001236,adrenal medulla
-MONDO:0004202,adrenal medulla carcinoma,MONDO:0004993,carcinoma,UBERON:0001236,adrenal medulla
-MONDO:0006077,adrenal medullary hyperplasia,MONDO:0005043,hyperplasia,UBERON:0001236,adrenal medulla
-MONDO:0002138,allergic contact dermatitis of eyelid,MONDO:0006525,allergic contact dermatitis,UBERON:0001711,eyelid
-MONDO:0001752,alveolar periostitis,MONDO:0004553,extrinsic allergic alveolitis,UBERON:0001708,jaw skeleton
-MONDO:0002670,ampulla of vater adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0003553,ampulla of vater adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0000919,ampulla of vater cancer,MONDO:0004992,cancer,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0003388,ampulla of vater clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0002736,ampulla of vater mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0000921,ampulla of vater neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0004913,hepatopancreatic ampulla
-MONDO:0004117,ampulla of vater small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0003490,ampulla of vater squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0002651,anal Paget's disease,MONDO:0002648,mammary Paget's disease,UBERON:0001245,anus
-MONDO:0004468,anal canal Paget's disease,MONDO:0002648,mammary Paget's disease,UBERON:0000159,anal canal
-MONDO:0002735,anal canal adenocarcinoma (disease),MONDO:0004970,adenocarcinoma,UBERON:0000159,anal canal
-MONDO:0000405,anal canal cancer,MONDO:0004992,cancer,UBERON:0000159,anal canal
-MONDO:0007108,anal canal carcinoma,MONDO:0004993,carcinoma,UBERON:0000159,anal canal
-MONDO:0004132,anal canal squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000159,anal canal
-MONDO:0003199,anal carcinoma,MONDO:0004993,carcinoma,UBERON:0001245,anus
-MONDO:0004707,anal carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000159,anal canal
-MONDO:0002734,anal colloid adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0001245,anus
-MONDO:0002940,anal margin basal cell carcinoma,MONDO:0005341,skin basal cell carcinoma,UBERON:0012336,perianal skin
-MONDO:0002941,anal margin carcinoma,MONDO:0004993,carcinoma,UBERON:0012336,perianal skin
-MONDO:0001470,anal margin squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0012336,perianal skin
-MONDO:0003504,anal neuroendocrine tumor,MONDO:0019496,neuroendocrine tumor,UBERON:0001245,anus
-MONDO:0001138,angiodysplasia of intestine,MONDO:0002322,angiodysplasia,UBERON:0000160,intestine
-MONDO:0004882,angioid streaks of choroid,MONDO:0011782,angioid streaks,UBERON:0001776,optic choroid
-MONDO:0000741,angular cheilitis,MONDO:0002102,cheilitis,UBERON:0018149,angle of oral opening
-MONDO:0002997,anterior cranial fossa meningioma,MONDO:0016642,meningioma (disease),UBERON:0003720,anterior cranial fossa
-MONDO:0003182,anterior horn disease,MONDO:0000001,disease,UBERON:0002257,ventral horn of spinal cord
-MONDO:0006650,anterior spinal artery syndrome,MONDO:0002254,syndromic disease,UBERON:0005431,anterior spinal artery
-MONDO:0002652,anus adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001245,anus
-MONDO:0004130,anus basaloid carcinoma,MONDO:0003486,basaloid squamous cell carcinoma,UBERON:0001245,anus
-MONDO:0001879,anus cancer,MONDO:0004992,cancer,UBERON:0001245,anus
-MONDO:0002519,anus disease,MONDO:0000001,disease,UBERON:0001245,anus
-MONDO:0003292,anus leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001245,anus
-MONDO:0003358,anus leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001245,anus
-MONDO:0001888,anus lymphoma,MONDO:0005062,lymphoma,UBERON:0001245,anus
-MONDO:0002864,anus rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0001245,anus
-MONDO:0002865,anus sarcoma,MONDO:0005089,sarcoma,UBERON:0001245,anus
-MONDO:0003023,aorta angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0000947,aorta
-MONDO:0005561,aortic disease,MONDO:0000001,disease,UBERON:0000947,aorta
-MONDO:0003803,aortic valve disease,MONDO:0000001,disease,UBERON:0002137,aortic valve
-MONDO:0003214,apocrine adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0008974,apocrine gland
-MONDO:0003215,apocrine sweat gland cancer,MONDO:0004992,cancer,UBERON:0000382,apocrine sweat gland
-MONDO:0001236,appendiceal neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001154,vermiform appendix
-MONDO:0006087,appendix adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001154,vermiform appendix
-MONDO:0006088,appendix adenoma,MONDO:0004972,adenoma,UBERON:0001154,vermiform appendix
-MONDO:0001235,appendix cancer,MONDO:0004992,cancer,UBERON:0001154,vermiform appendix
-MONDO:0000526,appendix carcinoid tumor,MONDO:0005369,carcinoid tumor (disease),UBERON:0001154,vermiform appendix
-MONDO:0003196,appendix carcinoma,MONDO:0004993,carcinoma,UBERON:0001154,vermiform appendix
-MONDO:0003300,appendix leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001154,vermiform appendix
-MONDO:0001237,appendix lymphoma,MONDO:0005062,lymphoma,UBERON:0001154,vermiform appendix
-MONDO:0002703,appendix mucinous cystadenocarcinoma,MONDO:0005858,mucinous cystadenocarcinoma,UBERON:0001154,vermiform appendix
-MONDO:0000473,artery disease,MONDO:0000001,disease,UBERON:0001637,artery
-MONDO:0003816,articular cartilage disease,MONDO:0000001,disease,UBERON:0010996,articular cartilage of joint
-MONDO:0004637,aryepiglottic fold cancer,MONDO:0004992,cancer,UBERON:0014385,aryepiglottic fold
-MONDO:0002238,ascending colon cancer,MONDO:0004992,cancer,UBERON:0001156,ascending colon
-MONDO:0019781,astrocytoma,MONDO:0015917,malignant glioma,CL:0000127,astrocyte
-MONDO:0002004,atheroembolism of kidney,MONDO:0005568,cholesterol embolism,UBERON:0002113,kidney
-MONDO:0005476,atrioventricular node disease,MONDO:0000001,disease,UBERON:0002352,atrioventricular node
-MONDO:0004532,auditory system cancer,MONDO:0004992,cancer,UBERON:0016490,auditory system
-MONDO:0002409,auditory system disease,MONDO:0000001,disease,UBERON:0016490,auditory system
-MONDO:0000602,autoimmune disease of blood,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0000178,blood
-MONDO:0000603,autoimmune disease of cardiovascular system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0004535,cardiovascular system
-MONDO:0000568,autoimmune disease of central nervous system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0001017,central nervous system
-MONDO:0000569,autoimmune disease of endocrine system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0000949,endocrine system
-MONDO:0000586,autoimmune disease of exocrine system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0002330,exocrine system
-MONDO:0000588,autoimmune disease of gastrointestinal tract,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0005409,alimentary part of gastrointestinal system
-MONDO:0000589,autoimmune disease of musculoskeletal system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0002204,musculoskeletal system
-MONDO:0000590,autoimmune disease of peripheral nervous system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0000010,peripheral nervous system
-MONDO:0000593,autoimmune disease of skin and connective tissue,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0002199,integument
-MONDO:0002977,autoimmune disease of the nervous system,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0001016,nervous system
-MONDO:0000601,autoimmune disease of urogenital tract,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0004122,genitourinary system
-MONDO:0017841,autoimmune disease with skin involvement,MONDO:0007179,hypersensitivity reaction type II disease,UBERON:0002097,skin of body
-MONDO:0001292,autonomic nervous system disease,MONDO:0000001,disease,UBERON:0002410,autonomic nervous system
-MONDO:0002366,autonomic nervous system neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002410,autonomic nervous system
-MONDO:0000604,autonomic peripheral neuropathy,MONDO:0005244,peripheral neuropathy,UBERON:0002410,autonomic nervous system
-MONDO:0000974,axillary lipoma,MONDO:0005106,lipoma,UBERON:0009472,axilla
-MONDO:0003070,axillary lymphadenitis,MONDO:0002052,lymphadenitis (disease),UBERON:0009472,axilla
-MONDO:0004183,axonal neuropathy,MONDO:0005244,peripheral neuropathy,GO:0030424,axon
-MONDO:0021114,bartholin gland neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000460,major vestibular gland
-MONDO:0015551,basal epidermolysis bullosa simplex,MONDO:0017610,epidermolysis bullosa simplex,UBERON:0002025,stratum basale of epidermis
-MONDO:0006505,basal ganglia cerebrovascular disease,MONDO:0011057,cerebrovascular disorder,UBERON:0010011,collection of basal ganglia
-MONDO:0003996,basal ganglia disease,MONDO:0000001,disease,UBERON:0010011,collection of basal ganglia
-MONDO:0004091,basaloid squamous cell skin carcinoma,MONDO:0003486,basaloid squamous cell carcinoma,UBERON:0000014,zone of skin
-MONDO:0002250,basilar artery insufficiency,MONDO:0002254,syndromic disease,UBERON:0001633,basilar artery
-MONDO:0006105,benign conjunctival neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001811,conjunctiva
-MONDO:0000385,benign digestive system neoplasm,MONDO:0005165,benign neoplasm,UBERON:0005409,alimentary part of gastrointestinal system
-MONDO:0000627,benign endocrine neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002368,endocrine gland
-MONDO:0002354,benign laryngeal neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001737,larynx
-MONDO:0004432,benign pericardial teratoma,MONDO:0003517,mature teratoma,UBERON:0002407,pericardium
-MONDO:0002112,benign peritoneal mesothelioma,MONDO:0002373,benign mesothelioma,UBERON:0002358,peritoneum
-MONDO:0006106,benign smooth muscle neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001135,smooth muscle tissue
-MONDO:0006107,benign thyroid gland neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002046,thyroid gland
-MONDO:0004177,benign urethral neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000057,urethra
-MONDO:0004180,benign urinary system neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001008,renal system
-MONDO:0000647,benign vaginal neoplasm,MONDO:0000624,female reproductive organ benign neoplasm,UBERON:0000996,vagina
-MONDO:0003193,bile duct adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002394,bile duct
-MONDO:0006108,bile duct adenoma,MONDO:0004972,adenoma,UBERON:0002394,bile duct
-MONDO:0003059,bile duct cancer,MONDO:0004992,cancer,UBERON:0002394,bile duct
-MONDO:0005496,bile duct carcinoma,MONDO:0004993,carcinoma,UBERON:0002394,bile duct
-MONDO:0000374,bile duct carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002394,bile duct
-MONDO:0004081,bile duct clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0002394,bile duct
-MONDO:0002868,bile duct cystadenocarcinoma,MONDO:0005596,cystadenocarcinoma,UBERON:0002394,bile duct
-MONDO:0003420,bile duct cystadenoma,MONDO:0002369,cystadenoma,UBERON:0002394,bile duct
-MONDO:0002887,bile duct disease,MONDO:0000001,disease,UBERON:0002394,bile duct
-MONDO:0002739,bile duct mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0002394,bile duct
-MONDO:0003089,bile duct mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0002394,bile duct
-MONDO:0003455,bile duct papillary neoplasm,MONDO:0021096,papillary epithelial neoplasm,UBERON:0002394,bile duct
-MONDO:0002577,bile duct rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0002394,bile duct
-MONDO:0002862,bile duct sarcoma,MONDO:0005089,sarcoma,UBERON:0002394,bile duct
-MONDO:0002664,bile duct signet ring cell carcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0002394,bile duct
-MONDO:0003060,biliary tract cancer,MONDO:0004992,cancer,UBERON:0001173,biliary tree
-MONDO:0004868,biliary tract disease,MONDO:0000001,disease,UBERON:0001173,biliary tree
-MONDO:0002751,bladder adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001255,urinary bladder
-MONDO:0000384,bladder benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001255,urinary bladder
-MONDO:0004986,bladder carcinoma (disease),MONDO:0004993,carcinoma,UBERON:0001255,urinary bladder
-MONDO:0004703,bladder carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001255,urinary bladder
-MONDO:0003386,bladder clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0001255,urinary bladder
-MONDO:0006026,bladder disease,MONDO:0000001,disease,UBERON:0001255,urinary bladder
-MONDO:0001380,bladder dome cancer,MONDO:0004992,cancer,UBERON:0006082,fundus of urinary bladder
-MONDO:0001634,bladder leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001255,urinary bladder
-MONDO:0001381,bladder lymphoma,MONDO:0005062,lymphoma,UBERON:0001255,urinary bladder
-MONDO:0001372,bladder neck cancer,MONDO:0004992,cancer,UBERON:0001258,neck of urinary bladder
-MONDO:0004056,bladder papillary urothelial carcinoma,MONDO:0006350,papillary transitional cell carcinoma,UBERON:0001255,urinary bladder
-MONDO:0003442,bladder papillary urothelial neoplasm,MONDO:0021096,papillary epithelial neoplasm,UBERON:0004645,urinary bladder urothelium
-MONDO:0001374,bladder sarcoma,MONDO:0005089,sarcoma,UBERON:0001255,urinary bladder
-MONDO:0003891,bladder signet ring cell adenocarcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0001255,urinary bladder
-MONDO:0002760,bladder squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001255,urinary bladder
-MONDO:0005611,bladder transitional cell carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0001255,urinary bladder
-MONDO:0001375,bladder trigone cancer,MONDO:0004992,cancer,UBERON:0001257,trigone of urinary bladder
-MONDO:0004987,bladder tumor,MONDO:0005070,neoplasm (disease),UBERON:0001255,urinary bladder
-MONDO:0004331,bladder urachal adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002068,urachus
-MONDO:0002759,bladder verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0001255,urinary bladder
-MONDO:0021080,blood vessel neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001981,blood vessel
-MONDO:0000513,bone ameloblastoma,MONDO:0017795,ameloblastoma,UBERON:0002481,bone tissue
-MONDO:0000631,bone benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002481,bone tissue
-MONDO:0002129,bone cancer,MONDO:0004992,cancer,UBERON:0004765,skeletal element
-MONDO:0002415,bone carcinoma,MONDO:0004993,carcinoma,UBERON:0001474,bone element
-MONDO:0000515,bone chondrosarcoma,MONDO:0008977,chondrosarcoma (disease),UBERON:0002481,bone tissue
-MONDO:0005497,bone development disease,MONDO:0000001,disease,GO:0060348,bone development
-MONDO:0005381,bone disease,MONDO:0000001,disease,UBERON:0001474,bone element
-MONDO:0021138,bone marrow cancer,MONDO:0004992,cancer,UBERON:0002371,bone marrow
-MONDO:0003225,bone marrow disease,MONDO:0000001,disease,UBERON:0002371,bone marrow
-MONDO:0005374,bone marrow neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002371,bone marrow
-MONDO:0000514,bone squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002481,bone tissue
-MONDO:0006682,brachial plexus neuritis,MONDO:0002122,neuritis,UBERON:0001814,brachial nerve plexus
-MONDO:0006683,brachial plexus neuropathy,MONDO:0005244,peripheral neuropathy,UBERON:0001814,brachial nerve plexus
-MONDO:0001657,brain cancer,MONDO:0004992,cancer,UBERON:0000955,brain
-MONDO:0005560,brain disease,MONDO:0000001,disease,UBERON:0000955,brain
-MONDO:0002214,brain germinoma,MONDO:0002598,germinoma (disease),UBERON:0000955,brain
-MONDO:0002501,brain glioblastoma multiforme,MONDO:0002498,glioblastoma multiforme (disease),UBERON:0000955,brain
-MONDO:0005499,brain glioma,MONDO:0015917,malignant glioma,UBERON:0000955,brain
-MONDO:0005299,brain ischemia,MONDO:0005053,ischemia,UBERON:0000955,brain
-MONDO:0000642,brain meningioma,MONDO:0016642,meningioma (disease),UBERON:0000955,brain
-MONDO:0002544,brain oligodendroglioma,MONDO:0016695,oligodendroglioma,UBERON:0000955,brain
-MONDO:0002216,brain sarcoma,MONDO:0005089,sarcoma,UBERON:0000955,brain
-MONDO:0003902,brain stem angioblastoma,MONDO:0016748,hemangioblastoma,UBERON:0002298,brainstem
-MONDO:0003173,brain stem astrocytic neoplasm,MONDO:0019781,astrocytoma,UBERON:0002298,brainstem
-MONDO:0002912,brain stem cancer,MONDO:0004992,cancer,UBERON:0002298,brainstem
-MONDO:0002911,brain stem glioma,MONDO:0015917,malignant glioma,UBERON:0002298,brainstem
-MONDO:0000517,brain stem medulloblastoma,MONDO:0007959,medulloblastoma,UBERON:0002298,brainstem
-MONDO:0004988,breast adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000310,breast
-MONDO:0002058,breast adenoma,MONDO:0004972,adenoma,UBERON:0000310,breast
-MONDO:0003024,breast angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0000310,breast
-MONDO:0004273,breast apocrine adenoma,MONDO:0002804,apocrine adenoma,UBERON:0000310,breast
-MONDO:0003934,breast apocrine carcinoma,MONDO:0003214,apocrine adenocarcinoma,UBERON:0000310,breast
-MONDO:0000620,breast benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000310,breast
-MONDO:0007254,breast cancer,MONDO:0004992,cancer,UBERON:0000310,breast
-MONDO:0003896,breast capillary hemangioma,MONDO:0002407,capillary hemangioma,UBERON:0000310,breast
-MONDO:0004989,breast carcinoma,MONDO:0004993,carcinoma,UBERON:0000310,breast
-MONDO:0004658,breast carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000310,breast
-MONDO:0002657,breast disease,MONDO:0000001,disease,UBERON:0000310,breast
-MONDO:0003897,breast epithelioid hemangioma,MONDO:0003119,histiocytoid hemangioma,UBERON:0000310,breast
-MONDO:0021046,breast fibroepithelial neoplasm,MONDO:0021045,fibroepithelial neoplasm,UBERON:0000310,breast
-MONDO:0003728,breast fibrosarcoma,MONDO:0005164,fibrosarcoma (disease),UBERON:0000310,breast
-MONDO:0002487,breast granular cell tumor,MONDO:0006235,granular cell tumor,UBERON:0000310,breast
-MONDO:0003126,breast hemangioma,MONDO:0006500,hemangioma,UBERON:0000310,breast
-MONDO:0003411,breast hemangiopericytoma,MONDO:0005094,spindle cell tumor,UBERON:0000310,breast
-MONDO:0003959,breast large cell neuroendocrine carcinoma,MONDO:0005057,large cell neuroendocrine carcinoma,UBERON:0000310,breast
-MONDO:0002057,breast leiomyoma,MONDO:0001572,leiomyoma,UBERON:0000310,breast
-MONDO:0003371,breast leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0000310,breast
-MONDO:0000970,breast lipoma,MONDO:0005106,lipoma,UBERON:0000310,breast
-MONDO:0003593,breast liposarcoma,MONDO:0005060,liposarcoma,UBERON:0000310,breast
-MONDO:0000552,breast lobular carcinoma,MONDO:0004993,carcinoma,UBERON:0001912,lobule of mammary gland
-MONDO:0003661,breast lymphoma,MONDO:0005062,lymphoma,UBERON:0000310,breast
-MONDO:0004420,breast malignant eccrine spiradenoma,MONDO:0004412,malignant spiradenoma,UBERON:0000310,breast
-MONDO:0002705,breast mucinous cystadenocarcinoma,MONDO:0005858,mucinous cystadenocarcinoma,UBERON:0000310,breast
-MONDO:0003087,breast mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0000310,breast
-MONDO:0002483,breast myoepithelial tumor,MONDO:0002380,myoepithelial tumor,UBERON:0000310,breast
-MONDO:0021100,breast neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000310,breast
-MONDO:0002485,breast neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0000310,breast
-MONDO:0004360,breast osteosarcoma,MONDO:0009807,osteosarcoma (disease),UBERON:0000310,breast
-MONDO:0003532,breast papillary carcinoma,MONDO:0006509,papillary carcinoma,UBERON:0000310,breast
-MONDO:0002063,breast papillomatosis,MONDO:0021098,papillomatosis,UBERON:0000310,breast
-MONDO:0002859,breast rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0000310,breast
-MONDO:0002490,breast sarcoma,MONDO:0005089,sarcoma,UBERON:0000310,breast
-MONDO:0002671,breast signet ring cell adenocarcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0000310,breast
-MONDO:0001108,broad ligament malignant neoplasm,MONDO:0004992,cancer,UBERON:0012332,broad ligament of uterus
-MONDO:0001358,bronchial disease,MONDO:0000001,disease,UBERON:0002185,bronchus
-MONDO:0003427,bronchus adenoma,MONDO:0004972,adenoma,UBERON:0002185,bronchus
-MONDO:0001672,bronchus cancer,MONDO:0004992,cancer,UBERON:0002185,bronchus
-MONDO:0002806,bronchus carcinoma,MONDO:0004993,carcinoma,UBERON:0002185,bronchus
-MONDO:0000375,bronchus carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002185,bronchus
-MONDO:0000531,bronchus mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0002185,bronchus
-MONDO:0001574,capillary disease,MONDO:0000001,disease,UBERON:0001982,capillary
-MONDO:0002407,capillary hemangioma,MONDO:0006500,hemangioma,UBERON:0001982,capillary
-MONDO:0002262,capillary lymphangioma,MONDO:0002013,lymphangioma,UBERON:0001982,capillary
-MONDO:0019086,carcinoma of esophagus,MONDO:0004993,carcinoma,UBERON:0001043,esophagus
-MONDO:0017590,carcinoma of the ampulla of vater,MONDO:0004993,carcinoma,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0016278,carcinosarcoma of the cervix uteri,MONDO:0002928,carcinosarcoma,UBERON:0000002,uterine cervix
-MONDO:0001063,cardia cancer,MONDO:0004992,cancer,UBERON:0001162,cardia of stomach
-MONDO:0006123,cardiac Rhabdomyoma (disease),MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0000948,heart
-MONDO:0003254,cardiac granular cell neoplasm,MONDO:0006235,granular cell tumor,UBERON:0000948,heart
-MONDO:0004995,cardiovascular disease,MONDO:0000001,disease,UBERON:0004535,cardiovascular system
-MONDO:0000629,cardiovascular organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0004535,cardiovascular system
-MONDO:0005269,carotid artery disease,MONDO:0000001,disease,UBERON:0005396,carotid artery segment
-MONDO:0021053,carotid body paraganglioma,MONDO:0000448,paraganglioma,UBERON:0001629,carotid body
-MONDO:0000639,cartilage cancer,MONDO:0004992,cancer,UBERON:0002418,cartilage tissue
-MONDO:0005569,cartilage disease,MONDO:0000001,disease,UBERON:0002418,cartilage tissue
-MONDO:0003164,cauda equina neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0012337,cauda equina
-MONDO:0005693,cauda equina syndrome,MONDO:0002254,syndromic disease,UBERON:0012337,cauda equina
-MONDO:0003644,cavernous hemangioma of colon,MONDO:0003155,cavernous hemangioma,UBERON:0001155,colon
-MONDO:0003645,cavernous hemangioma of face,MONDO:0003155,cavernous hemangioma,UBERON:0001456,face
-MONDO:0002996,cavernous sinus meningioma,MONDO:0016642,meningioma (disease),UBERON:0003712,cavernous sinus
-MONDO:0002031,cecal disease,MONDO:0000001,disease,UBERON:0001153,caecum
-MONDO:0006028,cecum adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001153,caecum
-MONDO:0002033,cecum cancer,MONDO:0004992,cancer,UBERON:0001153,caecum
-MONDO:0006029,cecum carcinoma,MONDO:0004993,carcinoma,UBERON:0001153,caecum
-MONDO:0002034,cecum lymphoma,MONDO:0005062,lymphoma,UBERON:0001153,caecum
-MONDO:0000525,cecum villous adenoma,MONDO:0004972,adenoma,UBERON:0001153,caecum
-MONDO:0006128,central nervous system anaplastic large cell lymphoma,MONDO:0020325,anaplastic large cell lymphoma,UBERON:0001017,central nervous system
-MONDO:0003021,central nervous system angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0001017,central nervous system
-MONDO:0002714,central nervous system cancer,MONDO:0004992,cancer,UBERON:0001017,central nervous system
-MONDO:0003750,central nervous system childhood germ cell tumor,MONDO:0003751,pediatric germ cell cancer,UBERON:0001017,central nervous system
-MONDO:0002779,central nervous system chondroma,MONDO:0002360,chondroma,UBERON:0001017,central nervous system
-MONDO:0002602,central nervous system disease,MONDO:0000001,disease,UBERON:0001017,central nervous system
-MONDO:0004154,central nervous system embryonal carcinoma,MONDO:0005440,embryonal carcinoma,UBERON:0001017,central nervous system
-MONDO:0003401,central nervous system endodermal sinus tumor,MONDO:0005744,endodermal sinus tumor,UBERON:0001017,central nervous system
-MONDO:0016713,central nervous system ewing sarcoma/peripheral primitive neuroectodermal tumor,MONDO:0021038,Ewing sarcoma/peripheral primitive neuroectodermal tumor,UBERON:0001017,central nervous system
-MONDO:0003882,central nervous system fibrosarcoma,MONDO:0005164,fibrosarcoma (disease),UBERON:0001017,central nervous system
-MONDO:0003000,central nervous system germ cell tumor,MONDO:0018080,rare germ cell tumor,UBERON:0001017,central nervous system
-MONDO:0002999,central nervous system germinoma,MONDO:0002598,germinoma (disease),UBERON:0001017,central nervous system
-MONDO:0003241,central nervous system hemangioma,MONDO:0006500,hemangioma,UBERON:0001017,central nervous system
-MONDO:0003641,central nervous system hematopoietic neoplasm,MONDO:0002334,hematopoietic and lymphoid system neoplasm,UBERON:0001017,central nervous system
-MONDO:0003287,central nervous system leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001017,central nervous system
-MONDO:0003349,central nervous system leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001017,central nervous system
-MONDO:0001606,central nervous system leukemia,MONDO:0005059,leukemia (disease),UBERON:0001017,central nervous system
-MONDO:0003844,central nervous system lipoma,MONDO:0005106,lipoma,UBERON:0001017,central nervous system
-MONDO:0002571,central nervous system lymphoma,MONDO:0005062,lymphoma,UBERON:0001017,central nervous system
-MONDO:0003733,central nervous system mature teratoma,MONDO:0003517,mature teratoma,UBERON:0001017,central nervous system
-MONDO:0006130,central nervous system neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001017,central nervous system
-MONDO:0000628,central nervous system organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001017,central nervous system
-MONDO:0004423,central nervous system osteosarcoma,MONDO:0009807,osteosarcoma (disease),UBERON:0001017,central nervous system
-MONDO:0000640,central nervous system primitive neuroectodermal neoplasm,MONDO:0002084,neuroectodermal tumor,UBERON:0001017,central nervous system
-MONDO:0002850,central nervous system rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0001017,central nervous system
-MONDO:0002217,central nervous system sarcoma,MONDO:0005089,sarcoma,UBERON:0001017,central nervous system
-MONDO:0002718,central nervous system teratoma,MONDO:0002601,teratoma,UBERON:0001017,central nervous system
-MONDO:0005696,central nervous system tuberculosis,MONDO:0018076,tuberculosis,UBERON:0001017,central nervous system
-MONDO:0003346,central nervous system vasculitis,MONDO:0018882,vasculitis,UBERON:0001017,central nervous system
-MONDO:0003901,cerebellar angioblastoma,MONDO:0016748,hemangioblastoma,UBERON:0002037,cerebellum
-MONDO:0003165,cerebellar astrocytoma,MONDO:0019781,astrocytoma,UBERON:0002037,cerebellum
-MONDO:0002427,cerebellar disease,MONDO:0000001,disease,UBERON:0002037,cerebellum
-MONDO:0002913,cerebellar neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002037,cerebellum
-MONDO:0002792,cerebellar vermis medulloblastoma,MONDO:0007959,medulloblastoma,UBERON:0004720,cerebellar vermis
-MONDO:0003860,cerebellopontine angle meningioma,MONDO:0016642,meningioma (disease),UBERON:0014908,cerebellopontine angle
-MONDO:0004422,cerebral falx meningioma,MONDO:0016642,meningioma (disease),UBERON:0006059,falx cerebri
-MONDO:0003948,cerebral hemangioma,MONDO:0006500,hemangioma,UBERON:0001893,telencephalon
-MONDO:0003843,cerebral hemisphere lipoma,MONDO:0005106,lipoma,UBERON:0001869,cerebral hemisphere
-MONDO:0003772,cerebral meningioma,MONDO:0016642,meningioma (disease),UBERON:0001893,telencephalon
-MONDO:0002900,cerebral neuroblastoma,MONDO:0005072,neuroblastoma,UBERON:0001893,telencephalon
-MONDO:0007300,cerebral sarcoma,MONDO:0005089,sarcoma,UBERON:0001893,telencephalon
-MONDO:0002682,cerebral ventricle cancer,MONDO:0004992,cancer,UBERON:0004086,brain ventricle
-MONDO:0002731,cerebrum cancer,MONDO:0004992,cancer,UBERON:0001893,telencephalon
-MONDO:0000644,cervical benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000002,uterine cervix
-MONDO:0002974,cervical cancer,MONDO:0004992,cancer,UBERON:0000002,uterine cervix
-MONDO:0005131,cervical carcinoma,MONDO:0004993,carcinoma,UBERON:0000002,uterine cervix
-MONDO:0006135,cervical clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0000002,uterine cervix
-MONDO:0003665,cervical endometrioid adenocarcinoma,MONDO:0005026,endometrioid adenocarcinoma,UBERON:0000002,uterine cervix
-MONDO:0003067,cervical lymphadenitis,MONDO:0002052,lymphadenitis (disease),UBERON:0000974,neck
-MONDO:0002761,cervical verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0000002,uterine cervix
-MONDO:0002256,cervix disease,MONDO:0000001,disease,UBERON:0000002,uterine cervix
-MONDO:0004693,cervix uteri carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000002,uterine cervix
-MONDO:0004645,cheek mucosa cancer,MONDO:0004992,cancer,UBERON:0006956,buccal mucosa
-MONDO:0003933,chest wall bone cancer,MONDO:0002129,bone cancer,UBERON:0016435,chest wall
-MONDO:0000971,chest wall lipoma,MONDO:0005106,lipoma,UBERON:0016435,chest wall
-MONDO:0003985,chest wall lymphoma,MONDO:0005062,lymphoma,UBERON:0016435,chest wall
-MONDO:0004443,chest wall parachordoma,MONDO:0006351,parachordoma,UBERON:0016435,chest wall
-MONDO:0004046,childhood brain meningioma,MONDO:0003057,pediatric meningioma,UBERON:0000955,brain
-MONDO:0003842,childhood cerebellar astrocytic neoplasm,MONDO:0002505,juvenile astrocytoma,UBERON:0002037,cerebellum
-MONDO:0004071,childhood cerebral astrocytoma,MONDO:0002505,juvenile astrocytoma,UBERON:0001893,telencephalon
-MONDO:0003759,childhood ovarian yolk sac tumor,MONDO:0003400,childhood endodermal sinus tumor,UBERON:0000992,ovary
-MONDO:0006532,cholesteatoma of external ear,MONDO:0006530,cholesteatoma (disease),UBERON:0001691,external ear
-MONDO:0006533,cholesteatoma of middle ear,MONDO:0006530,cholesteatoma (disease),UBERON:0001756,middle ear
-MONDO:0008207,chondromalacia patellae,MONDO:0002342,chondromalacia,UBERON:0002446,patella
-MONDO:0005207,choriocarcinoma (disease),MONDO:0004993,carcinoma,UBERON:0003124,chorion
-MONDO:0003507,choriocarcinoma of ovary,MONDO:0005207,choriocarcinoma (disease),UBERON:0000992,ovary
-MONDO:0016740,choriocarcinoma of the central nervous system,MONDO:0005207,choriocarcinoma (disease),UBERON:0001017,central nervous system
-MONDO:0006700,choroid cancer,MONDO:0004992,cancer,UBERON:0001776,optic choroid
-MONDO:0001898,choroid disease,MONDO:0000001,disease,UBERON:0001776,optic choroid
-MONDO:0004085,choroid epithelioid cell melanoma,MONDO:0002973,epithelioid cell melanoma,UBERON:0001776,optic choroid
-MONDO:0002681,choroid plexus cancer,MONDO:0004992,cancer,UBERON:0001886,choroid plexus
-MONDO:0003053,choroid plexus meningioma,MONDO:0016642,meningioma (disease),UBERON:0001886,choroid plexus
-MONDO:0009837,choroid plexus papilloma,MONDO:0002363,papilloma,UBERON:0001886,choroid plexus
-MONDO:0003745,choroid spindle cell melanoma,MONDO:0006427,spindle cell melanoma,UBERON:0001776,optic choroid
-MONDO:0004885,choroidal sclerosis,MONDO:0005559,neurodegenerative disease,UBERON:0001776,optic choroid
-MONDO:0002969,ciliary body cancer,MONDO:0004992,cancer,UBERON:0001775,ciliary body
-MONDO:0002970,ciliary body disease,MONDO:0000001,disease,UBERON:0001775,ciliary body
-MONDO:0004086,ciliary body epithelioid cell melanoma,MONDO:0002973,epithelioid cell melanoma,UBERON:0001775,ciliary body
-MONDO:0003746,ciliary body spindle cell melanoma,MONDO:0006427,spindle cell melanoma,UBERON:0001775,ciliary body
-MONDO:0005005,clear cell renal carcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0002113,kidney
-MONDO:0005006,clear cell sarcoma of kidney,MONDO:0002926,clear cell sarcoma,UBERON:0002113,kidney
-MONDO:0002290,clitoris cancer,MONDO:0004992,cancer,UBERON:0002411,clitoris
-MONDO:0003850,clivus chondroid chordoma,MONDO:0002893,chondroid chordoma,UBERON:0004108,clivus of occipital bone
-MONDO:0003849,clivus chordoma,MONDO:0008978,chordoma (disease),UBERON:0004108,clivus of occipital bone
-MONDO:0003908,clivus meningioma,MONDO:0016642,meningioma (disease),UBERON:0004108,clivus of occipital bone
-MONDO:0003452,cochlear disease,MONDO:0000001,disease,UBERON:0001844,cochlea
-MONDO:0005220,collecting duct carcinoma,MONDO:0004993,carcinoma,UBERON:0001232,collecting duct of renal tubule
-MONDO:0006150,colon Burkitt lymphoma,MONDO:0007243,Burkitts lymphoma,UBERON:0001155,colon
-MONDO:0002271,colon adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001155,colon
-MONDO:0000527,colon adenoma,MONDO:0004972,adenoma,UBERON:0001155,colon
-MONDO:0002032,colon carcinoma,MONDO:0004993,carcinoma,UBERON:0001155,colon
-MONDO:0004663,colon carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001155,colon
-MONDO:0001092,colon leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001155,colon
-MONDO:0003351,colon leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001155,colon
-MONDO:0002035,colon lymphoma,MONDO:0005062,lymphoma,UBERON:0001155,colon
-MONDO:0005007,colon mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0001155,colon
-MONDO:0002882,colon neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0001155,colon
-MONDO:0003352,colon sarcoma,MONDO:0005089,sarcoma,UBERON:0001155,colon
-MONDO:0003978,colon small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0001155,colon
-MONDO:0003485,colon squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001155,colon
-MONDO:0003409,colonic disease,MONDO:0000001,disease,UBERON:0001155,colon
-MONDO:0001093,colonic lymphangioma,MONDO:0002013,lymphangioma,UBERON:0001155,colon
-MONDO:0005401,colonic neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001155,colon
-MONDO:0005008,colorectal adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0012652,colorectum
-MONDO:0005484,colorectal adenoma,MONDO:0004972,adenoma,UBERON:0012652,colorectum
-MONDO:0006157,colorectal adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0012652,colorectum
-MONDO:0005575,colorectal cancer,MONDO:0004992,cancer,UBERON:0012652,colorectum
-MONDO:0006158,colorectal diffuse large b-cell lymphoma,MONDO:0018905,diffuse large B-cell lymphoma,UBERON:0012652,colorectum
-MONDO:0006160,colorectal hamartoma,MONDO:0006499,hamartoma (disease),UBERON:0012652,colorectum
-MONDO:0003299,colorectal leiomyoma,MONDO:0001572,leiomyoma,UBERON:0012652,colorectum
-MONDO:0005335,colorectal neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0012652,colorectum
-MONDO:0006165,colorectal squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0012652,colorectum
-MONDO:0002886,common bile duct disease,MONDO:0000001,disease,UBERON:0001174,common bile duct
-MONDO:0005449,conduction system disorder,MONDO:0000001,disease,UBERON:0002350,conducting system of heart
-MONDO:0003454,conjunctival cancer,MONDO:0004992,cancer,UBERON:0001811,conjunctiva
-MONDO:0002932,conjunctival disease,MONDO:0000001,disease,UBERON:0001811,conjunctiva
-MONDO:0006173,conjunctival squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001811,conjunctiva
-MONDO:0000654,connective tissue benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002384,connective tissue
-MONDO:0002176,connective tissue cancer,MONDO:0004992,cancer,UBERON:0002384,connective tissue
-MONDO:0003900,connective tissue disease,MONDO:0000001,disease,UBERON:0002384,connective tissue
-MONDO:0003802,cornea cancer,MONDO:0004992,cancer,UBERON:0000964,cornea
-MONDO:0001740,cornea squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000964,cornea
-MONDO:0000942,corneal disease,MONDO:0000001,disease,UBERON:0000964,cornea
-MONDO:0005010,coronary artery disease,MONDO:0000001,disease,UBERON:0001621,coronary artery
-MONDO:0003845,corpus callosum lipoma,MONDO:0005106,lipoma,UBERON:0002336,corpus callosum
-MONDO:0000519,corpus callosum oligodendroglioma,MONDO:0016695,oligodendroglioma,UBERON:0002336,corpus callosum
-MONDO:0001625,corpus luteum cyst,MONDO:0003282,ovarian cyst (disease),UBERON:0002512,corpus luteum
-MONDO:0002435,cranial nerve III tumor,MONDO:0005070,neoplasm (disease),UBERON:0001643,oculomotor nerve
-MONDO:0002433,cranial nerve malignant neoplasm,MONDO:0004992,cancer,UBERON:0001785,cranial nerve
-MONDO:0002633,cranial nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001785,cranial nerve
-MONDO:0003569,cranial nerve neuropathy,MONDO:0000001,disease,UBERON:0034713,cranial neuron projection bundle
-MONDO:0003180,cutaneous adenocystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0002097,skin of body
-MONDO:0000879,cutaneous candidiasis,MONDO:0002026,candidiasis,UBERON:0000014,zone of skin
-MONDO:0002291,cutaneous granular cell tumor,MONDO:0006235,granular cell tumor,UBERON:0000014,zone of skin
-MONDO:0005012,cutaneous melanoma (disease),MONDO:0005105,melanoma (disease),UBERON:0000014,zone of skin
-MONDO:0003091,cutaneous mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0000014,zone of skin
-MONDO:0019210,cutaneous neuroendocrine carcinoma,MONDO:0004993,carcinoma,CL:0000242,Merkel cell
-MONDO:0004380,dendritic cell sarcoma,MONDO:0005089,sarcoma,CL:0000451,dendritic cell
-MONDO:0002591,dendritic cell thymoma,MONDO:0006456,thymoma (disease),CL:0000451,dendritic cell
-MONDO:0003394,dental pulp disease,MONDO:0000001,disease,UBERON:0001754,dental pulp
-MONDO:0021154,dermis disease,MONDO:0000001,disease,UBERON:0002067,dermis
-MONDO:0008167,dermoid cyst of ovary,MONDO:0002378,dermoid cyst,UBERON:0000992,ovary
-MONDO:0001778,dermoid cyst of skin,MONDO:0002378,dermoid cyst,UBERON:0000014,zone of skin
-MONDO:0001462,descending colon cancer,MONDO:0004992,cancer,UBERON:0001158,descending colon
-MONDO:0005728,diaphragm disease,MONDO:0000001,disease,UBERON:0001103,diaphragm
-MONDO:0003169,diencephalic astrocytomas,MONDO:0019781,astrocytoma,UBERON:0001894,diencephalon
-MONDO:0002786,diencephalic cancer,MONDO:0004992,cancer,UBERON:0001894,diencephalon
-MONDO:0006180,digestive system adenoma,MONDO:0004972,adenoma,UBERON:0001555,digestive tract
-MONDO:0002516,digestive system cancer,MONDO:0004992,cancer,UBERON:0001007,digestive system
-MONDO:0000386,digestive system neuroendocrine tumor,MONDO:0019496,neuroendocrine tumor,UBERON:0005409,alimentary part of gastrointestinal system
-MONDO:0021145,disease of genitourinary system,MONDO:0000001,disease,UBERON:0004122,genitourinary system
-MONDO:0001674,diverticulitis of colon,MONDO:0004235,diverticulitis,UBERON:0001155,colon
-MONDO:0006186,duodenal adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002114,duodenum
-MONDO:0002866,duodenal disease,MONDO:0000001,disease,UBERON:0002114,duodenum
-MONDO:0004411,duodenal gastrinoma,MONDO:0003523,gastrin-producing neuroendocrine tumor,UBERON:0002114,duodenum
-MONDO:0006187,duodenal villous adenoma,MONDO:0004972,adenoma,UBERON:0002114,duodenum
-MONDO:0000920,duodenum cancer,MONDO:0004992,cancer,UBERON:0002114,duodenum
-MONDO:0003481,dysgerminoma of ovary,MONDO:0003002,dysgerminoma (disease),UBERON:0000992,ovary
-MONDO:0003207,eccrine adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000423,eccrine sweat gland
-MONDO:0002200,eccrine mixed tumor of skin,MONDO:0021043,mixed neoplasm,UBERON:0000423,eccrine sweat gland
-MONDO:0005506,eccrine sweat gland cancer,MONDO:0004992,cancer,UBERON:0000423,eccrine sweat gland
-MONDO:0002090,eccrine sweat gland neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000423,eccrine sweat gland
-MONDO:0003580,embryonal testis carcinoma,MONDO:0005440,embryonal carcinoma,UBERON:0000473,testis
-MONDO:0002233,enamel caries,MONDO:0005276,dental caries,UBERON:0001752,enamel
-MONDO:0003687,endocardium cancer,MONDO:0004992,cancer,UBERON:0002165,endocardium
-MONDO:0000470,endocardium disease,MONDO:0000001,disease,UBERON:0002165,endocardium
-MONDO:0000554,endocervical adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000458,endocervix
-MONDO:0004259,endocervical carcinoma,MONDO:0004993,carcinoma,UBERON:0000458,endocervix
-MONDO:0002082,endocrine gland neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002368,endocrine gland
-MONDO:0001933,endocrine pancreas disease,MONDO:0000001,disease,UBERON:0000016,endocrine pancreas
-MONDO:0005151,endocrine system disease,MONDO:0000001,disease,UBERON:0000949,endocrine system
-MONDO:0003556,endometrial adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0001295,endometrium
-MONDO:0011962,endometrial cancer,MONDO:0004992,cancer,UBERON:0001295,endometrium
-MONDO:0002447,endometrial carcinoma (disease),MONDO:0004993,carcinoma,UBERON:0001295,endometrium
-MONDO:0000931,endometrial disease,MONDO:0000001,disease,UBERON:0001295,endometrium
-MONDO:0002747,endometrial mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0001295,endometrium
-MONDO:0006198,endometrial squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001295,endometrium
-MONDO:0001284,endometriosis of intestine,MONDO:0005133,endometriosis (disease),UBERON:0000160,intestine
-MONDO:0001289,endometriosis of ovary,MONDO:0005133,endometriosis (disease),UBERON:0000992,ovary
-MONDO:0010888,endometriosis of uterus,MONDO:0005133,endometriosis (disease),UBERON:0001296,myometrium
-MONDO:0005461,endometrium adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001295,endometrium
-MONDO:0003315,endometrium carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001295,endometrium
-MONDO:0003104,epicardium cancer,MONDO:0004992,cancer,UBERON:0002348,epicardium
-MONDO:0003840,epicardium lipoma,MONDO:0005106,lipoma,UBERON:0002348,epicardium
-MONDO:0001017,epididymis adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001301,epididymis
-MONDO:0004227,epididymis adenomatoid tumor,MONDO:0004230,adenomatoid tumor,UBERON:0001301,epididymis
-MONDO:0001016,epididymis cancer,MONDO:0004992,cancer,UBERON:0001301,epididymis
-MONDO:0004473,epiglottis cancer,MONDO:0004992,cancer,UBERON:0000388,epiglottis
-MONDO:0005028,esophageal adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001043,esophagus
-MONDO:0007576,esophageal cancer,MONDO:0004992,cancer,UBERON:0001043,esophagus
-MONDO:0003749,esophageal disease,MONDO:0000001,disease,UBERON:0001043,esophagus
-MONDO:0003251,esophageal granular cell tumor,MONDO:0006235,granular cell tumor,UBERON:0001043,esophagus
-MONDO:0000963,esophageal lipoma,MONDO:0005106,lipoma,UBERON:0001043,esophagus
-MONDO:0003649,esophageal neuroendocrine tumor,MONDO:0019496,neuroendocrine tumor,UBERON:0001043,esophagus
-MONDO:0005580,esophageal squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001043,esophagus
-MONDO:0004189,esophageal tuberculosis,MONDO:0018076,tuberculosis,UBERON:0001043,esophagus
-MONDO:0004708,esophagus carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001043,esophagus
-MONDO:0004832,esophagus leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001043,esophagus
-MONDO:0003365,esophagus leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001043,esophagus
-MONDO:0003586,esophagus liposarcoma,MONDO:0005060,liposarcoma,UBERON:0001043,esophagus
-MONDO:0001188,esophagus lymphoma,MONDO:0005062,lymphoma,UBERON:0001043,esophagus
-MONDO:0001192,esophagus melanoma,MONDO:0005105,melanoma (disease),UBERON:0001043,esophagus
-MONDO:0001204,esophagus sarcoma,MONDO:0005089,sarcoma,UBERON:0001043,esophagus
-MONDO:0004116,esophagus small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0001043,esophagus
-MONDO:0004827,esophagus squamous cell papilloma,MONDO:0001825,squamous papilloma,UBERON:0001043,esophagus
-MONDO:0002762,esophagus verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0001043,esophagus
-MONDO:0001763,ethmoid sinus cancer,MONDO:0004992,cancer,UBERON:0002453,ethmoid sinus
-MONDO:0003925,ethmoid sinus inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0002453,ethmoid sinus
-MONDO:0002416,ethmoid sinus squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002453,ethmoid sinus
-MONDO:0005756,ethmoid sinusitis,MONDO:0005961,sinusitis,UBERON:0001679,ethmoid bone
-MONDO:0004866,eustachian tube disease,MONDO:0000001,disease,UBERON:0002393,pharyngotympanic tube
-MONDO:0002455,exocervical carcinoma,MONDO:0004993,carcinoma,UBERON:0012249,ectocervix
-MONDO:0005192,exocrine pancreatic carcinoma,MONDO:0004993,carcinoma,UBERON:0000017,exocrine pancreas
-MONDO:0002943,external ear basal cell carcinoma,MONDO:0002944,external ear carcinoma,CL:0000646,basal cell
-MONDO:0003574,external ear cancer,MONDO:0004992,cancer,UBERON:0001691,external ear
-MONDO:0002944,external ear carcinoma,MONDO:0004993,carcinoma,UBERON:0001691,external ear
-MONDO:0002776,external ear disease,MONDO:0000001,disease,UBERON:0001691,external ear
-MONDO:0003501,external ear squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001691,external ear
-MONDO:0002665,extrahepatic bile duct adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0003445,extrahepatic bile duct adenoma,MONDO:0004972,adenoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0003090,extrahepatic bile duct carcinoma,MONDO:0004993,carcinoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0004462,extrahepatic bile duct cystadenoma,MONDO:0002369,cystadenoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0003286,extrahepatic bile duct leiomyoma,MONDO:0001572,leiomyoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0003377,extrahepatic bile duct leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0000978,extrahepatic bile duct lipoma,MONDO:0005106,lipoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0004250,extrahepatic bile duct papillary adenoma,MONDO:0002533,papillary adenoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0006203,extrahepatic bile duct squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0003703,extrahepatic bile duct
-MONDO:0006757,extrahepatic cholestasis,MONDO:0001751,cholestasis,UBERON:0003703,extrahepatic bile duct
-MONDO:0000462,eye adnexa disease,MONDO:0000001,disease,UBERON:0035639,ocular adnexa
-MONDO:0002466,eye carcinoma,MONDO:0004993,carcinoma,UBERON:0000970,eye
-MONDO:0004659,eye carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000970,eye
-MONDO:0004884,eye degenerative disease,MONDO:0005559,neurodegenerative disease,UBERON:0000970,eye
-MONDO:0005328,eye disease,MONDO:0000001,disease,UBERON:0000970,eye
-MONDO:0004034,eye lymphoma,MONDO:0005062,lymphoma,UBERON:0000970,eye
-MONDO:0003876,eyelid carcinoma,MONDO:0004993,carcinoma,UBERON:0001711,eyelid
-MONDO:0000941,eyelid degenerative disease,MONDO:0005559,neurodegenerative disease,UBERON:0001711,eyelid
-MONDO:0003382,eyelid disease,MONDO:0000001,disease,UBERON:0001711,eyelid
-MONDO:0002235,eyelid neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001711,eyelid
-MONDO:0002098,facial nerve disease,MONDO:0000001,disease,UBERON:0001647,facial nerve
-MONDO:0002101,facial nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001647,facial nerve
-MONDO:0002746,fallopian tube adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0003889,fallopian tube
-MONDO:0003461,fallopian tube adenofibroma,MONDO:0006071,adenofibroma,UBERON:0003889,fallopian tube
-MONDO:0003328,fallopian tube adenomatoid tumor,MONDO:0004230,adenomatoid tumor,UBERON:0003889,fallopian tube
-MONDO:0002162,fallopian tube adenosarcoma,MONDO:0005636,adenosarcoma,UBERON:0003889,fallopian tube
-MONDO:0000645,fallopian tube benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0003889,fallopian tube
-MONDO:0002158,fallopian tube cancer,MONDO:0004992,cancer,UBERON:0003889,fallopian tube
-MONDO:0006206,fallopian tube carcinoma,MONDO:0004993,carcinoma,UBERON:0003889,fallopian tube
-MONDO:0006207,fallopian tube carcinosarcoma,MONDO:0002928,carcinosarcoma,UBERON:0003889,fallopian tube
-MONDO:0003383,fallopian tube clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0003889,fallopian tube
-MONDO:0004501,fallopian tube cystadenofibroma,MONDO:0003464,cystadenofibroma,UBERON:0003889,fallopian tube
-MONDO:0002156,fallopian tube disease,MONDO:0000001,disease,UBERON:0003889,fallopian tube
-MONDO:0001282,fallopian tube endometriosis,MONDO:0005133,endometriosis (disease),UBERON:0003889,fallopian tube
-MONDO:0003392,fallopian tube germ cell cancer,MONDO:0005040,germ cell tumor,UBERON:0003889,fallopian tube
-MONDO:0004489,fallopian tube gestational choriocarcinoma,MONDO:0020550,gestational choriocarcinoma,UBERON:0003889,fallopian tube
-MONDO:0003285,fallopian tube leiomyoma,MONDO:0001572,leiomyoma,UBERON:0003889,fallopian tube
-MONDO:0002159,fallopian tube leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0003889,fallopian tube
-MONDO:0002744,fallopian tube mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0003889,fallopian tube
-MONDO:0021092,fallopian tube neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0003889,fallopian tube
-MONDO:0003535,fallopian tube papillary adenocarcinoma,MONDO:0002512,papillary adenocarcinoma,UBERON:0003889,fallopian tube
-MONDO:0006208,fallopian tube serous adenocarcinoma,MONDO:0005278,serous adenocarcinoma,UBERON:0003889,fallopian tube
-MONDO:0003503,fallopian tube squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0003889,fallopian tube
-MONDO:0003515,fallopian tube teratoma,MONDO:0002601,teratoma,UBERON:0003889,fallopian tube
-MONDO:0002833,fallopian tube transitional cell carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0003889,fallopian tube
-MONDO:0021124,female infertility,MONDO:0005047,infertility,UBERON:0000474,female reproductive system
-MONDO:0000624,female reproductive organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0003134,female reproductive organ
-MONDO:0001416,female reproductive organ cancer,MONDO:0004992,cancer,UBERON:0003134,female reproductive organ
-MONDO:0002263,female reproductive system disease,MONDO:0000001,disease,UBERON:0000474,female reproductive system
-MONDO:0021148,female reproductive system neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0003134,female reproductive organ
-MONDO:0004203,female urethral cancer,MONDO:0004992,cancer,UBERON:0001334,female urethra
-MONDO:0003505,femoral cancer,MONDO:0004992,cancer,UBERON:0000981,femur
-MONDO:0001481,femoral vein thrombophlebitis,MONDO:0002800,thrombophlebitis,UBERON:0001361,femoral vein
-MONDO:0006549,fibroepithelial polyp of the anus,MONDO:0004026,skin tag,UBERON:0001245,anus
-MONDO:0006550,fibroepithelial polyp of urethra,MONDO:0004026,skin tag,UBERON:0000057,urethra
-MONDO:0005761,filarial elephantiasis,MONDO:0005424,elephantiasis,UBERON:0001711,eyelid
-MONDO:0000671,finger agnosia (disease),MONDO:0005638,agnosia,UBERON:0002389,manual digit
-MONDO:0006213,floor of mouth mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0003679,mouth floor
-MONDO:0005764,follicular dendritic cell sarcoma,MONDO:0005089,sarcoma,CL:0000442,follicular dendritic cell
-MONDO:0005034,follicular thyroid carcinoma (disease),MONDO:0004970,adenocarcinoma,UBERON:0002046,thyroid gland
-MONDO:0006552,folliculitis,MONDO:0002406,dermatitis,UBERON:0002073,hair follicle
-MONDO:0003109,foramen magnum meningioma,MONDO:0016642,meningioma (disease),UBERON:0003687,foramen magnum
-MONDO:0021131,frontal lobe ependymal tumor,MONDO:0017605,ependymal tumor,UBERON:0016525,frontal lobe
-MONDO:0002612,frontal lobe epilepsy,MONDO:0005027,epilepsy,UBERON:0016525,frontal lobe
-MONDO:0001421,frontal lobe neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0016525,frontal lobe
-MONDO:0001756,frontal sinus cancer,MONDO:0004992,cancer,UBERON:0001760,frontal sinus
-MONDO:0004448,frontal sinus inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0001760,frontal sinus
-MONDO:0002301,frontal sinus squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001760,frontal sinus
-MONDO:0000373,gall bladder carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002110,gall bladder
-MONDO:0006215,gallbladder adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002110,gall bladder
-MONDO:0006216,gallbladder adenoma,MONDO:0004972,adenoma,UBERON:0002110,gall bladder
-MONDO:0003026,gallbladder angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0002110,gall bladder
-MONDO:0005411,gallbladder cancer,MONDO:0004992,cancer,UBERON:0002110,gall bladder
-MONDO:0003220,gallbladder carcinoma,MONDO:0004993,carcinoma,UBERON:0002110,gall bladder
-MONDO:0005281,gallbladder disease,MONDO:0000001,disease,UBERON:0002110,gall bladder
-MONDO:0003297,gallbladder leiomyoma,MONDO:0001572,leiomyoma,UBERON:0002110,gall bladder
-MONDO:0003364,gallbladder leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002110,gall bladder
-MONDO:0000972,gallbladder lipoma,MONDO:0005106,lipoma,UBERON:0002110,gall bladder
-MONDO:0004474,gallbladder lymphoma,MONDO:0005062,lymphoma,UBERON:0002110,gall bladder
-MONDO:0004484,gallbladder melanoma,MONDO:0005105,melanoma (disease),UBERON:0002110,gall bladder
-MONDO:0004148,gallbladder papillary carcinoma,MONDO:0006509,papillary carcinoma,UBERON:0002110,gall bladder
-MONDO:0002518,gallbladder papillary neoplasm,MONDO:0021096,papillary epithelial neoplasm,UBERON:0002110,gall bladder
-MONDO:0002856,gallbladder rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0002110,gall bladder
-MONDO:0002857,gallbladder sarcoma,MONDO:0005089,sarcoma,UBERON:0002110,gall bladder
-MONDO:0002667,gallbladder signet ring cell adenocarcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0002110,gall bladder
-MONDO:0004115,gallbladder small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0002110,gall bladder
-MONDO:0006220,gallbladder squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002110,gall bladder
-MONDO:0005036,gastric adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000945,stomach
-MONDO:0006221,gastric adenoma,MONDO:0004972,adenoma,UBERON:0000945,stomach
-MONDO:0006034,gastric adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0000945,stomach
-MONDO:0003972,gastric body carcinoma,MONDO:0004993,carcinoma,UBERON:0001161,body of stomach
-MONDO:0001056,gastric cancer,MONDO:0004992,cancer,UBERON:0000945,stomach
-MONDO:0004950,gastric carcinoma,MONDO:0004993,carcinoma,UBERON:0000945,stomach
-MONDO:0003835,gastric cardia adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001162,cardia of stomach
-MONDO:0003834,gastric cardia carcinoma,MONDO:0004993,carcinoma,UBERON:0001162,cardia of stomach
-MONDO:0001058,gastric fundus cancer,MONDO:0004992,cancer,UBERON:0001160,fundus of stomach
-MONDO:0003970,gastric fundus carcinoma,MONDO:0004993,carcinoma,UBERON:0001160,fundus of stomach
-MONDO:0002414,gastric hemangioma,MONDO:0006500,hemangioma,UBERON:0000945,stomach
-MONDO:0021085,gastric neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000945,stomach
-MONDO:0006228,gastric papillary adenocarcinoma,MONDO:0002512,papillary adenocarcinoma,UBERON:0000945,stomach
-MONDO:0003920,gastric small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0000945,stomach
-MONDO:0006230,gastric squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000945,stomach
-MONDO:0003513,gastric teratoma,MONDO:0002601,teratoma,UBERON:0000945,stomach
-MONDO:0006035,gastric tubular adenocarcinoma,MONDO:0005606,tubular adenocarcinoma,UBERON:0000945,stomach
-MONDO:0003219,gastroesophageal junction adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0007650,esophagogastric junction
-MONDO:0004335,gastrointestinal system disease,MONDO:0000001,disease,UBERON:0005409,alimentary part of gastrointestinal system
-MONDO:0004490,gestational uterine corpus choriocarcinoma,MONDO:0020550,gestational choriocarcinoma,UBERON:0009853,body of uterus
-MONDO:0005507,gingival cancer,MONDO:0004992,cancer,UBERON:0001828,gingiva
-MONDO:0002021,gingival disease,MONDO:0000001,disease,UBERON:0001828,gingiva
-MONDO:0021086,gingival neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001828,gingiva
-MONDO:0000320,glandular tularemia,MONDO:0018077,tularemia,UBERON:0000029,lymph node
-MONDO:0001388,glans penis cancer,MONDO:0004992,cancer,UBERON:0001299,glans penis
-MONDO:0019722,glomerular disease,MONDO:0000001,disease,UBERON:0000074,renal glomerulus
-MONDO:0002462,glomerulonephritis (disease),MONDO:0001166,nephritis,UBERON:0000074,renal glomerulus
-MONDO:0018327,glomus tumor,MONDO:0005070,neoplasm (disease),UBERON:0004739,pronephric glomerulus
-MONDO:0002639,glossopharyngeal nerve disease,MONDO:0000001,disease,UBERON:0001649,glossopharyngeal nerve
-MONDO:0002638,glossopharyngeal nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001649,glossopharyngeal nerve
-MONDO:0002781,glossopharyngeal nerve paralysis,MONDO:0002782,cranial nerve palsy,UBERON:0001649,glossopharyngeal nerve
-MONDO:0002351,glottis cancer,MONDO:0004992,cancer,UBERON:0002486,glottis
-MONDO:0002355,glottis carcinoma,MONDO:0004993,carcinoma,UBERON:0002486,glottis
-MONDO:0002353,glottis neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002486,glottis
-MONDO:0004080,glottis squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002486,glottis
-MONDO:0004289,glottis verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0002486,glottis
-MONDO:0002259,gonadal disease,MONDO:0000001,disease,UBERON:0000991,gonad
-MONDO:0010768,gonadoblastoma,MONDO:0005565,blastoma,UBERON:0000991,gonad
-MONDO:0001027,gonococcal seminal vesiculitis,MONDO:0004277,gonorrhea,UBERON:0000998,seminal vesicle
-MONDO:0006036,granulosa cell tumor,MONDO:0005070,neoplasm (disease),CL:0000501,granulosa cell
-MONDO:0002917,hair disease,MONDO:0000001,disease,UBERON:0001037,strand of hair
-MONDO:0004719,hard palate cancer,MONDO:0004992,cancer,UBERON:0003216,hard palate
-MONDO:0002038,head and neck carcinoma,MONDO:0004993,carcinoma,UBERON:0000974,neck
-MONDO:0021059,head and neck disease,MONDO:0000001,disease,UBERON:0007811,craniocervical region
-MONDO:0005627,head and neck malignant neoplasia,MONDO:0004992,cancer,UBERON:0007811,craniocervical region
-MONDO:0005586,head and neck neoplasia,MONDO:0005070,neoplasm (disease),UBERON:0007811,craniocervical region
-MONDO:0006239,head and neck paraganglioma,MONDO:0000448,paraganglioma,UBERON:0007811,craniocervical region
-MONDO:0010150,head and neck squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0007811,craniocervical region
-MONDO:0005042,head disease,MONDO:0000001,disease,UBERON:0000033,head
-MONDO:0001340,heart cancer,MONDO:0004992,cancer,UBERON:0000948,heart
-MONDO:0005267,heart disease,MONDO:0000001,disease,UBERON:0000948,heart
-MONDO:0003742,heart fibrosarcoma,MONDO:0005164,fibrosarcoma (disease),UBERON:0000948,heart
-MONDO:0003353,heart leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0000948,heart
-MONDO:0003841,heart lipoma,MONDO:0005106,lipoma,UBERON:0000948,heart
-MONDO:0003917,heart lymphoma,MONDO:0005062,lymphoma,UBERON:0000948,heart
-MONDO:0003743,heart malignant hemangiopericytoma,MONDO:0005094,spindle cell tumor,UBERON:0000948,heart
-MONDO:0003354,heart sarcoma,MONDO:0005089,sarcoma,UBERON:0000948,heart
-MONDO:0002869,heart valve disease,MONDO:0000001,disease,UBERON:0000946,cardial valve
-MONDO:0003194,hemangioma of lung,MONDO:0006500,hemangioma,UBERON:0002048,lung
-MONDO:0006557,hemangioma of subcutaneous tissue,MONDO:0006500,hemangioma,UBERON:0011818,superficial fascia
-MONDO:0005570,hematological system disease,MONDO:0000001,disease,UBERON:0002390,hematopoietic system
-MONDO:0002334,hematopoietic and lymphoid system neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000178,blood
-MONDO:0002357,hepatic flexure cancer,MONDO:0004992,cancer,UBERON:0022277,hepatic flexure of colon
-MONDO:0003866,hepatic osteogenic sarcoma,MONDO:0009807,osteosarcoma (disease),UBERON:0002107,liver
-MONDO:0002515,hepatobiliary disease,MONDO:0000001,disease,UBERON:0002423,hepatobiliary system
-MONDO:0002514,hepatobiliary neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002423,hepatobiliary system
-MONDO:0001334,hypertrichosis of eyelid,MONDO:0019280,hypertrichosis (disease),UBERON:0001711,eyelid
-MONDO:0001810,hypoglossal nerve disease,MONDO:0000001,disease,UBERON:0001650,hypoglossal nerve
-MONDO:0002550,hypoglossal nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001650,hypoglossal nerve
-MONDO:0005216,hypopharyngeal carcinoma,MONDO:0004993,carcinoma,UBERON:0001051,hypopharynx
-MONDO:0005806,hypopharynx cancer,MONDO:0005517,pharynx cancer,UBERON:2000364,hypural
-MONDO:0002150,hypothalamic disease,MONDO:0003081,thalamic disease,UBERON:2000364,hypural
-MONDO:0006799,hypothalamic neoplasm,MONDO:0003766,thalamic cancer,UBERON:2000364,hypural
-MONDO:0001335,hypotrichosis of eyelid,MONDO:0003037,hypotrichosis,UBERON:0001711,eyelid
-MONDO:0000955,ileum cancer,MONDO:0004992,cancer,UBERON:0002116,ileum
-MONDO:0001148,iliac vein thrombophlebitis,MONDO:0002800,thrombophlebitis,UBERON:0005610,iliac vein
-MONDO:0003855,immature teratoma of ovary,MONDO:0003514,malignant teratoma,UBERON:0000992,ovary
-MONDO:0000621,immune system cancer,MONDO:0004992,cancer,UBERON:0002405,immune system
-MONDO:0005046,immune system disease,MONDO:0000001,disease,UBERON:0002405,immune system
-MONDO:0000630,immune system organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0005057,immune organ
-MONDO:0003278,inner ear cancer,MONDO:0004992,cancer,UBERON:0001846,internal ear
-MONDO:0002467,inner ear disease,MONDO:0000001,disease,UBERON:0001846,internal ear
-MONDO:0000652,integumentary system benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002416,integumental system
-MONDO:0000653,integumentary system cancer,MONDO:0004992,cancer,UBERON:0002416,integumental system
-MONDO:0002051,integumentary system disease,MONDO:0000001,disease,UBERON:0002416,integumental system
-MONDO:0003062,intestinal benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000160,intestine
-MONDO:0005814,intestinal cancer,MONDO:0004992,cancer,UBERON:0000160,intestine
-MONDO:0005020,intestinal disease,MONDO:0000001,disease,UBERON:0000160,intestine
-MONDO:0021118,intestinal neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000160,intestine
-MONDO:0002883,intestinal neuroendocrine benign tumor,MONDO:0019496,neuroendocrine tumor,UBERON:0000160,intestine
-MONDO:0001678,intestinal tuberculosis,MONDO:0018076,tuberculosis,UBERON:0000160,intestine
-MONDO:0004698,intestine carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000160,intestine
-MONDO:0002337,intra-abdominal hemangioma,MONDO:0006500,hemangioma,UBERON:0003684,abdominal cavity
-MONDO:0002328,intracranial hemangioma,MONDO:0006500,hemangioma,UBERON:0000955,brain
-MONDO:0021099,intraductal papillomatosis,MONDO:0021098,papillomatosis,UBERON:0000058,duct
-MONDO:0003444,intrahepatic bile duct adenoma,MONDO:0004972,adenoma,UBERON:0003704,intrahepatic bile duct
-MONDO:0003979,intrahepatic bile duct cystadenoma,MONDO:0002369,cystadenoma,UBERON:0003704,intrahepatic bile duct
-MONDO:0003936,invasive tubular breast carcinoma,MONDO:0005606,tubular adenocarcinoma,UBERON:0000310,breast
-MONDO:0021109,inverted urothelial papilloma,MONDO:0002537,inverted papilloma,UBERON:0000365,urothelium
-MONDO:0002658,iris cancer,MONDO:0004992,cancer,UBERON:0001769,iris
-MONDO:0002289,iris disease,MONDO:0000001,disease,UBERON:0001769,iris
-MONDO:0004188,iris spindle cell melanoma,MONDO:0006427,spindle cell melanoma,UBERON:0001769,iris
-MONDO:0004792,isthmus cancer,MONDO:0004992,cancer,UBERON:0003052,midbrain-hindbrain boundary
-MONDO:0002131,jaw cancer,MONDO:0004992,cancer,UBERON:0001708,jaw skeleton
-MONDO:0000541,jejunal adenocarcinoma (disease),MONDO:0004970,adenocarcinoma,UBERON:0002115,jejunum
-MONDO:0006815,jejunal cancer,MONDO:0004992,cancer,UBERON:0002115,jejunum
-MONDO:0006816,joint disease,MONDO:0000001,disease,UBERON:0000982,skeletal joint
-MONDO:0003771,jugular foramen meningioma,MONDO:0016642,meningioma (disease),UBERON:0005456,jugular foramen
-MONDO:0021064,jugulotympanic paraganglioma,MONDO:0021052,parasympathetic paraganglioma,UBERON:0002517,basicranium
-MONDO:0004555,kidney angiomyolipoma,MONDO:0002603,angiomyolipoma,UBERON:0002113,kidney
-MONDO:0002513,kidney benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002113,kidney
-MONDO:0002367,kidney cancer,MONDO:0004992,cancer,UBERON:0002113,kidney
-MONDO:0004732,kidney carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002113,kidney
-MONDO:0005240,kidney disease,MONDO:0000001,disease,UBERON:0002113,kidney
-MONDO:0003720,kidney fibrosarcoma,MONDO:0005164,fibrosarcoma (disease),UBERON:0002113,kidney
-MONDO:0002365,kidney hemangiopericytoma,MONDO:0005094,spindle cell tumor,UBERON:0002113,kidney
-MONDO:0003373,kidney leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002113,kidney
-MONDO:0000968,kidney lipoma,MONDO:0005106,lipoma,UBERON:0002113,kidney
-MONDO:0003591,kidney liposarcoma,MONDO:0005060,liposarcoma,UBERON:0002113,kidney
-MONDO:0003825,kidney oncocytoma,MONDO:0010795,oncocytic neoplasm,UBERON:0002113,kidney
-MONDO:0003721,kidney osteogenic sarcoma,MONDO:0009807,osteosarcoma (disease),UBERON:0002113,kidney
-MONDO:0003716,kidney pelvis papillary carcinoma,MONDO:0006509,papillary carcinoma,UBERON:0001224,renal pelvis
-MONDO:0004009,kidney pelvis sarcomatoid transitional cell carcinoma,MONDO:0002837,sarcomatoid transitional cell carcinoma,UBERON:0001224,renal pelvis
-MONDO:0002729,kidney rhabdoid cancer,MONDO:0002728,rhabdoid tumor,UBERON:0002113,kidney
-MONDO:0002930,kidney sarcoma,MONDO:0005089,sarcoma,UBERON:0002113,kidney
-MONDO:0001526,labia minora cancer,MONDO:0004992,cancer,UBERON:0004014,labium minora
-MONDO:0001602,labia minora carcinoma,MONDO:0004993,carcinoma,UBERON:0004014,labium minora
-MONDO:0001403,labium majus cancer,MONDO:0004992,cancer,UBERON:0004085,labium majora
-MONDO:0001854,lacrimal apparatus disease,MONDO:0000001,disease,UBERON:0001750,lacrimal apparatus
-MONDO:0002475,lacrimal gland adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001817,lacrimal gland
-MONDO:0002464,lacrimal gland cancer,MONDO:0004992,cancer,UBERON:0001817,lacrimal gland
-MONDO:0002463,lacrimal gland carcinoma,MONDO:0004993,carcinoma,UBERON:0001817,lacrimal gland
-MONDO:0003092,lacrimal gland mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0001817,lacrimal gland
-MONDO:0003492,lacrimal gland squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001817,lacrimal gland
-MONDO:0000528,large intestine adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000059,large intestine
-MONDO:0000529,large intestine adenoma,MONDO:0004972,adenoma,UBERON:0000059,large intestine
-MONDO:0003576,large intestine cancer,MONDO:0004992,cancer,UBERON:0000059,large intestine
-MONDO:0003885,large intestine lipoma,MONDO:0005106,lipoma,UBERON:0000059,large intestine
-MONDO:0002358,laryngeal carcinoma,MONDO:0004993,carcinoma,UBERON:0001737,larynx
-MONDO:0001691,laryngeal cartilage cancer,MONDO:0004992,cancer,UBERON:0001739,laryngeal cartilage
-MONDO:0004382,laryngeal disease,MONDO:0000001,disease,UBERON:0001737,larynx
-MONDO:0003095,laryngeal mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0001737,larynx
-MONDO:0021071,laryngeal neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001737,larynx
-MONDO:0015070,laryngeal neuroendocrine tumor,MONDO:0019496,neuroendocrine tumor,UBERON:0001737,larynx
-MONDO:0006265,laryngeal small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0001737,larynx
-MONDO:0005819,laryngeal tuberculosis,MONDO:0018076,tuberculosis,UBERON:0001737,larynx
-MONDO:0002352,larynx cancer,MONDO:0004992,cancer,UBERON:0001737,larynx
-MONDO:0004696,larynx carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001737,larynx
-MONDO:0000934,larynx leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001737,larynx
-MONDO:0003374,larynx leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001737,larynx
-MONDO:0003588,larynx liposarcoma,MONDO:0002448,larynx sarcoma,UBERON:0001833,lip
-MONDO:0002448,larynx sarcoma,MONDO:0005089,sarcoma,UBERON:0001737,larynx
-MONDO:0002766,larynx verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0001737,larynx
-MONDO:0003775,lateral ventricle meningioma,MONDO:0016642,meningioma (disease),UBERON:0002285,telencephalic ventricle
-MONDO:0016283,leiomyosarcoma of the cervix uteri,MONDO:0005058,leiomyosarcoma,UBERON:0000002,uterine cervix
-MONDO:0001176,lens disease,MONDO:0000001,disease,UBERON:0000965,lens of camera-type eye
-MONDO:0004330,leptomeninges sarcoma,MONDO:0005089,sarcoma,UBERON:0000391,leptomeninx
-MONDO:0004805,leukocyte disease,MONDO:0000001,disease,CL:0000738,leukocyte
-MONDO:0000491,limb ischemia,MONDO:0005053,ischemia,UBERON:0002101,limb
-MONDO:0006834,lip cancer,MONDO:0004992,cancer,UBERON:0001833,lip
-MONDO:0004636,lip carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001833,lip
-MONDO:0004748,lip disease,MONDO:0000001,disease,UBERON:0001833,lip
-MONDO:0021090,lipid-rich breast carcinoma,MONDO:0003570,lipid-rich carcinoma,UBERON:0000310,breast
-MONDO:0001091,lipoma of colon,MONDO:0005106,lipoma,UBERON:0001155,colon
-MONDO:0000975,lipoma of spermatic cord,MONDO:0005106,lipoma,UBERON:0005352,spermatic cord
-MONDO:0003884,lipoma of the rectum,MONDO:0005106,lipoma,UBERON:0001052,rectum
-MONDO:0005060,liposarcoma,MONDO:0005089,sarcoma,UBERON:0001833,lip
-MONDO:0003589,liposarcoma of the ovary,MONDO:0002225,ovary sarcoma,UBERON:0001833,lip
-MONDO:0002387,liver angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0002107,liver
-MONDO:0002691,liver cancer,MONDO:0004992,cancer,UBERON:0002107,liver
-MONDO:0004018,liver carcinoma,MONDO:0004993,carcinoma,UBERON:0002107,liver
-MONDO:0004715,liver carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002107,liver
-MONDO:0005154,liver disease,MONDO:0000001,disease,UBERON:0002107,liver
-MONDO:0004705,liver fibroma,MONDO:0005167,fibroma,UBERON:0002107,liver
-MONDO:0004435,liver fibrosarcoma,MONDO:0005164,fibrosarcoma (disease),UBERON:0002107,liver
-MONDO:0002404,liver hemangioma,MONDO:0006500,hemangioma,UBERON:0002107,liver
-MONDO:0004723,liver leiomyoma,MONDO:0001572,leiomyoma,UBERON:0002107,liver
-MONDO:0003378,liver leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002107,liver
-MONDO:0000965,liver lipoma,MONDO:0005106,lipoma,UBERON:0002107,liver
-MONDO:0004695,liver lymphoma,MONDO:0005062,lymphoma,UBERON:0002107,liver
-MONDO:0002849,liver rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0002107,liver
-MONDO:0002397,liver sarcoma,MONDO:0005089,sarcoma,UBERON:0002107,liver
-MONDO:0007063,long bone adamantinoma,MONDO:0002422,adamantinoma,UBERON:0002495,long bone
-MONDO:0004713,lower gum cancer,MONDO:0004992,cancer,UBERON:0011602,gingiva of lower jaw
-MONDO:0004673,lower lip cancer,MONDO:0004992,cancer,UBERON:0001835,lower lip
-MONDO:0000270,lower respiratory tract disease,MONDO:0000001,disease,UBERON:0001558,lower respiratory tract
-MONDO:0005061,lung adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002048,lung
-MONDO:0003181,lung adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0002048,lung
-MONDO:0003422,lung adenoma,MONDO:0004972,adenoma,UBERON:0002048,lung
-MONDO:0002732,lung benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002048,lung
-MONDO:0008903,lung cancer,MONDO:0004992,cancer,UBERON:0002048,lung
-MONDO:0005138,lung carcinoma,MONDO:0004993,carcinoma,UBERON:0002048,lung
-MONDO:0004660,lung carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002048,lung
-MONDO:0005275,lung disease,MONDO:0000001,disease,UBERON:0002048,lung
-MONDO:0004332,lung hilum cancer,MONDO:0004992,cancer,UBERON:0004886,lung hilus
-MONDO:0003050,lung large cell carcinoma,MONDO:0005232,large cell carcinoma,UBERON:0002048,lung
-MONDO:0003293,lung leiomyoma,MONDO:0001572,leiomyoma,UBERON:0002048,lung
-MONDO:0003357,lung leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002048,lung
-MONDO:0003987,lung lymphoma,MONDO:0005062,lymphoma,UBERON:0002048,lung
-MONDO:0003638,lung meningioma,MONDO:0016642,meningioma (disease),UBERON:0002048,lung
-MONDO:0021117,lung neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002048,lung
-MONDO:0005454,lung neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0002048,lung
-MONDO:0002426,lung sarcoma,MONDO:0005089,sarcoma,UBERON:0002048,lung
-MONDO:0000715,lymph node adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0000029,lymph node
-MONDO:0001082,lymph node cancer,MONDO:0004992,cancer,UBERON:0000029,lymph node
-MONDO:0004928,lymph node disease,MONDO:0000001,disease,UBERON:0000029,lymph node
-MONDO:0005831,lymph node tuberculosis,MONDO:0018076,tuberculosis,UBERON:0000029,lymph node
-MONDO:0000612,lymphatic system cancer,MONDO:0004992,cancer,UBERON:0006558,lymphatic part of lymphoid system
-MONDO:0005833,lymphatic system disease,MONDO:0000001,disease,UBERON:0006558,lymphatic part of lymphoid system
-MONDO:0005834,lymphogranuloma venereum,MONDO:0005777,granuloma inguinale,UBERON:0002391,lymph
-MONDO:0003004,macular degeneration,MONDO:0004580,retinal degeneration,UBERON:0000054,macula
-MONDO:0002811,main bronchus cancer,MONDO:0004992,cancer,UBERON:0002182,main bronchus
-MONDO:0006284,major salivary gland carcinoma,MONDO:0004993,carcinoma,UBERON:0001829,major salivary gland
-MONDO:0006285,major salivary gland carcinoma ex pleomorphic adenoma,MONDO:0006403,salivary gland carcinoma ex pleomorphic adenoma,UBERON:0001829,major salivary gland
-MONDO:0006286,major salivary gland mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0001829,major salivary gland
-MONDO:0005628,male breast carcinoma,MONDO:0004993,carcinoma,UBERON:0016410,male breast
-MONDO:0005372,male infertility,MONDO:0005047,infertility,UBERON:0000079,male reproductive system
-MONDO:0000625,male reproductive organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0003135,male reproductive organ
-MONDO:0005836,male reproductive organ cancer,MONDO:0004992,cancer,UBERON:0003135,male reproductive organ
-MONDO:0003150,male reproductive system disease,MONDO:0000001,disease,UBERON:0000079,male reproductive system
-MONDO:0004197,male urethral cancer,MONDO:0004992,cancer,UBERON:0001333,male urethra
-MONDO:0002975,malignant breast melanoma,MONDO:0005105,melanoma (disease),UBERON:0000310,breast
-MONDO:0003990,malignant breast myoepithelioma,MONDO:0003158,myoepithelial carcinoma,UBERON:0000310,breast
-MONDO:0021063,malignant colon neoplasm,MONDO:0004992,cancer,UBERON:0001155,colon
-MONDO:0003363,malignant dermis tumor,MONDO:0004992,cancer,UBERON:0002067,dermis
-MONDO:0003277,malignant ear neoplasm,MONDO:0004992,cancer,UBERON:0001690,ear
-MONDO:0021069,malignant endocrine neoplasm,MONDO:0004992,cancer,UBERON:0002368,endocrine gland
-MONDO:0002116,malignant exocrine pancreas neoplasm,MONDO:0004992,cancer,UBERON:0000017,exocrine pancreas
-MONDO:0004048,malignant gastric teratoma,MONDO:0003514,malignant teratoma,UBERON:0000945,stomach
-MONDO:0006290,malignant germ cell tumor,MONDO:0004992,cancer,CL:0000586,germ cell
-MONDO:0016289,malignant germ cell tumor of cervix uteri,MONDO:0006290,malignant germ cell tumor,UBERON:0000002,uterine cervix
-MONDO:0016273,malignant germ cell tumor of corpus uteri,MONDO:0006290,malignant germ cell tumor,UBERON:0009853,body of uterus
-MONDO:0018171,malignant germ cell tumor of ovary,MONDO:0006290,malignant germ cell tumor,UBERON:0000992,ovary
-MONDO:0003340,malignant glomus tumor,MONDO:0004992,cancer,UBERON:0004739,pronephric glomerulus
-MONDO:0006291,malignant jugulotympanic paraganglioma,MONDO:0004992,cancer,UBERON:0034972,jugular body
-MONDO:0003762,malignant leptomeningeal tumor,MONDO:0004992,cancer,UBERON:0000391,leptomeninx
-MONDO:0000377,malignant leydig cell tumor,MONDO:0004992,cancer,CL:0000178,Leydig cell
-MONDO:0003809,malignant mediastinum hemangiopericytoma,MONDO:0005094,spindle cell tumor,UBERON:0003728,mediastinum
-MONDO:0002432,malignant neoplasm of acoustic nerve,MONDO:0004992,cancer,UBERON:0001648,vestibulocochlear nerve
-MONDO:0002434,malignant oculomotor nerve tumor,MONDO:0004992,cancer,UBERON:0001643,oculomotor nerve
-MONDO:0009831,malignant pancreatic neoplasm,MONDO:0004992,cancer,UBERON:0001264,pancreas
-MONDO:0003805,malignant pericardial mesothelioma,MONDO:0005065,mesothelioma,UBERON:0002407,pericardium
-MONDO:0005112,malignant pleural mesothelioma,MONDO:0005065,mesothelioma,UBERON:0000977,pleura
-MONDO:0006294,malignant pleural neoplasm,MONDO:0004992,cancer,UBERON:0000977,pleura
-MONDO:0006519,malignant rectal neoplasm,MONDO:0004992,cancer,UBERON:0001052,rectum
-MONDO:0006295,malignant urinary system neoplasm,MONDO:0004992,cancer,UBERON:0001008,renal system
-MONDO:0005837,mandibular cancer,MONDO:0004992,cancer,UBERON:0001684,mandible
-MONDO:0006495,marginal zone b-cell lymphoma,MONDO:0005062,lymphoma,CL:0000845,marginal zone B cell
-MONDO:0019024,mast cell sarcoma,MONDO:0005089,sarcoma,CL:0000097,mast cell
-MONDO:0004467,mature gastric teratoma,MONDO:0003517,mature teratoma,UBERON:0000945,stomach
-MONDO:0003820,mature ovarian teratoma,MONDO:0003517,mature teratoma,UBERON:0000992,ovary
-MONDO:0005841,maxillary neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0011597,bone of upper jaw
-MONDO:0004457,maxillary sinus Schneiderian papilloma,MONDO:0006353,paranasal sinus Schneiderian papilloma,UBERON:0001764,maxillary sinus
-MONDO:0006297,maxillary sinus adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0001764,maxillary sinus
-MONDO:0001748,maxillary sinus cancer,MONDO:0004992,cancer,UBERON:0001764,maxillary sinus
-MONDO:0006577,maxillary sinus cholesteatoma,MONDO:0006530,cholesteatoma (disease),UBERON:0001764,maxillary sinus
-MONDO:0004384,maxillary sinus inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0001764,maxillary sinus
-MONDO:0004394,maxillary sinus squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001764,maxillary sinus
-MONDO:0004914,median arcuate ligament syndrome,MONDO:0002254,syndromic disease,UBERON:0015215,median arcuate ligament
-MONDO:0005843,mediastinal cancer,MONDO:0004992,cancer,UBERON:0003728,mediastinum
-MONDO:0021067,mediastinal germ cell tumor,MONDO:0005040,germ cell tumor,UBERON:0003728,mediastinum
-MONDO:0003255,mediastinal granular cell myoblastoma,MONDO:0006235,granular cell tumor,UBERON:0003728,mediastinum
-MONDO:0004021,mediastinal malignant lymphoma,MONDO:0005062,lymphoma,UBERON:0003728,mediastinum
-MONDO:0003808,mediastinal osteogenic sarcoma,MONDO:0009807,osteosarcoma (disease),UBERON:0003728,mediastinum
-MONDO:0003034,mediastinum angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0003728,mediastinum
-MONDO:0001096,mediastinum ganglioneuroblastoma,MONDO:0005035,ganglioneuroblastoma (disease),UBERON:0003728,mediastinum
-MONDO:0003284,mediastinum leiomyoma,MONDO:0001572,leiomyoma,UBERON:0003728,mediastinum
-MONDO:0003376,mediastinum leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0003728,mediastinum
-MONDO:0003601,mediastinum liposarcoma,MONDO:0002852,mediastinum sarcoma,UBERON:0001833,lip
-MONDO:0001095,mediastinum neuroblastoma,MONDO:0005072,neuroblastoma,UBERON:0003728,mediastinum
-MONDO:0001426,mediastinum neurofibroma,MONDO:0016755,neurofibroma,UBERON:0003728,mediastinum
-MONDO:0002851,mediastinum rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0003728,mediastinum
-MONDO:0002852,mediastinum sarcoma,MONDO:0005089,sarcoma,UBERON:0003728,mediastinum
-MONDO:0003826,mediastinum seminoma,MONDO:0003001,seminoma,UBERON:0003728,mediastinum
-MONDO:0003467,mediastinum synovial sarcoma,MONDO:0010434,synovial sarcoma (disease),UBERON:0003728,mediastinum
-MONDO:0003518,mediastinum teratoma,MONDO:0002601,teratoma,UBERON:0003728,mediastinum
-MONDO:0015277,medullary thyroid gland carcinoma,MONDO:0004993,carcinoma,CL:0000570,parafollicular cell
-MONDO:0007959,medulloblastoma,MONDO:0005564,embryonal neoplasm,UBERON:0002037,cerebellum
-MONDO:0004512,meningeal melanomatosis,MONDO:0004141,melanomatosis,UBERON:0010743,meningeal cluster
-MONDO:0003223,meninges hemangiopericytoma,MONDO:0005094,spindle cell tumor,UBERON:0010743,meningeal cluster
-MONDO:0004308,meninges sarcoma,MONDO:0005089,sarcoma,UBERON:0010743,meningeal cluster
-MONDO:0001116,mesenteric lymphadenitis,MONDO:0002052,lymphadenitis (disease),UBERON:0002095,mesentery
-MONDO:0003121,middle cranial fossa meningioma,MONDO:0016642,meningioma (disease),UBERON:0003722,middle cranial fossa
-MONDO:0003189,middle ear adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001756,middle ear
-MONDO:0003423,middle ear adenoma,MONDO:0004972,adenoma,UBERON:0001756,middle ear
-MONDO:0003275,middle ear cancer,MONDO:0004992,cancer,UBERON:0001756,middle ear
-MONDO:0003190,middle ear carcinoma,MONDO:0004993,carcinoma,UBERON:0001756,middle ear
-MONDO:0003276,middle ear disease,MONDO:0000001,disease,UBERON:0001756,middle ear
-MONDO:0006303,middle ear squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001756,middle ear
-MONDO:0003767,mitral valve disease,MONDO:0000001,disease,UBERON:0002135,mitral valve
-MONDO:0016742,mixed germ cell tumor of central nervous system,MONDO:0015864,mixed germ cell tumor,UBERON:0001017,central nervous system
-MONDO:0002469,mixed lacrimal gland cancer,MONDO:0005853,malignant mixed neoplasm,UBERON:0001817,lacrimal gland
-MONDO:0020128,motor neuron disease,MONDO:0000001,disease,CL:0000100,motor neuron
-MONDO:0006858,mouth disease,MONDO:0000001,disease,UBERON:0000165,mouth
-MONDO:0004957,mucinous adenocarcinoma,MONDO:0004993,carcinoma,GO:0070701,mucus layer
-MONDO:0018330,mucinous adenocarcinoma of the appendix,MONDO:0004957,mucinous adenocarcinoma,UBERON:0001154,vermiform appendix
-MONDO:0002583,mucinous ovarian cystadenoma,MONDO:0006859,mucinous cystadenoma,UBERON:0000992,ovary
-MONDO:0003093,mucoepidermoid esophageal carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0001043,esophagus
-MONDO:0009693,multiple myeloma,MONDO:0005170,myeloid neoplasm,CL:0000786,plasma cell
-MONDO:0005864,muscle cancer,MONDO:0004992,cancer,UBERON:0005090,muscle structure
-MONDO:0003939,muscle tissue disease,MONDO:0000001,disease,UBERON:0002385,muscle tissue
-MONDO:0019119,muscular channelopathy,MONDO:0021016,channelopathy,UBERON:0002385,muscle tissue
-MONDO:0005218,muscular disease,MONDO:0000001,disease,UBERON:0001630,muscle organ
-MONDO:0000636,musculoskeletal system benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0002204,musculoskeletal system
-MONDO:0000637,musculoskeletal system cancer,MONDO:0004992,cancer,UBERON:0002204,musculoskeletal system
-MONDO:0002081,musculoskeletal system disease,MONDO:0000001,disease,UBERON:0002204,musculoskeletal system
-MONDO:0004749,myocardium cancer,MONDO:0004992,cancer,UBERON:0002349,myocardium
-MONDO:0006312,myofibroma,MONDO:0001572,leiomyoma,UBERON:0001833,lip
-MONDO:0004746,myopathy of extraocular muscle,MONDO:0005336,myopathy,UBERON:0001601,extra-ocular muscle
-MONDO:0004436,myxoid liposarcoma of the ovary,MONDO:0013280,myxoid liposarcoma,UBERON:0000992,ovary
-MONDO:0002884,nail disease,MONDO:0000001,disease,UBERON:0001705,nail
-MONDO:0003211,nasal cavity adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001707,nasal cavity
-MONDO:0001128,nasal cavity cancer,MONDO:0004992,cancer,UBERON:0001707,nasal cavity
-MONDO:0003212,nasal cavity carcinoma,MONDO:0004993,carcinoma,UBERON:0001707,nasal cavity
-MONDO:0003784,nasal cavity carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001707,nasal cavity
-MONDO:0002232,nasal cavity disease,MONDO:0000001,disease,UBERON:0001707,nasal cavity
-MONDO:0001130,nasal cavity lymphoma,MONDO:0005062,lymphoma,UBERON:0001707,nasal cavity
-MONDO:0001129,nasal cavity olfactory neuroblastoma,MONDO:0006329,olfactory neuroblastoma,UBERON:0001707,nasal cavity
-MONDO:0006059,nasal cavity squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001707,nasal cavity
-MONDO:0003753,nasal vestibule papilloma,MONDO:0002363,papilloma,UBERON:0000402,nasal vestibule
-MONDO:0015459,nasopharyngeal carcinoma,MONDO:0004993,carcinoma,UBERON:0001728,nasopharynx
-MONDO:0004821,nasopharyngeal disease,MONDO:0000001,disease,UBERON:0001728,nasopharynx
-MONDO:0001010,natural killer cell leukemia,MONDO:0005059,leukemia (disease),CL:0000623,natural killer cell
-MONDO:0004464,nephrogenic adenoma of the urethra,MONDO:0004191,nephrogenic adenoma,UBERON:0000057,urethra
-MONDO:0004190,nephrogenic adenoma of urinary bladder,MONDO:0004191,nephrogenic adenoma,UBERON:0001255,urinary bladder
-MONDO:0000648,nervous system benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001016,nervous system
-MONDO:0005872,nervous system cancer,MONDO:0004992,cancer,UBERON:0001016,nervous system
-MONDO:0005071,nervous system disease,MONDO:0000001,disease,UBERON:0001016,nervous system
-MONDO:0003926,neurilemmoma of the pleura,MONDO:0002546,schwannoma,UBERON:0000977,pleura
-MONDO:0003303,neurofibroma of gallbladder,MONDO:0016755,neurofibroma,UBERON:0002110,gall bladder
-MONDO:0001789,neurofibroma of spinal cord,MONDO:0016755,neurofibroma,UBERON:0002240,spinal cord
-MONDO:0004837,neurofibroma of the esophagus,MONDO:0016755,neurofibroma,UBERON:0001043,esophagus
-MONDO:0004752,neurofibroma of the heart,MONDO:0016755,neurofibroma,UBERON:0000948,heart
-MONDO:0007450,neurohypophyseal diabetes insipidus,MONDO:0004782,diabetes insipidus,UBERON:0000007,pituitary gland
-MONDO:0003256,neurohypophysis granular cell tumor,MONDO:0006235,granular cell tumor,UBERON:0002198,neurohypophysis
-MONDO:0003950,nipple carcinoma,MONDO:0004993,carcinoma,UBERON:0002030,nipple
-MONDO:0003603,non-functioning pituitary gland neoplasm,MONDO:0021119,non-functioning endocrine neoplasm,UBERON:0000007,pituitary gland
-MONDO:0002436,nose disease,MONDO:0000001,disease,UBERON:0000004,nose
-MONDO:0002597,notochordal cancer,MONDO:0004992,cancer,UBERON:0002328,notochord
-MONDO:0004709,occipital lobe neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002021,occipital lobe
-MONDO:0002236,ocular cancer,MONDO:0004992,cancer,UBERON:0000970,eye
-MONDO:0006325,ocular melanoma,MONDO:0005105,melanoma (disease),UBERON:0000970,eye
-MONDO:0001355,ocular siderosis,MONDO:0001436,hemosiderosis,UBERON:0000019,camera-type eye
-MONDO:0001557,olecranon bursitis,MONDO:0002471,bursitis,UBERON:0006810,olecranon
-MONDO:0004446,olfactory groove meningioma,MONDO:0016642,meningioma (disease),UBERON:0002772,olfactory sulcus
-MONDO:0002727,olfactory nerve disease,MONDO:0000001,disease,UBERON:0001579,olfactory nerve
-MONDO:0002722,olfactory nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001579,olfactory nerve
-MONDO:0003234,optic nerve astrocytoma,MONDO:0019781,astrocytoma,UBERON:0001908,optic tract
-MONDO:0002135,optic nerve disease,MONDO:0000001,disease,UBERON:0000941,cranial nerve II
-MONDO:0002640,optic nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000941,cranial nerve II
-MONDO:0005886,oral candidiasis,MONDO:0002026,candidiasis,UBERON:0000165,mouth
-MONDO:0005515,oral cavity cancer,MONDO:0004992,cancer,UBERON:0000167,oral cavity
-MONDO:0000371,oral cavity carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000167,oral cavity
-MONDO:0004958,oral squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000165,mouth
-MONDO:0004943,orbit sarcoma,MONDO:0005089,sarcoma,UBERON:0001697,orbit of skull
-MONDO:0002889,orbital cancer,MONDO:0004992,cancer,UBERON:0001697,orbit of skull
-MONDO:0000236,oropharyngeal anthrax,MONDO:0005119,anthrax infection,UBERON:0001729,oropharynx
-MONDO:0004608,oropharynx cancer,MONDO:0004992,cancer,UBERON:0001729,oropharynx
-MONDO:0009807,osteosarcoma (disease),MONDO:0005089,sarcoma,UBERON:0008883,osteoid
-MONDO:0003035,ovarian angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0000992,ovary
-MONDO:0000646,ovarian benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000992,ovary
-MONDO:0008170,ovarian cancer,MONDO:0004992,cancer,UBERON:0000992,ovary
-MONDO:0005140,ovarian carcinoma,MONDO:0004993,carcinoma,UBERON:0000992,ovary
-MONDO:0006045,ovarian clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0000992,ovary
-MONDO:0003695,ovarian clear cell adenofibroma,MONDO:0003460,clear cell adenofibroma,UBERON:0000992,ovary
-MONDO:0003694,ovarian clear cell cystadenofibroma,MONDO:0003693,clear cell cystadenofibroma,UBERON:0000992,ovary
-MONDO:0002702,ovarian cystadenocarcinoma,MONDO:0005596,cystadenocarcinoma,UBERON:0000992,ovary
-MONDO:0005558,ovarian disease,MONDO:0000001,disease,UBERON:0000992,ovary
-MONDO:0003581,ovarian embryonal carcinoma,MONDO:0005440,embryonal carcinoma,UBERON:0000992,ovary
-MONDO:0003812,ovarian endometrial cancer,MONDO:0002480,female reproductive endometrioid cancer,UBERON:0000992,ovary
-MONDO:0006335,ovarian endometrioid adenocarcinoma,MONDO:0005461,endometrium adenocarcinoma,UBERON:0000992,ovary
-MONDO:0002229,ovarian epithelial tumor,MONDO:0005626,epithelial neoplasm,UBERON:0000992,ovary
-MONDO:0011366,ovarian germ cell tumor,MONDO:0005040,germ cell tumor,UBERON:0000992,ovary
-MONDO:0002697,ovarian gonadoblastoma (disease),MONDO:0010768,gonadoblastoma,UBERON:0000992,ovary
-MONDO:0002227,ovarian lymphoma,MONDO:0005062,lymphoma,UBERON:0000992,ovary
-MONDO:0002223,ovarian malignant mesothelioma,MONDO:0006292,malignant mesothelioma (disease),UBERON:0000992,ovary
-MONDO:0000543,ovarian melanoma,MONDO:0005105,melanoma (disease),UBERON:0000992,ovary
-MONDO:0005601,ovarian mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0000992,ovary
-MONDO:0003887,ovarian mucinous adenofibroma,MONDO:0002398,mucinous adenofibroma,UBERON:0000992,ovary
-MONDO:0002701,ovarian mucinous cystadenocarcinoma,MONDO:0005858,mucinous cystadenocarcinoma,UBERON:0000992,ovary
-MONDO:0021068,ovarian neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000992,ovary
-MONDO:0004185,ovarian serous cystadenofibroma,MONDO:0005182,serous cystadenofibroma,UBERON:0000992,ovary
-MONDO:0003494,ovarian squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000992,ovary
-MONDO:0003495,ovarian squamous cell neoplasm,MONDO:0002532,squamous cell neoplasm,UBERON:0000992,ovary
-MONDO:0002230,ovarian wilms tumor,MONDO:0006058,Wilms tumor,UBERON:0000992,ovary
-MONDO:0002752,ovary adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000992,ovary
-MONDO:0003355,ovary leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0000992,ovary
-MONDO:0002481,ovary neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0000992,ovary
-MONDO:0003874,ovary papillary carcinoma,MONDO:0006509,papillary carcinoma,UBERON:0000992,ovary
-MONDO:0002858,ovary rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0000992,ovary
-MONDO:0002225,ovary sarcoma,MONDO:0005089,sarcoma,UBERON:0000992,ovary
-MONDO:0003625,ovary serous adenocarcinoma,MONDO:0005278,serous adenocarcinoma,UBERON:0000992,ovary
-MONDO:0002830,ovary transitional cell carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0000992,ovary
-MONDO:0006345,palmar fibromatosis,MONDO:0005031,fibromatosis,UBERON:0008878,palmar part of manus
-MONDO:0002356,pancreas disease,MONDO:0000001,disease,UBERON:0001264,pancreas
-MONDO:0002114,pancreas lymphoma,MONDO:0005062,lymphoma,UBERON:0001264,pancreas
-MONDO:0002117,pancreas sarcoma,MONDO:0005089,sarcoma,UBERON:0001264,pancreas
-MONDO:0006346,pancreatic acinar cell carcinoma,MONDO:0004993,carcinoma,CL:0002064,pancreatic acinar cell
-MONDO:0006047,pancreatic adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001264,pancreas
-MONDO:0005614,pancreatic adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0001264,pancreas
-MONDO:0005184,pancreatic ductal adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0007329,pancreatic duct
-MONDO:0005893,pancreatic endocrine carcinoma,MONDO:0004993,carcinoma,UBERON:0000016,endocrine pancreas
-MONDO:0021076,pancreatic exocrine neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000017,exocrine pancreas
-MONDO:0006347,pancreatic large cell neuroendocrine carcinoma,MONDO:0005057,large cell neuroendocrine carcinoma,UBERON:0001264,pancreas
-MONDO:0021040,pancreatic neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001264,pancreas
-MONDO:0005815,pancreatic neuroendocrine neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000016,endocrine pancreas
-MONDO:0003630,pancreatic serous cystadenocarcinoma,MONDO:0005278,serous adenocarcinoma,UBERON:0001264,pancreas
-MONDO:0002666,pancreatic signet ring cell adenocarcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0001264,pancreas
-MONDO:0006348,pancreatic small cell neuroendocrine carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0000016,endocrine pancreas
-MONDO:0005603,pancreatic tubular adenocarcinoma,MONDO:0005606,tubular adenocarcinoma,UBERON:0001264,pancreas
-MONDO:0016285,papillary carcinoma of the cervix uteri,MONDO:0006509,papillary carcinoma,UBERON:0000002,uterine cervix
-MONDO:0006049,papillary lung adenocarcinoma,MONDO:0002512,papillary adenocarcinoma,UBERON:0002048,lung
-MONDO:0003261,papillary meningioma of the cerebellum,MONDO:0021088,papillary meningioma,UBERON:0002037,cerebellum
-MONDO:0003443,papillary urothelial neoplasm,MONDO:0021096,papillary epithelial neoplasm,UBERON:0000365,urothelium
-MONDO:0001350,parametrium malignant neoplasm,MONDO:0004992,cancer,UBERON:0010391,parametrium
-MONDO:0006352,paranasal sinus adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0001825,paranasal sinus
-MONDO:0000380,paranasal sinus cancer,MONDO:0004992,cancer,UBERON:0001825,paranasal sinus
-MONDO:0001735,paranasal sinus disease,MONDO:0000001,disease,UBERON:0001825,paranasal sinus
-MONDO:0001743,paranasal sinus lymphoma,MONDO:0005062,lymphoma,UBERON:0001825,paranasal sinus
-MONDO:0001758,paranasal sinus sarcoma,MONDO:0005089,sarcoma,UBERON:0001825,paranasal sinus
-MONDO:0018215,paraneoplastic neurologic syndrome,MONDO:0021073,paraneoplastic syndrome,UBERON:0001016,nervous system
-MONDO:0021052,parasympathetic paraganglioma,MONDO:0000448,paraganglioma,UBERON:0000011,parasympathetic nervous system
-MONDO:0006890,parathyroid gland adenoma,MONDO:0004972,adenoma,UBERON:0001132,parathyroid gland
-MONDO:0012004,parathyroid gland carcinoma,MONDO:0004993,carcinoma,UBERON:0001132,parathyroid gland
-MONDO:0001223,parathyroid gland disease,MONDO:0000001,disease,UBERON:0001132,parathyroid gland
-MONDO:0006354,parathyroid hyperplasia (disease),MONDO:0005043,hyperplasia,UBERON:0001132,parathyroid gland
-MONDO:0001869,paraurethral gland cancer,MONDO:0004992,cancer,UBERON:0010145,paraurethral gland
-MONDO:0000520,parietal lobe ependymoma,MONDO:0016698,ependymoma,UBERON:0001872,parietal lobe
-MONDO:0001952,parietal lobe neoplasm,MONDO:0004992,cancer,UBERON:0001872,parietal lobe
-MONDO:0005899,parotid disease,MONDO:0000001,disease,UBERON:0001831,parotid gland
-MONDO:0006355,parotid gland acinic cell carcinoma,MONDO:0004965,acinar cell carcinoma,UBERON:0001831,parotid gland
-MONDO:0006356,parotid gland adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0001831,parotid gland
-MONDO:0004700,parotid gland cancer,MONDO:0004992,cancer,UBERON:0001831,parotid gland
-MONDO:0006357,parotid gland carcinoma ex pleomorphic adenoma,MONDO:0002472,carcinoma ex pleomorphic adenoma,UBERON:0001831,parotid gland
-MONDO:0006358,parotid gland squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001831,parotid gland
-MONDO:0005902,peanut allergic reaction,MONDO:0006872,nut allergic reaction,CL:0002303,pigmented ciliary epithelial cell
-MONDO:0001325,penile cancer,MONDO:0004992,cancer,UBERON:0000989,penis
-MONDO:0006360,penile carcinoma,MONDO:0004993,carcinoma,UBERON:0000989,penis
-MONDO:0002036,penile disease,MONDO:0000001,disease,UBERON:0000989,penis
-MONDO:0006361,penile fibromatosis,MONDO:0005031,fibromatosis,UBERON:0000989,penis
-MONDO:0002653,penis Paget's disease,MONDO:0002648,mammary Paget's disease,UBERON:0000989,penis
-MONDO:0002935,penis basal cell carcinoma,MONDO:0005341,skin basal cell carcinoma,UBERON:0000989,penis
-MONDO:0004089,penis basaloid carcinoma,MONDO:0003486,basaloid squamous cell carcinoma,UBERON:0000989,penis
-MONDO:0004671,penis carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000989,penis
-MONDO:0004433,penis papillary carcinoma,MONDO:0006509,papillary carcinoma,UBERON:0000989,penis
-MONDO:0001387,penis sarcoma,MONDO:0005089,sarcoma,UBERON:0000989,penis
-MONDO:0003484,penis squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000989,penis
-MONDO:0003698,penis verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0000989,penis
-MONDO:0004465,periampullary adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0012273,periampullary region of duodenum
-MONDO:0004337,perianal skin Paget's disease,MONDO:0002648,mammary Paget's disease,UBERON:0012336,perianal skin
-MONDO:0001322,pericardium cancer,MONDO:0004992,cancer,UBERON:0002407,pericardium
-MONDO:0000474,pericardium disease,MONDO:0000001,disease,UBERON:0002407,pericardium
-MONDO:0003294,pericardium leiomyoma,MONDO:0001572,leiomyoma,UBERON:0002407,pericardium
-MONDO:0002635,periodontal disease,MONDO:0000001,disease,UBERON:0001758,periodontium
-MONDO:0021089,peripheral nervous system cancer,MONDO:0004992,cancer,UBERON:0000010,peripheral nervous system
-MONDO:0003620,peripheral nervous system disease,MONDO:0000001,disease,UBERON:0000010,peripheral nervous system
-MONDO:0001406,peripheral nervous system neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000010,peripheral nervous system
-MONDO:0002981,peripheral primitive neuroectodermal tumor of bone,MONDO:0018271,peripheral primitive neuroectodermal tumor,UBERON:0002481,bone tissue
-MONDO:0002113,peritoneal carcinoma,MONDO:0004993,carcinoma,UBERON:0002358,peritoneum
-MONDO:0006362,peritoneal mesothelioma (disease),MONDO:0005065,mesothelioma,UBERON:0002358,peritoneum
-MONDO:0003195,peritoneal serous adenocarcinoma,MONDO:0005278,serous adenocarcinoma,UBERON:0002358,peritoneum
-MONDO:0002087,peritoneum cancer,MONDO:0004992,cancer,UBERON:0002358,peritoneum
-MONDO:0000516,phalanx chondroma,MONDO:0002360,chondroma,UBERON:0003221,phalanx
-MONDO:0005517,pharynx cancer,MONDO:0004992,cancer,UBERON:0006562,pharynx
-MONDO:0000372,pharynx carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0006562,pharynx
-MONDO:0000536,pharynx squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0006562,pharynx
-MONDO:0003168,pilocytic astrocytoma of cerebellum,MONDO:0016691,pilocytic astrocytoma,UBERON:0002037,cerebellum
-MONDO:0003171,pineal gland astrocytoma,MONDO:0019781,astrocytoma,UBERON:0001905,pineal body
-MONDO:0003249,pineal gland cancer,MONDO:0004992,cancer,UBERON:0001905,pineal body
-MONDO:0003399,pineal region yolk sac tumor,MONDO:0019495,yolk sac tumor,UBERON:0001905,pineal body
-MONDO:0017582,pituitary adenocarcinoma (disease),MONDO:0004970,adenocarcinoma,UBERON:0000007,pituitary gland
-MONDO:0006373,pituitary gland adenoma,MONDO:0004972,adenoma,UBERON:0000007,pituitary gland
-MONDO:0003381,pituitary gland disease,MONDO:0000001,disease,UBERON:0000007,pituitary gland
-MONDO:0004447,pituitary stalk meningioma,MONDO:0016642,meningioma (disease),UBERON:0002434,pituitary stalk
-MONDO:0002178,placenta cancer,MONDO:0004992,cancer,UBERON:0001987,placenta
-MONDO:0005917,placenta disease,MONDO:0000001,disease,UBERON:0001987,placenta
-MONDO:0006374,placental choriocarcinoma,MONDO:0005207,choriocarcinoma (disease),UBERON:0001987,placenta
-MONDO:0006375,placental hemangioma,MONDO:0006500,hemangioma,UBERON:0001987,placenta
-MONDO:0004684,plantar fibromatosis,MONDO:0016037,superficial fibromatosis,UBERON:0008338,plantar part of pes
-MONDO:0002765,plantar verrucous skin carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0008338,plantar part of pes
-MONDO:0002037,pleural disease,MONDO:0000001,disease,UBERON:0000977,pleura
-MONDO:0000969,pleural lipoma,MONDO:0005106,lipoma,UBERON:0000977,pleura
-MONDO:0021065,pleural neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002402,pleural cavity
-MONDO:0021041,pleural solitary fibrous tumor,MONDO:0016238,solitary fibrous tumor,UBERON:0002402,pleural cavity
-MONDO:0005922,pleural tuberculosis,MONDO:0018076,tuberculosis,UBERON:0000977,pleura
-MONDO:0001339,portal vein thrombosis,MONDO:0000831,thrombotic disease,UBERON:0002017,portal vein
-MONDO:0003068,postauricular lymphadenitis,MONDO:0002052,lymphadenitis (disease),UBERON:0016392,mastoid lymph node
-MONDO:0002919,posterior cranial fossa meningioma,MONDO:0016642,meningioma (disease),UBERON:0008788,posterior cranial fossa
-MONDO:0002972,posterior mediastinum cancer,MONDO:0004992,cancer,UBERON:0008822,posterior mediastinum
-MONDO:0001653,prepuce cancer,MONDO:0004992,cancer,UBERON:0011374,prepuce
-MONDO:0002834,primary prostate urothelial carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0002367,prostate gland
-MONDO:0005082,prostate adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002367,prostate gland
-MONDO:0003177,prostate adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0002367,prostate gland
-MONDO:0003033,prostate angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0002367,prostate gland
-MONDO:0008315,prostate cancer,MONDO:0004992,cancer,UBERON:0002367,prostate gland
-MONDO:0005159,prostate carcinoma,MONDO:0004993,carcinoma,UBERON:0002367,prostate gland
-MONDO:0004623,prostate carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0002367,prostate gland
-MONDO:0003105,prostate disease,MONDO:0000001,disease,UBERON:0002367,prostate gland
-MONDO:0002574,prostate embryonal rhabdomyosarcoma,MONDO:0009993,embryonal rhabdomyosarcoma (disease),UBERON:0002367,prostate gland
-MONDO:0002452,prostate leiomyoma,MONDO:0001572,leiomyoma,UBERON:0002367,prostate gland
-MONDO:0003368,prostate leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002367,prostate gland
-MONDO:0000996,prostate lymphoma,MONDO:0005062,lymphoma,UBERON:0002367,prostate gland
-MONDO:0002477,prostate neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0002367,prostate gland
-MONDO:0021102,prostate phyllodes tumor,MONDO:0005078,phyllodes tumor,UBERON:0002367,prostate gland
-MONDO:0006389,prostate rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0002367,prostate gland
-MONDO:0002854,prostate sarcoma,MONDO:0005089,sarcoma,UBERON:0002367,prostate gland
-MONDO:0002672,prostate signet ring cell adenocarcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0002367,prostate gland
-MONDO:0000993,prostate squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002367,prostate gland
-MONDO:0002450,prostatic adenoma,MONDO:0004972,adenoma,UBERON:0002367,prostate gland
-MONDO:0003506,pulmonary artery choriocarcinoma,MONDO:0005207,choriocarcinoma (disease),UBERON:0002012,pulmonary artery
-MONDO:0004207,pulmonary artery leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002012,pulmonary artery
-MONDO:0000266,pulmonary aspergilloma,MONDO:0005657,aspergillosis,UBERON:0002048,lung
-MONDO:0005933,pulmonary blastoma,MONDO:0005565,blastoma,UBERON:0002048,lung
-MONDO:0005616,pulmonary mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0002048,lung
-MONDO:0001708,pulmonary sarcoidosis,MONDO:0019338,sarcoidosis,UBERON:0002048,lung
-MONDO:0003628,pulmonary valve disease,MONDO:0000001,disease,UBERON:0002146,pulmonary valve
-MONDO:0004206,pulmonary vein leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002016,pulmonary vein
-MONDO:0002285,pupil disease,MONDO:0000001,disease,UBERON:0001771,pupil
-MONDO:0001062,pyloric antrum cancer,MONDO:0004992,cancer,UBERON:0001165,pyloric antrum
-MONDO:0006391,pyloric gland adenoma,MONDO:0004972,adenoma,UBERON:0008861,pyloric gastric gland
-MONDO:0001061,pylorus cancer,MONDO:0004992,cancer,UBERON:0001166,pylorus
-MONDO:0020036,rare nervous system tumor,MONDO:0020031,rare tumor,UBERON:0001016,nervous system
-MONDO:0015936,rare tumor of endocrine glands,MONDO:0020031,rare tumor,UBERON:0002368,endocrine gland
-MONDO:0001593,rectal disease,MONDO:0000001,disease,UBERON:0001052,rectum
-MONDO:0004196,rectal sarcomatoid carcinoma,MONDO:0002838,spindle cell carcinoma,UBERON:0001052,rectum
-MONDO:0006396,rectal villous adenoma,MONDO:0000502,villous adenoma,UBERON:0001052,rectum
-MONDO:0002424,rectosigmoid carcinoma,MONDO:0004993,carcinoma,UBERON:0036214,rectosigmoid junction
-MONDO:0002425,rectosigmoid junction cancer,MONDO:0004992,cancer,UBERON:0036214,rectosigmoid junction
-MONDO:0002423,rectosigmoid junction neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0036214,rectosigmoid junction
-MONDO:0003796,rectum Kaposi's sarcoma,MONDO:0005055,Kaposi's sarcoma (disease),UBERON:0001052,rectum
-MONDO:0002169,rectum adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001052,rectum
-MONDO:0000530,rectum adenoma,MONDO:0004972,adenoma,UBERON:0001052,rectum
-MONDO:0004725,rectum carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0001052,rectum
-MONDO:0004125,rectum leiomyoma,MONDO:0001572,leiomyoma,UBERON:0001052,rectum
-MONDO:0003379,rectum leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001052,rectum
-MONDO:0002166,rectum lymphoma,MONDO:0005062,lymphoma,UBERON:0001052,rectum
-MONDO:0002167,rectum malignant melanoma,MONDO:0005105,melanoma (disease),UBERON:0001052,rectum
-MONDO:0002748,rectum mucinous adenocarcinoma,MONDO:0004957,mucinous adenocarcinoma,UBERON:0001052,rectum
-MONDO:0003646,rectum neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0001052,rectum
-MONDO:0002853,rectum rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0001052,rectum
-MONDO:0002168,rectum sarcoma,MONDO:0005089,sarcoma,UBERON:0001052,rectum
-MONDO:0004336,rectum signet ring adenocarcinoma,MONDO:0005092,signet ring cell carcinoma,UBERON:0001052,rectum
-MONDO:0003491,rectum squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001052,rectum
-MONDO:0001876,renal artery atheroma,MONDO:0005311,atherosclerosis,UBERON:0001184,renal artery
-MONDO:0005206,renal carcinoma,MONDO:0004993,carcinoma,UBERON:0002113,kidney
-MONDO:0005086,renal cell carcinoma (disease),MONDO:0004970,adenocarcinoma,UBERON:0002113,kidney
-MONDO:0003205,renal pelvis adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001224,renal pelvis
-MONDO:0005519,renal pelvis carcinoma,MONDO:0004992,cancer,UBERON:0001224,renal pelvis
-MONDO:0003776,renal pelvis inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0001224,renal pelvis
-MONDO:0003497,renal pelvis squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001224,renal pelvis
-MONDO:0005938,renal tuberculosis,MONDO:0018076,tuberculosis,UBERON:0002113,kidney
-MONDO:0000383,reproductive organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0003133,reproductive organ
-MONDO:0002149,reproductive organ cancer,MONDO:0004992,cancer,UBERON:0003133,reproductive organ
-MONDO:0005039,reproductive system disease,MONDO:0000001,disease,UBERON:0000990,reproductive system
-MONDO:0000382,respiratory system benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0001004,respiratory system
-MONDO:0000376,respiratory system cancer,MONDO:0004992,cancer,UBERON:0001004,respiratory system
-MONDO:0005087,respiratory system disease,MONDO:0000001,disease,UBERON:0001004,respiratory system
-MONDO:0003191,rete ovarii adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0010185,rete ovarii
-MONDO:0004005,rete ovarii adenoma,MONDO:0004972,adenoma,UBERON:0010185,rete ovarii
-MONDO:0004006,rete ovarii cystadenofibroma,MONDO:0003464,cystadenofibroma,UBERON:0010185,rete ovarii
-MONDO:0003610,rete ovarii cystadenoma,MONDO:0002369,cystadenoma,UBERON:0010185,rete ovarii
-MONDO:0001992,rete testis adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0003959,rete testis
-MONDO:0003893,rete testis adenoma,MONDO:0004972,adenoma,UBERON:0003959,rete testis
-MONDO:0009975,reticulum cell sarcoma,MONDO:0005089,sarcoma,CL:0000432,reticular cell
-MONDO:0004349,retina lymphoma,MONDO:0005062,lymphoma,UBERON:0000966,retina
-MONDO:0003072,retinal cancer,MONDO:0004992,cancer,UBERON:0000966,retina
-MONDO:0004338,retinal cell cancer,MONDO:0004992,cancer,CL:0009004,retinal cell
-MONDO:0003343,retinal hemangioblastoma,MONDO:0016748,hemangioblastoma,UBERON:0004864,vasculature of retina
-MONDO:0008380,retinoblastoma,MONDO:0005072,neuroblastoma,UBERON:0000966,retina
-MONDO:0005283,retinopathy,MONDO:0005328,eye disease,UBERON:0000966,retina
-MONDO:0001499,retroperitoneal lymphoma,MONDO:0005062,lymphoma,UBERON:0003693,retroperitoneal space
-MONDO:0000551,retroperitoneal neuroblastoma,MONDO:0005072,neuroblastoma,UBERON:0003693,retroperitoneal space
-MONDO:0001501,retroperitoneal sarcoma,MONDO:0005089,sarcoma,UBERON:0003693,retroperitoneal space
-MONDO:0001502,retroperitoneum carcinoma,MONDO:0004993,carcinoma,UBERON:0003693,retroperitoneal space
-MONDO:0016282,rhabdomyosarcoma of the cervix uteri,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0000002,uterine cervix
-MONDO:0003627,rheumatic pulmonary valve disease,MONDO:0005554,rheumatologic disorder,UBERON:0002146,pulmonary valve
-MONDO:0001352,round ligament malignant neoplasm,MONDO:0004992,cancer,UBERON:0006589,round ligament of uterus
-MONDO:0000518,sacrum chordoma,MONDO:0008978,chordoma (disease),UBERON:0003690,fused sacrum
-MONDO:0003175,salivary gland adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0001044,saliva-secreting gland
-MONDO:0004669,salivary gland cancer,MONDO:0004992,cancer,UBERON:0001044,saliva-secreting gland
-MONDO:0000521,salivary gland carcinoma,MONDO:0004993,carcinoma,UBERON:0001044,saliva-secreting gland
-MONDO:0006403,salivary gland carcinoma ex pleomorphic adenoma,MONDO:0002472,carcinoma ex pleomorphic adenoma,UBERON:0001044,saliva-secreting gland
-MONDO:0001142,salivary gland disease,MONDO:0000001,disease,UBERON:0001044,saliva-secreting gland
-MONDO:0006404,salivary gland large cell carcinoma,MONDO:0005232,large cell carcinoma,UBERON:0001044,saliva-secreting gland
-MONDO:0006405,salivary gland small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0001044,saliva-secreting gland
-MONDO:0016280,sarcoma of cervix uteri,MONDO:0005089,sarcoma,UBERON:0000002,uterine cervix
-MONDO:0004307,sarcomatosis of the meninges,MONDO:0004309,sarcomatosis,UBERON:0010743,meningeal cluster
-MONDO:0003980,schwannoma of jugular foramen,MONDO:0002546,schwannoma,UBERON:0005456,jugular foramen
-MONDO:0002549,schwannoma of twelfth cranial nerve,MONDO:0002546,schwannoma,UBERON:0001650,hypoglossal nerve
-MONDO:0001400,schwannoma of ureter,MONDO:0002546,schwannoma,UBERON:0000056,ureter
-MONDO:0001269,scleral disease,MONDO:0000001,disease,UBERON:0001773,sclera
-MONDO:0003951,scrotal angioma,MONDO:0006500,hemangioma,UBERON:0001300,scrotum
-MONDO:0002650,scrotal carcinoma,MONDO:0004993,carcinoma,UBERON:0001300,scrotum
-MONDO:0002649,scrotum Paget's disease,MONDO:0002648,mammary Paget's disease,UBERON:0001300,scrotum
-MONDO:0002936,scrotum basal cell carcinoma,MONDO:0002650,scrotal carcinoma,CL:0000646,basal cell
-MONDO:0021112,scrotum cancer,MONDO:0004992,cancer,UBERON:0001300,scrotum
-MONDO:0001652,scrotum melanoma,MONDO:0005105,melanoma (disease),UBERON:0001300,scrotum
-MONDO:0003319,scrotum neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001300,scrotum
-MONDO:0001651,scrotum squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001300,scrotum
-MONDO:0006962,sebaceous adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0001821,sebaceous gland
-MONDO:0002375,sebaceous adenoma,MONDO:0004972,adenoma,UBERON:0001821,sebaceous gland
-MONDO:0019286,sebaceous gland anomaly,MONDO:0019277,epidermal appendage anomaly,UBERON:0001821,sebaceous gland
-MONDO:0006607,sebaceous gland disease,MONDO:0000001,disease,UBERON:0001821,sebaceous gland
-MONDO:0006963,sebaceous gland neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001821,sebaceous gland
-MONDO:0006609,seborrheic infantile dermatitis,MONDO:0006608,seborrheic dermatitis (disease),UBERON:0000403,scalp
-MONDO:0001993,seminal vesicle adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000998,seminal vesicle
-MONDO:0003609,seminal vesicle cystadenoma,MONDO:0002369,cystadenoma,UBERON:0000998,seminal vesicle
-MONDO:0000633,sensory organ benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000020,sense organ
-MONDO:0000649,sensory system cancer,MONDO:0004992,cancer,UBERON:0001032,sensory system
-MONDO:0005128,sensory system disease,MONDO:0000001,disease,UBERON:0001032,sensory system
-MONDO:0006969,sialadenitis,MONDO:0002052,lymphadenitis (disease),UBERON:0001044,saliva-secreting gland
-MONDO:0001464,sigmoid colon cancer,MONDO:0004992,cancer,UBERON:0001159,sigmoid colon
-MONDO:0006971,sigmoid neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001159,sigmoid colon
-MONDO:0000469,sinoatrial node disease,MONDO:0000001,disease,UBERON:0002351,sinoatrial node
-MONDO:0002847,skeletal muscle cancer,MONDO:0004992,cancer,UBERON:0014895,somatic muscle
-MONDO:0020120,skeletal muscle disease,MONDO:0000001,disease,UBERON:0001134,skeletal muscle tissue
-MONDO:0005172,skeletal system disease,MONDO:0000001,disease,UBERON:0001434,skeletal system
-MONDO:0005962,skeletal tuberculosis,MONDO:0018076,tuberculosis,UBERON:0002204,musculoskeletal system
-MONDO:0000932,skin amelanotic melanoma,MONDO:0002971,amelanotic melanoma,UBERON:0000014,zone of skin
-MONDO:0003029,skin angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0000014,zone of skin
-MONDO:0006973,skin appendage carcinoma,MONDO:0004993,carcinoma,UBERON:0000021,cutaneous appendage
-MONDO:0002898,skin cancer,MONDO:0004992,cancer,UBERON:0000014,zone of skin
-MONDO:0002656,skin carcinoma,MONDO:0004993,carcinoma,UBERON:0000014,zone of skin
-MONDO:0004641,skin carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000014,zone of skin
-MONDO:0001939,skin epithelioid hemangioma,MONDO:0003119,histiocytoid hemangioma,UBERON:0000014,zone of skin
-MONDO:0002298,skin glomangioma,MONDO:0002299,glomangioma,UBERON:0000014,zone of skin
-MONDO:0002295,skin glomus tumor,MONDO:0018327,glomus tumor,UBERON:0000014,zone of skin
-MONDO:0003110,skin hemangioma,MONDO:0006500,hemangioma,UBERON:0000014,zone of skin
-MONDO:0000964,skin lipoma,MONDO:0005106,lipoma,UBERON:0000014,zone of skin
-MONDO:0004429,skin meningioma,MONDO:0016642,meningioma (disease),UBERON:0000014,zone of skin
-MONDO:0002531,skin neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000014,zone of skin
-MONDO:0002536,skin papilloma,MONDO:0002363,papilloma,UBERON:0000014,zone of skin
-MONDO:0006611,skin sarcoidosis,MONDO:0019338,sarcoidosis,UBERON:0000014,zone of skin
-MONDO:0006414,skin sarcoma,MONDO:0005089,sarcoma,UBERON:0000014,zone of skin
-MONDO:0002529,skin squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000014,zone of skin
-MONDO:0019293,skin vascular disease,MONDO:0000001,disease,UBERON:0035549,superficial vasculature
-MONDO:0002998,skull base meningioma,MONDO:0016642,meningioma (disease),UBERON:0002517,basicranium
-MONDO:0002132,skull cancer,MONDO:0004992,cancer,UBERON:0003129,skull
-MONDO:0018272,small cell carcinoma of the ovary,MONDO:0000402,small cell carcinoma,UBERON:0000992,ovary
-MONDO:0008433,small cell lung carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0002048,lung
-MONDO:0006416,small intestinal Burkitt lymphoma,MONDO:0007243,Burkitts lymphoma,UBERON:0002108,small intestine
-MONDO:0006417,small intestinal diffuse large b-cell lymphoma,MONDO:0018905,diffuse large B-cell lymphoma,UBERON:0002108,small intestine
-MONDO:0004028,small intestinal fibrosarcoma,MONDO:0005164,fibrosarcoma (disease),UBERON:0002108,small intestine
-MONDO:0003198,small intestine adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002108,small intestine
-MONDO:0000956,small intestine cancer,MONDO:0004992,cancer,UBERON:0002108,small intestine
-MONDO:0005522,small intestine carcinoma,MONDO:0004993,carcinoma,UBERON:0002108,small intestine
-MONDO:0001229,small intestine diverticulitis,MONDO:0004235,diverticulitis,UBERON:0002108,small intestine
-MONDO:0002092,small intestine leiomyoma,MONDO:0001572,leiomyoma,UBERON:0002108,small intestine
-MONDO:0003360,small intestine leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0002108,small intestine
-MONDO:0001852,small intestine lymphoma,MONDO:0005062,lymphoma,UBERON:0002108,small intestine
-MONDO:0002995,small intestine neuroendocrine neoplasm,MONDO:0019496,neuroendocrine tumor,UBERON:0002108,small intestine
-MONDO:0004611,soft palate cancer,MONDO:0004992,cancer,UBERON:0001733,soft palate
-MONDO:0002756,solitary plasmacytoma of chest wall,MONDO:0005615,plasmacytoma,UBERON:0016435,chest wall
-MONDO:0001654,spermatic cord cancer,MONDO:0004992,cancer,UBERON:0005352,spermatic cord
-MONDO:0004326,sphenoid sinus inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0001724,sphenoidal sinus
-MONDO:0001995,sphenoid sinus squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001724,sphenoidal sinus
-MONDO:0005964,sphenoid sinusitis,MONDO:0005961,sinusitis,UBERON:0001677,sphenoid bone
-MONDO:0001994,sphenoidal sinus cancer,MONDO:0004992,cancer,UBERON:0001724,sphenoidal sinus
-MONDO:0002626,spinal accessory nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0009674,accessory XI nerve spinal component
-MONDO:0003174,spinal cord astrocytoma,MONDO:0019781,astrocytoma,UBERON:0002240,spinal cord
-MONDO:0003544,spinal cord cancer,MONDO:0004992,cancer,UBERON:0002240,spinal cord
-MONDO:0004096,spinal cord dermoid cyst,MONDO:0002378,dermoid cyst,UBERON:0002240,spinal cord
-MONDO:0002545,spinal cord disease,MONDO:0000001,disease,UBERON:0002240,spinal cord
-MONDO:0002542,spinal cord glioma,MONDO:0015917,malignant glioma,UBERON:0002240,spinal cord
-MONDO:0001790,spinal cord lipoma,MONDO:0005106,lipoma,UBERON:0002240,spinal cord
-MONDO:0001892,spinal cord lymphoma,MONDO:0005062,lymphoma,UBERON:0002240,spinal cord
-MONDO:0001893,spinal cord melanoma,MONDO:0005105,melanoma (disease),UBERON:0002240,spinal cord
-MONDO:0004024,spinal cord neuroblastoma,MONDO:0005072,neuroblastoma,UBERON:0002240,spinal cord
-MONDO:0002541,spinal cord oligodendroglioma,MONDO:0016695,oligodendroglioma,UBERON:0002240,spinal cord
-MONDO:0001894,spinal cord sarcoma,MONDO:0005089,sarcoma,UBERON:0002240,spinal cord
-MONDO:0005309,spinal fracture,MONDO:0005315,bone fracture,UBERON:0001130,vertebral column
-MONDO:0004151,spinal meninges cancer,MONDO:0004992,cancer,UBERON:0003292,meninx of spinal cord
-MONDO:0001275,spinal meningioma,MONDO:0016642,meningioma (disease),UBERON:0002240,spinal cord
-MONDO:0002376,spleen angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0002106,spleen
-MONDO:0005966,spleen cancer,MONDO:0004992,cancer,UBERON:0002106,spleen
-MONDO:0002332,splenic disease,MONDO:0000001,disease,UBERON:0002106,spleen
-MONDO:0001463,splenic flexure cancer,MONDO:0004992,cancer,UBERON:0022276,splenic flexure of colon
-MONDO:0002343,splenic hemangioma,MONDO:0006500,hemangioma,UBERON:0002106,spleen
-MONDO:0003500,squamous cell bile duct carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002394,bile duct
-MONDO:0006056,squamous cell breast carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000310,breast
-MONDO:0005097,squamous cell lung carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002048,lung
-MONDO:0004204,squamous cell papilloma of skin,MONDO:0001825,squamous papilloma,UBERON:0000014,zone of skin
-MONDO:0003273,sternum cancer,MONDO:0004992,cancer,UBERON:0000975,sternum
-MONDO:0003988,sternum lymphoma,MONDO:0005062,lymphoma,UBERON:0000975,sternum
-MONDO:0004716,stomach carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000945,stomach
-MONDO:0004298,stomach disease,MONDO:0000001,disease,UBERON:0000945,stomach
-MONDO:0000539,striated muscle rhabdoid tumor,MONDO:0002728,rhabdoid tumor,UBERON:0002036,striated muscle tissue
-MONDO:0019296,subcutaneous tissue disease,MONDO:0000001,disease,UBERON:0011818,superficial fascia
-MONDO:0001293,subglottis cancer,MONDO:0004992,cancer,UBERON:0036068,subglottis
-MONDO:0004358,subglottis carcinoma,MONDO:0004993,carcinoma,UBERON:0036068,subglottis
-MONDO:0000933,subglottis neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0036068,subglottis
-MONDO:0000545,sublingual gland adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0001832,sublingual gland
-MONDO:0004667,sublingual gland cancer,MONDO:0004992,cancer,UBERON:0001832,sublingual gland
-MONDO:0021070,sublingual gland carcinoma,MONDO:0004993,carcinoma,UBERON:0001832,sublingual gland
-MONDO:0003066,submandibular adenitis,MONDO:0002052,lymphadenitis (disease),UBERON:0001736,submandibular gland
-MONDO:0004724,submandibular gland cancer,MONDO:0004992,cancer,UBERON:0001736,submandibular gland
-MONDO:0001597,submandibular gland disease,MONDO:0000001,disease,UBERON:0001736,submandibular gland
-MONDO:0002687,superior mesenteric artery syndrome,MONDO:0002254,syndromic disease,UBERON:0001182,superior mesenteric artery
-MONDO:0003032,superior vena cava angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0001585,anterior vena cava
-MONDO:0004208,superior vena cava leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0001585,anterior vena cava
-MONDO:0015550,suprabasal epidermolysis bullosa simplex,MONDO:0017610,epidermolysis bullosa simplex,UBERON:0010402,epidermis suprabasal layer
-MONDO:0001724,supraglottis cancer,MONDO:0004992,cancer,UBERON:0036263
-MONDO:0004427,supraglottis neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0036263
-MONDO:0021110,sweat gland adenoma,MONDO:0004972,adenoma,UBERON:0001820,sweat gland
-MONDO:0002206,sweat gland cancer,MONDO:0004992,cancer,UBERON:0001820,sweat gland
-MONDO:0005524,sweat gland carcinoma,MONDO:0004993,carcinoma,UBERON:0001820,sweat gland
-MONDO:0006615,sweat gland disease,MONDO:0000001,disease,UBERON:0001820,sweat gland
-MONDO:0021072,sympathetic paraganglioma,MONDO:0000448,paraganglioma,UBERON:0000013,sympathetic nervous system
-MONDO:0004519,synovial angioma,MONDO:0006500,hemangioma,UBERON:0007616,layer of synovial tissue
-MONDO:0002403,synovium cancer,MONDO:0004992,cancer,UBERON:0007616,layer of synovial tissue
-MONDO:0005115,temporal lobe epilepsy,MONDO:0005027,epilepsy,UBERON:0001871,temporal lobe
-MONDO:0002218,temporal lobe neoplasm,MONDO:0004992,cancer,UBERON:0001871,temporal lobe
-MONDO:0006442,tendon sheath fibroma,MONDO:0005167,fibroma,UBERON:0000304,tendon sheath
-MONDO:0004076,tendon sheath lipoma,MONDO:0005106,lipoma,UBERON:0000304,tendon sheath
-MONDO:0002522,tenosynovial giant cell tumor,MONDO:0002171,giant cell tumor,UBERON:0000304,tendon sheath
-MONDO:0005447,testicular cancer,MONDO:0004992,cancer,UBERON:0000473,testis
-MONDO:0006445,testicular choriocarcinoma,MONDO:0005207,choriocarcinoma (disease),UBERON:0000473,testis
-MONDO:0002329,testicular disease,MONDO:0000001,disease,UBERON:0000473,testis
-MONDO:0002698,testicular gonadoblastoma (disease),MONDO:0010768,gonadoblastoma,UBERON:0000473,testis
-MONDO:0003395,testicular granulosa cell tumor,MONDO:0006036,granulosa cell tumor,UBERON:0000473,testis
-MONDO:0003124,testicular leydig cell tumor,MONDO:0006266,leydig cell tumor,UBERON:0000473,testis
-MONDO:0003669,testicular seminoma,MONDO:0003001,seminoma,UBERON:0000473,testis
-MONDO:0003125,testicular sex cord-stromal neoplasm,MONDO:0005958,sex cord-stromal tumor,UBERON:0000473,testis
-MONDO:0003402,testicular yolk sac tumor,MONDO:0019495,yolk sac tumor,UBERON:0000473,testis
-MONDO:0002860,testis rhabdomyosarcoma,MONDO:0005212,rhabdomyosarcoma (disease),UBERON:0000473,testis
-MONDO:0002861,testis sarcoma,MONDO:0005089,sarcoma,UBERON:0000473,testis
-MONDO:0003766,thalamic cancer,MONDO:0004992,cancer,UBERON:0001897,dorsal plus ventral thalamus
-MONDO:0003081,thalamic disease,MONDO:0000001,disease,UBERON:0001897,dorsal plus ventral thalamus
-MONDO:0003546,third cranial nerve disease,MONDO:0000001,disease,UBERON:0001643,oculomotor nerve
-MONDO:0002773,third ventricle chordoid glioma,MONDO:0016706,chordoid glioma,UBERON:0002286,third ventricle
-MONDO:0003274,thoracic cancer,MONDO:0004992,cancer,UBERON:0000915,thoracic segment of trunk
-MONDO:0000651,thoracic disease,MONDO:0000001,disease,UBERON:0000915,thoracic segment of trunk
-MONDO:0006451,thymic carcinoma,MONDO:0004993,carcinoma,UBERON:0002370,thymus
-MONDO:0006452,thymic sarcomatoid carcinoma,MONDO:0006406,sarcomatoid carcinoma,UBERON:0002370,thymus
-MONDO:0003209,thymus adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0002370,thymus
-MONDO:0003551,thymus adenosquamous carcinoma,MONDO:0006074,adenosquamous carcinoma,UBERON:0002370,thymus
-MONDO:0004092,thymus basaloid carcinoma,MONDO:0003486,basaloid squamous cell carcinoma,UBERON:0002370,thymus
-MONDO:0002586,thymus cancer,MONDO:0004992,cancer,UBERON:0002370,thymus
-MONDO:0003393,thymus gland disease,MONDO:0000001,disease,UBERON:0002370,thymus
-MONDO:0003047,thymus large cell carcinoma,MONDO:0005232,large cell carcinoma,UBERON:0002370,thymus
-MONDO:0002163,thymus lipoma,MONDO:0005106,lipoma,UBERON:0002370,thymus
-MONDO:0000951,thymus lymphoma,MONDO:0005062,lymphoma,UBERON:0002370,thymus
-MONDO:0003086,thymus mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0002370,thymus
-MONDO:0005197,thymus neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0002370,thymus
-MONDO:0004122,thymus small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0002370,thymus
-MONDO:0003493,thymus squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002370,thymus
-MONDO:0002454,thyroid adenoma (disease),MONDO:0004972,adenoma,UBERON:0002046,thyroid gland
-MONDO:0003027,thyroid angiosarcoma,MONDO:0016982,angiosarcoma (disease),UBERON:0002046,thyroid gland
-MONDO:0002108,thyroid cancer,MONDO:0004992,cancer,UBERON:0002046,thyroid gland
-MONDO:0015075,thyroid carcinoma (disease),MONDO:0004993,carcinoma,UBERON:0002046,thyroid gland
-MONDO:0003240,thyroid gland disease,MONDO:0000001,disease,UBERON:0002046,thyroid gland
-MONDO:0006463,thyroid gland mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0002046,thyroid gland
-MONDO:0019962,thyroid lymphoma,MONDO:0005062,lymphoma,UBERON:0002046,thyroid gland
-MONDO:0003028,thyroid sarcoma,MONDO:0005089,sarcoma,UBERON:0002046,thyroid gland
-MONDO:0006469,tibial adamantinoma,MONDO:0007063,long bone adamantinoma,UBERON:0000979,tibia
-MONDO:0001127,tibialis tendinitis,MONDO:0004857,tendinitis,UBERON:0008230,tibialis
-MONDO:0000242,tinea barbae,MONDO:0004678,dermatophytosis,UBERON:0010167,beard
-MONDO:0002967,tinea capitis,MONDO:0004678,dermatophytosis,UBERON:0000403,scalp
-MONDO:0001699,tinea manuum,MONDO:0004678,dermatophytosis,UBERON:0002398,manus
-MONDO:0005984,tinea pedis,MONDO:0004678,dermatophytosis,UBERON:0002387,pes
-MONDO:0001628,tinea unguium,MONDO:0004678,dermatophytosis,UBERON:0001705,nail
-MONDO:0004631,tongue cancer,MONDO:0004992,cancer,UBERON:0001723,tongue
-MONDO:0001165,tongue disease,MONDO:0000001,disease,UBERON:0001723,tongue
-MONDO:0000500,tongue squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0001723,tongue
-MONDO:0006998,tonsil cancer,MONDO:0004992,cancer,UBERON:0002372,tonsil
-MONDO:0000535,tonsil squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002372,tonsil
-MONDO:0004690,tonsillar fossa cancer,MONDO:0004992,cancer,UBERON:0035228,tonsillar fossa
-MONDO:0006470,tonsillar squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0002373,palatine tonsil
-MONDO:0008007,tooth ankylosis,MONDO:0002257,ankylosis (disease),UBERON:0001091,calcareous tooth
-MONDO:0006999,tooth disease,MONDO:0000001,disease,UBERON:0001091,calcareous tooth
-MONDO:0003184,trachea carcinoma,MONDO:0004993,carcinoma,UBERON:0003126,trachea
-MONDO:0004661,trachea carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0003126,trachea
-MONDO:0002318,trachea leiomyoma,MONDO:0001572,leiomyoma,UBERON:0003126,trachea
-MONDO:0000534,trachea mucoepidermoid carcinoma,MONDO:0003036,mucoepidermoid carcinoma,UBERON:0003126,trachea
-MONDO:0001418,trachea sarcoma,MONDO:0005089,sarcoma,UBERON:0003126,trachea
-MONDO:0001419,trachea squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0003126,trachea
-MONDO:0006471,tracheal adenoid cystic carcinoma,MONDO:0004971,adenoid cystic carcinoma,UBERON:0003126,trachea
-MONDO:0001407,tracheal cancer,MONDO:0004992,cancer,UBERON:0003126,trachea
-MONDO:0002567,tracheal disease,MONDO:0000001,disease,UBERON:0003126,trachea
-MONDO:0001417,tracheal lymphoma,MONDO:0005062,lymphoma,UBERON:0003126,trachea
-MONDO:0006474,transitional cell carcinoma,MONDO:0004993,carcinoma,CL:0000731,urothelial cell
-MONDO:0005221,transitional cell carcinoma of kidney,MONDO:0006474,transitional cell carcinoma,UBERON:0001224,renal pelvis
-MONDO:0016272,transitional cell carcinoma of the corpus uteri,MONDO:0006474,transitional cell carcinoma,UBERON:0009853,body of uterus
-MONDO:0002361,transverse colon cancer,MONDO:0004992,cancer,UBERON:0001157,transverse colon
-MONDO:0000471,tricuspid valve disease,MONDO:0000001,disease,UBERON:0002134,tricuspid valve
-MONDO:0003543,trigeminal nerve disease,MONDO:0000001,disease,UBERON:0001645,trigeminal nerve
-MONDO:0001420,trigeminal nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001645,trigeminal nerve
-MONDO:0007002,trochlear nerve disease,MONDO:0000001,disease,UBERON:0001644,trochlear nerve
-MONDO:0002642,trochlear nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001644,trochlear nerve
-MONDO:0016743,tumor of meninges,MONDO:0020036,rare nervous system tumor,UBERON:0010743,meningeal cluster
-MONDO:0003648,tympanic membrane disease,MONDO:0000001,disease,UBERON:0002364,tympanic membrane
-MONDO:0006476,undifferentiated gallbladder carcinoma,MONDO:0005617,undifferentiated carcinoma,UBERON:0002110,gall bladder
-MONDO:0006477,undifferentiated ovarian carcinoma,MONDO:0005617,undifferentiated carcinoma,UBERON:0000992,ovary
-MONDO:0004615,upper gum cancer,MONDO:0004992,cancer,UBERON:0011601,gingiva of upper jaw
-MONDO:0004621,upper lip cancer,MONDO:0004992,cancer,UBERON:0001834,upper lip
-MONDO:0004867,upper respiratory tract disease,MONDO:0000001,disease,UBERON:0001557,upper respiratory tract
-MONDO:0001378,urachus cancer,MONDO:0004992,cancer,UBERON:0002068,urachus
-MONDO:0003216,ureter adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000056,ureter
-MONDO:0001398,ureter benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000056,ureter
-MONDO:0008627,ureter cancer,MONDO:0004992,cancer,UBERON:0000056,ureter
-MONDO:0006481,ureter carcinoma,MONDO:0004993,carcinoma,UBERON:0000056,ureter
-MONDO:0004043,ureter inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0000056,ureter
-MONDO:0001399,ureter leiomyoma,MONDO:0001572,leiomyoma,UBERON:0000056,ureter
-MONDO:0021111,ureter neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000056,ureter
-MONDO:0006482,ureter small cell carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0000056,ureter
-MONDO:0003502,ureter squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000056,ureter
-MONDO:0004030,ureter transitional cell carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0000056,ureter
-MONDO:0004517,ureter tuberculosis,MONDO:0018076,tuberculosis,UBERON:0000056,ureter
-MONDO:0001926,ureteral disease,MONDO:0000001,disease,UBERON:0000056,ureter
-MONDO:0001977,ureteral lymphoma,MONDO:0005062,lymphoma,UBERON:0000056,ureter
-MONDO:0001379,ureteric orifice cancer,MONDO:0004992,cancer,UBERON:0012303,ureteral orifice
-MONDO:0003200,urethra adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000057,urethra
-MONDO:0004192,urethra cancer,MONDO:0004992,cancer,UBERON:0000057,urethra
-MONDO:0003387,urethra clear cell adenocarcinoma,MONDO:0005004,clear cell adenocarcinoma,UBERON:0000057,urethra
-MONDO:0002222,urethra leiomyoma,MONDO:0001572,leiomyoma,UBERON:0000057,urethra
-MONDO:0002764,urethra squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000057,urethra
-MONDO:0002836,urethra transitional cell carcinoma,MONDO:0006474,transitional cell carcinoma,UBERON:0000057,urethra
-MONDO:0004184,urethral disease,MONDO:0000001,disease,UBERON:0000057,urethra
-MONDO:0002221,urethral urothelial papilloma,MONDO:0004041,urothelial papilloma,UBERON:0000057,urethra
-MONDO:0002763,urethral verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0000057,urethra
-MONDO:0001187,urinary bladder cancer,MONDO:0004992,cancer,UBERON:0001255,urinary bladder
-MONDO:0004040,urinary bladder inverted papilloma,MONDO:0002537,inverted papilloma,UBERON:0001255,urinary bladder
-MONDO:0004114,urinary bladder small cell neuroendocrine carcinoma,MONDO:0000402,small cell carcinoma,UBERON:0001255,urinary bladder
-MONDO:0004272,urinary bladder tuberculosis,MONDO:0018076,tuberculosis,UBERON:0001255,urinary bladder
-MONDO:0003439,urinary bladder villous adenoma,MONDO:0000502,villous adenoma,UBERON:0001255,urinary bladder
-MONDO:0006001,urinary schistosomiasis,MONDO:0015254,schistosomiasis,UBERON:0001255,urinary bladder
-MONDO:0002118,urinary system disease,MONDO:0000001,disease,UBERON:0001008,renal system
-MONDO:0021066,urinary system neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001008,renal system
-MONDO:0006002,urogenital tuberculosis,MONDO:0018076,tuberculosis,UBERON:0004122,genitourinary system
-MONDO:0002715,uterine cancer,MONDO:0004992,cancer,UBERON:0000995,uterus
-MONDO:0005213,uterine carcinoma,MONDO:0004993,carcinoma,UBERON:0000995,uterus
-MONDO:0003458,uterine corpus adenofibroma,MONDO:0006071,adenofibroma,UBERON:0009853,body of uterus
-MONDO:0001781,uterine corpus adenomatoid tumor,MONDO:0004230,adenomatoid tumor,UBERON:0009853,body of uterus
-MONDO:0002878,uterine corpus adenosarcoma,MONDO:0005636,adenosarcoma,UBERON:0009853,body of uterus
-MONDO:0004386,uterine corpus atypical polypoid adenomyoma,MONDO:0003236,atypical polypoid adenomyoma,UBERON:0009853,body of uterus
-MONDO:0001846,uterine corpus bizarre leiomyoma,MONDO:0003288,bizarre leiomyoma,UBERON:0009853,body of uterus
-MONDO:0006003,uterine corpus cancer,MONDO:0004992,cancer,UBERON:0009853,body of uterus
-MONDO:0004162,uterine corpus cellular leiomyoma,MONDO:0003296,cellular leiomyoma,UBERON:0009853,body of uterus
-MONDO:0004491,uterine corpus choriocarcinoma,MONDO:0005207,choriocarcinoma (disease),UBERON:0009853,body of uterus
-MONDO:0000553,uterine corpus endometrial carcinoma,MONDO:0002447,endometrial carcinoma (disease),UBERON:0009853,body of uterus
-MONDO:0002923,uterine corpus endometrial stromal sarcoma,MONDO:0006745,endometrial stromal sarcoma,UBERON:0009853,body of uterus
-MONDO:0003782,uterine corpus epithelioid leiomyosarcoma,MONDO:0003356,epithelioid leiomyosarcoma,UBERON:0009853,body of uterus
-MONDO:0003703,uterine corpus leiomyomatosis,MONDO:0003295,leiomyomatosis,UBERON:0009853,body of uterus
-MONDO:0001845,uterine corpus lipoleiomyoma,MONDO:0006312,myofibroma,UBERON:0009853,body of uterus
-MONDO:0003928,uterine corpus myxoid leiomyosarcoma,MONDO:0003359,myxoid leiomyosarcoma,UBERON:0009853,body of uterus
-MONDO:0004221,uterine corpus perivascular epithelioid cell tumor,MONDO:0006359,neoplasm with perivascular epithelioid cell differentiation,UBERON:0009853,body of uterus
-MONDO:0003629,uterine corpus serous adenocarcinoma,MONDO:0005278,serous adenocarcinoma,UBERON:0009853,body of uterus
-MONDO:0002654,uterine disease,MONDO:0000001,disease,UBERON:0000995,uterus
-MONDO:0007886,uterine fibroid,MONDO:0005167,fibroma,UBERON:0000995,uterus
-MONDO:0003612,uterine ligament cancer,MONDO:0004992,cancer,UBERON:0036262
-MONDO:0005210,uterine sarcoma,MONDO:0005089,sarcoma,UBERON:0009853,body of uterus
-MONDO:0004710,uterus carcinoma in situ,MONDO:0004647,in situ carcinoma,UBERON:0000995,uterus
-MONDO:0003375,uterus leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0000995,uterus
-MONDO:0002659,uveal cancer,MONDO:0004992,cancer,UBERON:0001768,uvea
-MONDO:0002661,uveal disease,MONDO:0000001,disease,UBERON:0001768,uvea
-MONDO:0006486,uveal melanoma,MONDO:0005105,melanoma (disease),UBERON:0001768,uvea
-MONDO:0004624,uvula cancer,MONDO:0004992,cancer,UBERON:0001734,palatine uvula
-MONDO:0003994,vagina botryoid rhabdomyosarcoma,MONDO:0002578,botryoid rhabdomyosarcoma,UBERON:0000996,vagina
-MONDO:0001536,vagina leiomyoma,MONDO:0001572,leiomyoma,UBERON:0000996,vagina
-MONDO:0003369,vagina leiomyosarcoma,MONDO:0005058,leiomyosarcoma,UBERON:0000996,vagina
-MONDO:0002140,vagina sarcoma,MONDO:0005089,sarcoma,UBERON:0000996,vagina
-MONDO:0001402,vaginal cancer,MONDO:0004992,cancer,UBERON:0000996,vagina
-MONDO:0015867,vaginal carcinoma,MONDO:0004993,carcinoma,UBERON:0000996,vagina
-MONDO:0001433,vaginal disease,MONDO:0000001,disease,UBERON:0000996,vagina
-MONDO:0021050,vaginal neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0000996,vagina
-MONDO:0006490,vaginal squamous cell carcinoma,MONDO:0004993,carcinoma,CL:1001578,vagina squamous cell
-MONDO:0001535,vagus nerve disease,MONDO:0000001,disease,UBERON:0001759,vagus nerve
-MONDO:0001608,vagus nerve neoplasm,MONDO:0005070,neoplasm (disease),UBERON:0001759,vagus nerve
-MONDO:0004607,vallecula cancer,MONDO:0004992,cancer,UBERON:0013165,epiglottic vallecula
-MONDO:0002095,vascular cancer,MONDO:0004992,cancer,UBERON:0002012,pulmonary artery
-MONDO:0005385,vascular disease,MONDO:0000001,disease,UBERON:0002049,vasculature
-MONDO:0005329,vascular sarcoma,MONDO:0005089,sarcoma,UBERON:0001981,blood vessel
-MONDO:0004814,vascular skin disease,MONDO:0005093,skin disease,UBERON:0002049,vasculature
-MONDO:0004634,vein disease,MONDO:0000001,disease,UBERON:0001638,vein
-MONDO:0001631,vertebral artery insufficiency,MONDO:0002254,syndromic disease,UBERON:0001535,vertebral artery
-MONDO:0000812,vertebral column disease,MONDO:0000001,disease,UBERON:0001130,vertebral column
-MONDO:0002643,vestibular disease,MONDO:0000001,disease,UBERON:0004681,vestibular system
-MONDO:0000626,vestibular gland benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0011826,vestibular gland
-MONDO:0002194,vestibular papilloma,MONDO:0001825,squamous papilloma,UBERON:0000997,mammalian vulva
-MONDO:0001563,vestibulocochlear nerve disease,MONDO:0000001,disease,UBERON:0001648,vestibulocochlear nerve
-MONDO:0021084,vision disorder,MONDO:0000001,disease,UBERON:0002104,visual system
-MONDO:0003584,visual cortex disease,MONDO:0000001,disease,UBERON:0000411,visual cortex
-MONDO:0001834,visual pathway disease,MONDO:0000001,disease,UBERON:0001908,optic tract
-MONDO:0004860,vitreous disease,MONDO:0000001,disease,UBERON:0001797,vitreous humor
-MONDO:0002208,vulva adenocarcinoma,MONDO:0004970,adenocarcinoma,UBERON:0000997,mammalian vulva
-MONDO:0002955,vulva basal cell carcinoma,MONDO:0005341,skin basal cell carcinoma,UBERON:0000997,mammalian vulva
-MONDO:0001528,vulva cancer,MONDO:0004992,cancer,UBERON:0000997,mammalian vulva
-MONDO:0006620,vulva fibroepithelial polyp,MONDO:0004026,skin tag,UBERON:0000997,mammalian vulva
-MONDO:0005214,vulva sarcoma,MONDO:0005089,sarcoma,UBERON:0000997,mammalian vulva
-MONDO:0002210,vulva squamous cell carcinoma,MONDO:0005096,squamous cell carcinoma,UBERON:0000997,mammalian vulva
-MONDO:0002758,vulva verrucous carcinoma,MONDO:0006006,verrucous carcinoma,UBERON:0000997,mammalian vulva
-MONDO:0002192,vulvar angiokeratoma,MONDO:0003954,angiokeratoma of Fordyce,UBERON:0000997,mammalian vulva
-MONDO:0000643,vulvar benign neoplasm,MONDO:0005165,benign neoplasm,UBERON:0000997,mammalian vulva
-MONDO:0005215,vulvar carcinoma,MONDO:0004993,carcinoma,UBERON:0000997,mammalian vulva
-MONDO:0003253,vulvar granular cell tumor,MONDO:0006235,granular cell tumor,UBERON:0000997,mammalian vulva
-MONDO:0006622,vulvar seborrheic keratosis,MONDO:0008420,seborrheic keratosis,UBERON:0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0004120,Bartholin gland small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0003909,Bartholin's gland adenomyoma,http://purl.obolibrary.org/obo/MONDO_0005635,adenomyoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0005665,Bell's palsy,http://purl.obolibrary.org/obo/MONDO_0006496,palsy,http://purl.obolibrary.org/obo/UBERON_0001647,facial nerve
+http://purl.obolibrary.org/obo/MONDO_0003940,Kummell disease,http://purl.obolibrary.org/obo/MONDO_0005380,osteonecrosis,http://purl.obolibrary.org/obo/UBERON_0001075,bony vertebral centrum
+http://purl.obolibrary.org/obo/MONDO_0006576,Ludwig's angina,http://purl.obolibrary.org/obo/MONDO_0005230,cellulitis (disease),http://purl.obolibrary.org/obo/UBERON_0003679,mouth floor
+http://purl.obolibrary.org/obo/MONDO_0007650,MALT lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001961,mucosa-associated lymphoid tissue
+http://purl.obolibrary.org/obo/MONDO_0003539,T-cell adult acute lymphocytic leukemia,http://purl.obolibrary.org/obo/MONDO_0003541,adult acute lymphoblastic leukemia,http://purl.obolibrary.org/obo/CL_0000084,T cell
+http://purl.obolibrary.org/obo/MONDO_0005525,T-cell leukemia,http://purl.obolibrary.org/obo/MONDO_0005059,leukemia (disease),http://purl.obolibrary.org/obo/CL_0000084,T cell
+http://purl.obolibrary.org/obo/MONDO_0001858,Tietze syndrome,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0002293,costochondral joint
+http://purl.obolibrary.org/obo/MONDO_0044965,abdominal and pelvic region disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002417,abdominal segment of trunk
+http://purl.obolibrary.org/obo/MONDO_0043759,abdominal ectopic pregnancy,http://purl.obolibrary.org/obo/MONDO_0000755,ectopic pregnancy,http://purl.obolibrary.org/obo/UBERON_0000916,abdomen
+http://purl.obolibrary.org/obo/MONDO_0007033,abducens nerve palsy,http://purl.obolibrary.org/obo/MONDO_0002782,cranial nerve palsy,http://purl.obolibrary.org/obo/UBERON_0001646,abducens nerve
+http://purl.obolibrary.org/obo/MONDO_0002636,accessory nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002019,accessory XI nerve
+http://purl.obolibrary.org/obo/MONDO_0003624,acinic cell breast carcinoma,http://purl.obolibrary.org/obo/MONDO_0004989,breast carcinoma,http://purl.obolibrary.org/obo/CL_0000622,acinar cell
+http://purl.obolibrary.org/obo/MONDO_0002520,acute hepatic porphyria,http://purl.obolibrary.org/obo/MONDO_0037939,porphyria,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0016287,adenoid basal carcinoma of the cervix uteri,http://purl.obolibrary.org/obo/MONDO_0002951,skin adenoid basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0003237,adenomyoma of uterine corpus,http://purl.obolibrary.org/obo/MONDO_0005635,adenomyoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002816,adrenal cortex disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0005495,adrenal gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0004477,adrenal gland ganglioneuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005035,ganglioneuroblastoma (disease),http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0006076,adrenal gland neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0019470,aggressive NK-cell leukemia,http://purl.obolibrary.org/obo/MONDO_0005059,leukemia (disease),http://purl.obolibrary.org/obo/CL_0000623,natural killer cell
+http://purl.obolibrary.org/obo/MONDO_0002138,allergic contact dermatitis of eyelid,http://purl.obolibrary.org/obo/MONDO_0006525,allergic contact dermatitis,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0006551,alopecia mucinosa,http://purl.obolibrary.org/obo/MONDO_0021653,cutaneous focal mucinosis,http://purl.obolibrary.org/obo/UBERON_0002073,hair follicle
+http://purl.obolibrary.org/obo/MONDO_0001752,alveolar periostitis,http://purl.obolibrary.org/obo/MONDO_0004553,extrinsic allergic alveolitis,http://purl.obolibrary.org/obo/UBERON_0001708,jaw skeleton
+http://purl.obolibrary.org/obo/MONDO_0005208,amelanotic skin melanoma,http://purl.obolibrary.org/obo/MONDO_0002971,amelanotic melanoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0017438,amelia of lower limb,http://purl.obolibrary.org/obo/MONDO_0017419,non-syndromic amelia,http://purl.obolibrary.org/obo/UBERON_0002103,hindlimb
+http://purl.obolibrary.org/obo/MONDO_0017437,amelia of upper limb,http://purl.obolibrary.org/obo/MONDO_0017419,non-syndromic amelia,http://purl.obolibrary.org/obo/UBERON_0002102,forelimb
+http://purl.obolibrary.org/obo/MONDO_0003504,anal canal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0002940,anal margin basal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0012336,perianal skin
+http://purl.obolibrary.org/obo/MONDO_0006081,anal melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0001138,angiodysplasia of intestine,http://purl.obolibrary.org/obo/MONDO_0002322,angiodysplasia,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0024310,angiodysplasia of stomach,http://purl.obolibrary.org/obo/MONDO_0002322,angiodysplasia,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0004882,angioid streaks of choroid,http://purl.obolibrary.org/obo/MONDO_0011782,angioid streaks,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0022454,angiosarcoma of the scalp,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000403,scalp
+http://purl.obolibrary.org/obo/MONDO_0000741,angular cheilitis,http://purl.obolibrary.org/obo/MONDO_0002102,cheilitis,http://purl.obolibrary.org/obo/UBERON_0018149,angle of oral opening
+http://purl.obolibrary.org/obo/MONDO_0000480,anismus,http://purl.obolibrary.org/obo/MONDO_0000477,focal dystonia,http://purl.obolibrary.org/obo/UBERON_0004832,anal region skeletal muscle
+http://purl.obolibrary.org/obo/MONDO_0043895,ankle injury,http://purl.obolibrary.org/obo/MONDO_0021178,injury,http://purl.obolibrary.org/obo/UBERON_0004454,tarsal region
+http://purl.obolibrary.org/obo/MONDO_0002997,anterior cranial fossa meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0003720,anterior cranial fossa
+http://purl.obolibrary.org/obo/MONDO_0003182,anterior horn disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002257,ventral horn of spinal cord
+http://purl.obolibrary.org/obo/MONDO_0024468,anterior pituitary gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002196,adenohypophysis
+http://purl.obolibrary.org/obo/MONDO_0006650,anterior spinal artery syndrome,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0005431,anterior spinal artery
+http://purl.obolibrary.org/obo/MONDO_0002519,anus disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0003292,anus leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0003358,anus leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0001888,anus lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0002864,anus rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0003023,aorta angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000947,aorta
+http://purl.obolibrary.org/obo/MONDO_0000980,aortic atherosclerosis (disease),http://purl.obolibrary.org/obo/MONDO_0005311,atherosclerosis,http://purl.obolibrary.org/obo/UBERON_0000947,aorta
+http://purl.obolibrary.org/obo/MONDO_0005561,aortic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000947,aorta
+http://purl.obolibrary.org/obo/MONDO_0003803,aortic valve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002137,aortic valve
+http://purl.obolibrary.org/obo/MONDO_0024467,apocrine sweat gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000382,apocrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0021101,appendix L-cell glucagon-like peptide-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0004211,L-cell glucagon-like peptide-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0003300,appendix leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0001237,appendix lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0024501,appendix neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0000473,arterial disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001637,artery
+http://purl.obolibrary.org/obo/MONDO_0042495,arteriosclerotic retinopathy,http://purl.obolibrary.org/obo/MONDO_0002277,arteriosclerosis disorder,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0006816,arthropathy,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000982,skeletal joint
+http://purl.obolibrary.org/obo/MONDO_0003816,articular cartilage disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0010996,articular cartilage of joint
+http://purl.obolibrary.org/obo/MONDO_0002004,atheroembolism of kidney,http://purl.obolibrary.org/obo/MONDO_0005568,cholesterol embolism,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0005476,atrioventricular node disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002352,atrioventricular node
+http://purl.obolibrary.org/obo/MONDO_0024624,atrophy of lacrimal gland,http://purl.obolibrary.org/obo/MONDO_0024236,degenerative disorder,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0002409,auditory system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0016490,auditory system
+http://purl.obolibrary.org/obo/MONDO_0000602,autoimmune disease of blood,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0000178,blood
+http://purl.obolibrary.org/obo/MONDO_0000603,autoimmune disease of cardiovascular system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0004535,cardiovascular system
+http://purl.obolibrary.org/obo/MONDO_0000568,autoimmune disease of central nervous system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0000569,autoimmune disease of endocrine system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0000949,endocrine system
+http://purl.obolibrary.org/obo/MONDO_0000586,autoimmune disease of exocrine system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0002330,exocrine system
+http://purl.obolibrary.org/obo/MONDO_0000588,autoimmune disease of gastrointestinal tract,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0005409,alimentary part of gastrointestinal system
+http://purl.obolibrary.org/obo/MONDO_0000589,autoimmune disease of musculoskeletal system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0002204,musculoskeletal system
+http://purl.obolibrary.org/obo/MONDO_0000590,autoimmune disease of peripheral nervous system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0000010,peripheral nervous system
+http://purl.obolibrary.org/obo/MONDO_0002977,autoimmune disease of the nervous system,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0000601,autoimmune disease of urogenital tract,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0004122,genitourinary system
+http://purl.obolibrary.org/obo/MONDO_0100014,autoimmune retinopathy,http://purl.obolibrary.org/obo/MONDO_0007179,autoimmune disease,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0001292,autonomic nervous system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002410,autonomic nervous system
+http://purl.obolibrary.org/obo/MONDO_0001300,autonomic neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy,http://purl.obolibrary.org/obo/UBERON_0002410,autonomic nervous system
+http://purl.obolibrary.org/obo/MONDO_0020049,autosomal anomaly,http://purl.obolibrary.org/obo/MONDO_0019040,chromosomal anomaly,http://purl.obolibrary.org/obo/GO_0030849,autosome
+http://purl.obolibrary.org/obo/MONDO_0000974,axillary lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0009472,axilla
+http://purl.obolibrary.org/obo/MONDO_0003070,axillary lymphadenitis,http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0009472,axilla
+http://purl.obolibrary.org/obo/MONDO_0004183,axonal neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy,http://purl.obolibrary.org/obo/GO_0030424,axon
+http://purl.obolibrary.org/obo/MONDO_0015551,basal epidermolysis bullosa simplex,http://purl.obolibrary.org/obo/MONDO_0017610,epidermolysis bullosa simplex,http://purl.obolibrary.org/obo/UBERON_0002025,stratum basale of epidermis
+http://purl.obolibrary.org/obo/MONDO_0006505,basal ganglia cerebrovascular disease,http://purl.obolibrary.org/obo/MONDO_0011057,cerebrovascular disorder,http://purl.obolibrary.org/obo/UBERON_0010011,collection of basal ganglia
+http://purl.obolibrary.org/obo/MONDO_0003996,basal ganglia disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0010011,collection of basal ganglia
+http://purl.obolibrary.org/obo/MONDO_0002250,basilar artery insufficiency,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0001633,basilar artery
+http://purl.obolibrary.org/obo/MONDO_0044983,benign lipomatous neoplasm,http://purl.obolibrary.org/obo/MONDO_0000654,benign connective and soft tissue neoplasm,http://purl.obolibrary.org/obo/UBERON_0001013,adipose tissue
+http://purl.obolibrary.org/obo/MONDO_0002887,bile duct disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0004868,biliary tract disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001173,biliary tree
+http://purl.obolibrary.org/obo/MONDO_0001634,bladder leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0001381,bladder lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0000513,bone ameloblastoma,http://purl.obolibrary.org/obo/MONDO_0017795,ameloblastoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0002617,bone angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0000515,bone chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0008977,chondrosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0005497,bone development disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/GO_0060348,bone development
+http://purl.obolibrary.org/obo/MONDO_0005381,bone disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001474,bone element
+http://purl.obolibrary.org/obo/MONDO_0002624,bone leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0003225,bone marrow disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002371,bone marrow
+http://purl.obolibrary.org/obo/MONDO_0003994,botryoid-type embryonal rhabdomyosarcoma of the vagina,http://purl.obolibrary.org/obo/MONDO_0002578,botryoid rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0006682,brachial plexus neuritis,http://purl.obolibrary.org/obo/MONDO_0002122,neuritis,http://purl.obolibrary.org/obo/UBERON_0001814,brachial nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0006683,brachial plexus neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy,http://purl.obolibrary.org/obo/UBERON_0001814,brachial nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0021631,brain astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0005560,brain disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0002501,brain glioblastoma,http://purl.obolibrary.org/obo/MONDO_0018177,glioblastoma (disease),http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0005499,brain glioma,http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0043510,brain injury,http://purl.obolibrary.org/obo/MONDO_0021178,injury,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0005299,brain ischemia,http://purl.obolibrary.org/obo/MONDO_0005053,ischemic disease,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0000642,brain meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0002544,brain oligodendroglioma,http://purl.obolibrary.org/obo/MONDO_0016695,oligodendroglioma,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0003173,brain stem astrocytic neoplasm,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0003477,brain stem ependymoma,http://purl.obolibrary.org/obo/MONDO_0016698,ependymoma,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0002911,brain stem glioma,http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0003902,brain stem hemangioblastoma,http://purl.obolibrary.org/obo/MONDO_0016748,hemangioblastoma,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0006686,brain stem infarction,http://purl.obolibrary.org/obo/MONDO_0005394,brain infarction,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0000517,brain stem medulloblastoma,http://purl.obolibrary.org/obo/MONDO_0007959,medulloblastoma,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0003024,breast angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0004273,breast apocrine adenoma,http://purl.obolibrary.org/obo/MONDO_0002804,apocrine adenoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003934,breast apocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0003214,apocrine adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003896,breast capillary hemangioma,http://purl.obolibrary.org/obo/MONDO_0002407,capillary hemangioma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0006117,breast diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0018905,diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002657,breast disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003897,breast epithelioid hemangioma,http://purl.obolibrary.org/obo/MONDO_0003119,histiocytoid hemangioma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002487,breast granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003126,breast hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003959,breast large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0005057,large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002057,breast leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003371,breast leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0000970,breast lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003593,breast liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003661,breast lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0004420,breast malignant eccrine spiradenoma,http://purl.obolibrary.org/obo/MONDO_0004412,malignant spiradenoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002485,breast neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002859,breast rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0001358,bronchial disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0019963,bronchial endocrine tumor,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0001574,capillary disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001982,capillary
+http://purl.obolibrary.org/obo/MONDO_0003254,cardiac granular cell neoplasm,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0006123,cardiac rhabdomyoma (disease),http://purl.obolibrary.org/obo/MONDO_0036688,rhabdomyoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0001707,cardiac sarcoidosis,http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0045001,cardiac ventricle disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002082,cardiac ventricle
+http://purl.obolibrary.org/obo/MONDO_0004995,cardiovascular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0004535,cardiovascular system
+http://purl.obolibrary.org/obo/MONDO_0005269,carotid artery disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0005396,carotid artery segment
+http://purl.obolibrary.org/obo/MONDO_0004450,carotid artery occlusion,http://purl.obolibrary.org/obo/MONDO_0003718,occlusion precerebral artery,http://purl.obolibrary.org/obo/UBERON_0005396,carotid artery segment
+http://purl.obolibrary.org/obo/MONDO_0021053,carotid body paraganglioma,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://purl.obolibrary.org/obo/UBERON_0001629,carotid body
+http://purl.obolibrary.org/obo/MONDO_0044998,carpal region disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0004452,carpal region
+http://purl.obolibrary.org/obo/MONDO_0005569,cartilage disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002418,cartilage tissue
+http://purl.obolibrary.org/obo/MONDO_0005693,cauda equina syndrome,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0012337,cauda equina
+http://purl.obolibrary.org/obo/MONDO_0003644,cavernous hemangioma of colon,http://purl.obolibrary.org/obo/MONDO_0003155,cavernous hemangioma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003645,cavernous hemangioma of face,http://purl.obolibrary.org/obo/MONDO_0003155,cavernous hemangioma,http://purl.obolibrary.org/obo/UBERON_0001456,face
+http://purl.obolibrary.org/obo/MONDO_0021281,cavernous hemangioma of retina,http://purl.obolibrary.org/obo/MONDO_0003155,cavernous hemangioma,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0002996,cavernous sinus meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0003712,cavernous sinus
+http://purl.obolibrary.org/obo/MONDO_0002031,cecal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0002034,cecum lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0006128,central nervous system anaplastic large cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0020325,anaplastic large cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003021,central nervous system angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002602,central nervous system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003241,central nervous system hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003641,central nervous system hematopoietic neoplasm,http://purl.obolibrary.org/obo/MONDO_0002334,hematopoietic and lymphoid system neoplasm,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003943,central nervous system hibernoma,http://purl.obolibrary.org/obo/MONDO_0021168,hibernoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003287,central nervous system leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003349,central nervous system leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0001606,central nervous system leukemia,http://purl.obolibrary.org/obo/MONDO_0005059,leukemia (disease),http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003844,central nervous system lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002571,central nervous system lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003222,central nervous system melanocytic neoplasm,http://purl.obolibrary.org/obo/MONDO_0021143,melanocytic neoplasm,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0044887,central nervous system non-hodgkin lymphoma,http://purl.obolibrary.org/obo/MONDO_0018908,non-Hodgkin lymphoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0000640,central nervous system primitive neuroectodermal neoplasm,http://purl.obolibrary.org/obo/MONDO_0005462,primitive neuroectodermal tumor,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002850,central nervous system rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003346,central nervous system vasculitis,http://purl.obolibrary.org/obo/MONDO_0018882,vasculitis,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002303,central retinal vein occlusion,http://purl.obolibrary.org/obo/MONDO_0006951,retinal vein occlusion,http://purl.obolibrary.org/obo/UBERON_0001673,central retinal vein
+http://purl.obolibrary.org/obo/MONDO_0003165,cerebellar astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0022687,cerebellar degeneration,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0002427,cerebellar disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0003901,cerebellar hemangioblastoma,http://purl.obolibrary.org/obo/MONDO_0016748,hemangioblastoma,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0003168,cerebellar pilocytic astrocytoma,http://purl.obolibrary.org/obo/MONDO_0016691,pilocytic astrocytoma,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0002792,cerebellar vermis medulloblastoma,http://purl.obolibrary.org/obo/MONDO_0007959,medulloblastoma,http://purl.obolibrary.org/obo/UBERON_0004720,cerebellar vermis
+http://purl.obolibrary.org/obo/MONDO_0003860,cerebellopontine angle meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0014908,cerebellopontine angle
+http://purl.obolibrary.org/obo/MONDO_0021633,cerebral astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0001869,cerebral hemisphere
+http://purl.obolibrary.org/obo/MONDO_0044996,cerebral cortex disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000956,cerebral cortex
+http://purl.obolibrary.org/obo/MONDO_0024238,cerebral degeneration,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0004422,cerebral falx meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0006059,falx cerebri
+http://purl.obolibrary.org/obo/MONDO_0003948,cerebral hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0003843,cerebral hemisphere lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001869,cerebral hemisphere
+http://purl.obolibrary.org/obo/MONDO_0002679,cerebral infarction,http://purl.obolibrary.org/obo/MONDO_0005394,brain infarction,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0003772,cerebral meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0002900,cerebral neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0019213,cerebral organic aciduria,http://purl.obolibrary.org/obo/MONDO_0000688,inherited organic acidemia,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0001706,cerebral sarcoidosis,http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0002876,cervical adenosarcoma,http://purl.obolibrary.org/obo/MONDO_0005636,adenosarcoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0044343,cervical disc degenerative disorder,http://purl.obolibrary.org/obo/MONDO_0011385,intervertebral disc degenerative disorder,http://purl.obolibrary.org/obo/UBERON_0006072,cervical region of vertebral column
+http://purl.obolibrary.org/obo/MONDO_0003665,cervical endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0005026,endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0003067,cervical lymphadenitis,http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0000974,neck
+http://purl.obolibrary.org/obo/MONDO_0000549,cervical neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0000974,neck
+http://purl.obolibrary.org/obo/MONDO_0006142,cervical small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0002256,cervix disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0002706,cervix endometriosis,http://purl.obolibrary.org/obo/MONDO_0005133,endometriosis (disease),http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0003933,chest wall bone cancer,http://purl.obolibrary.org/obo/MONDO_0002129,bone cancer,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0000971,chest wall lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0003985,chest wall lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0004046,childhood brain meningioma,http://purl.obolibrary.org/obo/MONDO_0003057,pediatric meningioma,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0003842,childhood cerebellar astrocytic neoplasm,http://purl.obolibrary.org/obo/MONDO_0002505,childhood astrocytic tumor,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0004071,childhood cerebral astrocytoma,http://purl.obolibrary.org/obo/MONDO_0002505,childhood astrocytic tumor,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0004315,cholangiolocellular carcinoma,http://purl.obolibrary.org/obo/MONDO_0019087,cholangiocarcinoma,http://purl.obolibrary.org/obo/UBERON_0001282,intralobular bile duct
+http://purl.obolibrary.org/obo/MONDO_0006532,cholesteatoma of external ear,http://purl.obolibrary.org/obo/MONDO_0006530,cholesteatoma (disease),http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0006533,cholesteatoma of middle ear,http://purl.obolibrary.org/obo/MONDO_0006530,cholesteatoma (disease),http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0008207,chondromalacia patellae,http://purl.obolibrary.org/obo/MONDO_0002342,chondromalacia,http://purl.obolibrary.org/obo/UBERON_0002446,patella
+http://purl.obolibrary.org/obo/MONDO_0004085,choroid epithelioid cell melanoma,http://purl.obolibrary.org/obo/MONDO_0002973,epithelioid cell melanoma,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0003913,choroid mixed cell melanoma,http://purl.obolibrary.org/obo/MONDO_0003910,mixed cell uveal melanoma,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0003053,choroid plexus meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0001886,choroid plexus
+http://purl.obolibrary.org/obo/MONDO_0003745,choroid spindle cell melanoma,http://purl.obolibrary.org/obo/MONDO_0006427,spindle cell melanoma,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0004885,choroidal sclerosis,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0002970,ciliary body disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0004086,ciliary body epithelioid cell melanoma,http://purl.obolibrary.org/obo/MONDO_0002973,epithelioid cell melanoma,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0003911,ciliary body mixed cell melanoma,http://purl.obolibrary.org/obo/MONDO_0003910,mixed cell uveal melanoma,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0003746,ciliary body spindle cell melanoma,http://purl.obolibrary.org/obo/MONDO_0006427,spindle cell melanoma,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0003850,clivus chondroid chordoma,http://purl.obolibrary.org/obo/MONDO_0006145,chondroid chordoma,http://purl.obolibrary.org/obo/UBERON_0004108,clivus of occipital bone
+http://purl.obolibrary.org/obo/MONDO_0003849,clivus chordoma,http://purl.obolibrary.org/obo/MONDO_0008978,chordoma (disease),http://purl.obolibrary.org/obo/UBERON_0004108,clivus of occipital bone
+http://purl.obolibrary.org/obo/MONDO_0003908,clivus meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0004108,clivus of occipital bone
+http://purl.obolibrary.org/obo/MONDO_0003452,cochlear disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001844,cochlea
+http://purl.obolibrary.org/obo/MONDO_0006150,colon Burkitt lymphoma,http://purl.obolibrary.org/obo/MONDO_0007243,Burkitts lymphoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003997,colon Kaposi sarcoma,http://purl.obolibrary.org/obo/MONDO_0005055,Kaposi's sarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0001092,colon leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003351,colon leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0002035,colon lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0002882,colon neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003978,colon small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0004210,colonic L-cell glucagon-like peptide producing tumor,http://purl.obolibrary.org/obo/MONDO_0004211,L-cell glucagon-like peptide-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0003409,colonic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0024659,colorectal Kaposi sarcoma,http://purl.obolibrary.org/obo/MONDO_0005055,Kaposi's sarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0006158,colorectal diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0018905,diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0003299,colorectal leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0003885,colorectal lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0024656,colorectal lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0015381,commissural lip fistula,http://purl.obolibrary.org/obo/MONDO_0015476,cysts and fistulae of the face and oral cavity,http://purl.obolibrary.org/obo/UBERON_1000011,labial commissure
+http://purl.obolibrary.org/obo/MONDO_0002886,common bile duct disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001174,common bile duct
+http://purl.obolibrary.org/obo/MONDO_0001542,common peroneal nerve lesion,http://purl.obolibrary.org/obo/MONDO_0024334,peripheral nerve lesion,http://purl.obolibrary.org/obo/UBERON_0001324,common fibular nerve
+http://purl.obolibrary.org/obo/MONDO_0005449,conduction system disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002350,conducting system of heart
+http://purl.obolibrary.org/obo/MONDO_0018771,congenital anomaly of ventricular septum,http://purl.obolibrary.org/obo/MONDO_0019512,congenital heart malformation,http://purl.obolibrary.org/obo/UBERON_0002094,interventricular septum
+http://purl.obolibrary.org/obo/MONDO_0002932,conjunctival disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0001174,conjunctival vascular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0010366,conjunctival vasculature
+http://purl.obolibrary.org/obo/MONDO_0003900,connective tissue disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002384,connective tissue
+http://purl.obolibrary.org/obo/MONDO_0000942,corneal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0000766,corneal endothelial dystrophy,http://purl.obolibrary.org/obo/MONDO_0018102,corneal dystrophy (disease),http://purl.obolibrary.org/obo/UBERON_0001772,corneal epithelium
+http://purl.obolibrary.org/obo/MONDO_0004577,corneal ulcer,http://purl.obolibrary.org/obo/MONDO_0043839,ulcer disease,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001621,coronary artery
+http://purl.obolibrary.org/obo/MONDO_0021661,coronary atherosclerosis,http://purl.obolibrary.org/obo/MONDO_0002277,arteriosclerosis disorder,http://purl.obolibrary.org/obo/UBERON_0001621,coronary artery
+http://purl.obolibrary.org/obo/MONDO_0044875,coronary microvascular disease,http://purl.obolibrary.org/obo/MONDO_0005267,heart disease,http://purl.obolibrary.org/obo/UBERON_0008339,microvascular endothelium
+http://purl.obolibrary.org/obo/MONDO_0006716,coronary thrombosis,http://purl.obolibrary.org/obo/MONDO_0000831,thrombotic disease,http://purl.obolibrary.org/obo/UBERON_0005985,coronary vessel
+http://purl.obolibrary.org/obo/MONDO_0003845,corpus callosum lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002336,corpus callosum
+http://purl.obolibrary.org/obo/MONDO_0000519,corpus callosum oligodendroglioma,http://purl.obolibrary.org/obo/MONDO_0016695,oligodendroglioma,http://purl.obolibrary.org/obo/UBERON_0002336,corpus callosum
+http://purl.obolibrary.org/obo/MONDO_0001625,corpus luteum cyst,http://purl.obolibrary.org/obo/MONDO_0003282,ovarian cyst (disease),http://purl.obolibrary.org/obo/UBERON_0002512,corpus luteum
+http://purl.obolibrary.org/obo/MONDO_0045051,cortical cataract,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://purl.obolibrary.org/obo/UBERON_0000389,lens cortex
+http://purl.obolibrary.org/obo/MONDO_0001749,cortical senile cataract,http://purl.obolibrary.org/obo/MONDO_0004847,senile cataract,http://purl.obolibrary.org/obo/UBERON_0000389,lens cortex
+http://purl.obolibrary.org/obo/MONDO_0003569,cranial nerve neuropathy,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0034713,cranial neuron projection bundle
+http://purl.obolibrary.org/obo/MONDO_0016374,cranial neuralgia,http://purl.obolibrary.org/obo/MONDO_0021667,neuralgia,http://purl.obolibrary.org/obo/UBERON_0034713,cranial neuron projection bundle
+http://purl.obolibrary.org/obo/MONDO_0002291,cutaneous granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003362,cutaneous leiomyosarcoma (disease),http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003600,cutaneous liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0005012,cutaneous melanoma (disease),http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0002141,cutaneous undifferentiated pleomorphic sarcoma,http://purl.obolibrary.org/obo/MONDO_0002142,undifferentiated pleomorphic sarcoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003301,dartoic leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0013718,dartos muscle
+http://purl.obolibrary.org/obo/MONDO_0003394,dental pulp disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001754,dental pulp
+http://purl.obolibrary.org/obo/MONDO_0001041,dentin caries,http://purl.obolibrary.org/obo/MONDO_0005276,dental caries,http://purl.obolibrary.org/obo/UBERON_0001751,dentine
+http://purl.obolibrary.org/obo/MONDO_0001762,dentine erosion,http://purl.obolibrary.org/obo/MONDO_0002325,"tooth erosion, non-bacterial",http://purl.obolibrary.org/obo/UBERON_0001751,dentine
+http://purl.obolibrary.org/obo/MONDO_0002967,dermatophytosis of scalp or beard,http://purl.obolibrary.org/obo/MONDO_0004678,dermatophytosis,http://purl.obolibrary.org/obo/UBERON_0000403,scalp
+http://purl.obolibrary.org/obo/MONDO_0021154,dermis disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002067,dermis
+http://purl.obolibrary.org/obo/MONDO_0005728,diaphragm disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001103,diaphragm
+http://purl.obolibrary.org/obo/MONDO_0004108,diaphragma sellae meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0035416,diaphragma sellae
+http://purl.obolibrary.org/obo/MONDO_0003169,diencephalic astrocytomas,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0001894,diencephalon
+http://purl.obolibrary.org/obo/MONDO_0017596,diffuse large B-cell lymphoma of the central nervous system,http://purl.obolibrary.org/obo/MONDO_0018905,diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0015384,digestive duplication cyst of the tongue,http://purl.obolibrary.org/obo/MONDO_0015476,cysts and fistulae of the face and oral cavity,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0004335,digestive system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0024503,digestive system neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0005409,alimentary part of gastrointestinal system
+http://purl.obolibrary.org/obo/MONDO_0044789,digital papillary eccrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0003531,papillary eccrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002544,digit
+http://purl.obolibrary.org/obo/MONDO_0021205,disease of ear,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001690,ear
+http://purl.obolibrary.org/obo/MONDO_0045013,disease of extraembryonic membrane,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0005631,extraembryonic membrane
+http://purl.obolibrary.org/obo/MONDO_0023369,disease of facial skeleton,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0011156,facial skeleton
+http://purl.obolibrary.org/obo/MONDO_0021145,disease of genitourinary system,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0004122,genitourinary system
+http://purl.obolibrary.org/obo/MONDO_0002022,disease of orbital region,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0004088,orbital region
+http://purl.obolibrary.org/obo/MONDO_0002917,disease of pilosebaceous unit,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0011932,pilosebaceous unit
+http://purl.obolibrary.org/obo/MONDO_0045043,disease of uterine broad ligament,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0012332,broad ligament of uterus
+http://purl.obolibrary.org/obo/MONDO_0024458,disease of visual system,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002104,visual system
+http://purl.obolibrary.org/obo/MONDO_0024625,disorder of lacrimal gland,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0015141,disorder of medulla oblongata,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001896,medulla oblongata
+http://purl.obolibrary.org/obo/MONDO_0003568,disorder of optic chiasm,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000959,optic chiasma
+http://purl.obolibrary.org/obo/MONDO_0001674,diverticulitis of colon,http://purl.obolibrary.org/obo/MONDO_0004235,diverticulitis,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0002866,duodenal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0004411,duodenal gastrin-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0003523,gastrin-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0024500,duodenal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0002576,embryonal extrahepatic bile duct rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0009993,embryonal rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002233,enamel caries,http://purl.obolibrary.org/obo/MONDO_0005276,dental caries,http://purl.obolibrary.org/obo/UBERON_0001752,enamel
+http://purl.obolibrary.org/obo/MONDO_0003944,endobronchial leiomyoma,http://purl.obolibrary.org/obo/MONDO_0003293,lung leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0000470,endocardium disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002165,endocardium
+http://purl.obolibrary.org/obo/MONDO_0001933,endocrine pancreas disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000016,endocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0005151,endocrine system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000949,endocrine system
+http://purl.obolibrary.org/obo/MONDO_0000931,endometrial disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0006197,endometrial small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0003314,endometrioid stromal and related neoplasms of the vagina,http://purl.obolibrary.org/obo/MONDO_0037742,endometrioid stromal and related neoplasms,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0003030,endometrioid stromal sarcoma of the cervix,http://purl.obolibrary.org/obo/MONDO_0006745,endometrioid stromal sarcoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0003313,endometrioid stromal sarcoma of the vagina,http://purl.obolibrary.org/obo/MONDO_0006745,endometrioid stromal sarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0001284,endometriosis of intestine,http://purl.obolibrary.org/obo/MONDO_0005133,endometriosis (disease),http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0010888,endometriosis of uterus,http://purl.obolibrary.org/obo/MONDO_0005133,endometriosis (disease),http://purl.obolibrary.org/obo/UBERON_0001296,myometrium
+http://purl.obolibrary.org/obo/MONDO_0002183,enthesopathy,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0035845,enthesis
+http://purl.obolibrary.org/obo/MONDO_0044972,eosinophil disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/CL_0000771,eosinophil
+http://purl.obolibrary.org/obo/MONDO_0004245,ependymal tumor of brain,http://purl.obolibrary.org/obo/MONDO_0003266,ependymal tumor,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0021546,ependymal tumor of spinal cord,http://purl.obolibrary.org/obo/MONDO_0003266,ependymal tumor,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0003840,epicardium lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002348,epicardium
+http://purl.obolibrary.org/obo/MONDO_0002712,epidural spinal canal angiolipoma,http://purl.obolibrary.org/obo/MONDO_0006085,angiolipoma,http://purl.obolibrary.org/obo/UBERON_0003691,epidural space
+http://purl.obolibrary.org/obo/MONDO_0006200,epithelioid cell uveal melanoma,http://purl.obolibrary.org/obo/MONDO_0002973,epithelioid cell melanoma,http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0003749,esophageal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0003251,esophageal granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0000963,esophageal lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0001192,esophageal melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0003649,esophageal neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004116,esophageal small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0044782,esophageal ulcer,http://purl.obolibrary.org/obo/MONDO_0043839,ulcer disease,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0001221,esophageal varices,http://purl.obolibrary.org/obo/MONDO_0008638,varicose disease,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004832,esophagus leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0003365,esophagus leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0003586,esophagus liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0001188,esophagus lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0005756,ethmoid sinusitis,http://purl.obolibrary.org/obo/MONDO_0005961,sinusitis,http://purl.obolibrary.org/obo/UBERON_0001679,ethmoid bone
+http://purl.obolibrary.org/obo/MONDO_0004866,eustachian tube disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002393,pharyngotympanic tube
+http://purl.obolibrary.org/obo/MONDO_0002943,external ear basal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0002776,external ear disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0000973,external ear lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0003286,extrahepatic bile duct leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0003377,extrahepatic bile duct leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0000978,extrahepatic bile duct lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002577,extrahepatic bile duct rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0006757,extrahepatic cholestasis,http://purl.obolibrary.org/obo/MONDO_0001751,cholestasis,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0000462,eye adnexa disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0035639,ocular adnexa
+http://purl.obolibrary.org/obo/MONDO_0004884,eye degenerative disease,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0005328,eye disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0004034,eye lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0021627,eyelid capillary hemangioma,http://purl.obolibrary.org/obo/MONDO_0002407,capillary hemangioma,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0000941,eyelid degenerative disease,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0003382,eyelid disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0000928,eyelid melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0021607,eyelid seborrheic keratosis,http://purl.obolibrary.org/obo/MONDO_0008420,seborrheic keratosis,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0044987,face disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001456,face
+http://purl.obolibrary.org/obo/MONDO_0002098,facial nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001647,facial nerve
+http://purl.obolibrary.org/obo/MONDO_0001818,facial neuralgia,http://purl.obolibrary.org/obo/MONDO_0021667,neuralgia,http://purl.obolibrary.org/obo/UBERON_0001647,facial nerve
+http://purl.obolibrary.org/obo/MONDO_0001835,facial paralysis,http://purl.obolibrary.org/obo/MONDO_0006496,palsy,http://purl.obolibrary.org/obo/UBERON_0001456,face
+http://purl.obolibrary.org/obo/MONDO_0002162,fallopian tube adenosarcoma,http://purl.obolibrary.org/obo/MONDO_0005636,adenosarcoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0004501,fallopian tube cystadenofibroma,http://purl.obolibrary.org/obo/MONDO_0003464,cystadenofibroma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0002156,fallopian tube disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0003666,fallopian tube endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0005026,endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0021576,fallopian tube endometrioid tumor,http://purl.obolibrary.org/obo/MONDO_0021251,endometrium neoplasm,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0001282,fallopian tube endometriosis,http://purl.obolibrary.org/obo/MONDO_0005133,endometriosis (disease),http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0004489,fallopian tube gestational choriocarcinoma,http://purl.obolibrary.org/obo/MONDO_0020550,gestational choriocarcinoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0003285,fallopian tube leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0002159,fallopian tube leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0003461,fallopian tube serous adenofibroma,http://purl.obolibrary.org/obo/MONDO_0024886,serous adenofibroma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0021124,female infertility,http://purl.obolibrary.org/obo/MONDO_0005047,infertility disorder,http://purl.obolibrary.org/obo/UBERON_0000474,female reproductive system
+http://purl.obolibrary.org/obo/MONDO_0002263,female reproductive system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000474,female reproductive system
+http://purl.obolibrary.org/obo/MONDO_0043589,femoral neck fracture,http://purl.obolibrary.org/obo/MONDO_0005315,bone fracture,http://purl.obolibrary.org/obo/UBERON_0007119,neck of femur
+http://purl.obolibrary.org/obo/MONDO_0006759,femoral neuropathy,http://purl.obolibrary.org/obo/MONDO_0024334,peripheral nerve lesion,http://purl.obolibrary.org/obo/UBERON_0001267,femoral nerve
+http://purl.obolibrary.org/obo/MONDO_0001481,femoral vein thrombophlebitis,http://purl.obolibrary.org/obo/MONDO_0002800,thrombophlebitis,http://purl.obolibrary.org/obo/UBERON_0001361,femoral vein
+http://purl.obolibrary.org/obo/MONDO_0006549,fibroepithelial polyp of the anus,http://purl.obolibrary.org/obo/MONDO_0004026,skin tag,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0006550,fibroepithelial polyp of urethra,http://purl.obolibrary.org/obo/MONDO_0004026,skin tag,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0005761,filarial elephantiasis,http://purl.obolibrary.org/obo/MONDO_0005424,elephantiasis,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0006552,folliculitis,http://purl.obolibrary.org/obo/MONDO_0002406,dermatitis,http://purl.obolibrary.org/obo/UBERON_0002073,hair follicle
+http://purl.obolibrary.org/obo/MONDO_0044989,foot disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002387,pes
+http://purl.obolibrary.org/obo/MONDO_0003109,foramen magnum meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0003687,foramen magnum
+http://purl.obolibrary.org/obo/MONDO_0001146,fourth cranial nerve palsy,http://purl.obolibrary.org/obo/MONDO_0002782,cranial nerve palsy,http://purl.obolibrary.org/obo/UBERON_0001644,trochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0021131,frontal lobe ependymal tumor,http://purl.obolibrary.org/obo/MONDO_0003266,ependymal tumor,http://purl.obolibrary.org/obo/UBERON_0016525,frontal lobe
+http://purl.obolibrary.org/obo/MONDO_0002612,frontal lobe epilepsy,http://purl.obolibrary.org/obo/MONDO_0005027,epilepsy,http://purl.obolibrary.org/obo/UBERON_0016525,frontal lobe
+http://purl.obolibrary.org/obo/MONDO_0003604,functioning pituitary gland neoplasm,http://purl.obolibrary.org/obo/MONDO_0021120,functioning endocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0003026,gallbladder angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0005281,gallbladder disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003297,gallbladder leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003364,gallbladder leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0000972,gallbladder lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0004474,gallbladder lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0004484,gallbladder melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0024502,gallbladder neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0002856,gallbladder rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0006219,gallbladder small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0004313,gasserian ganglion meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_3011045,gasserian ganglion
+http://purl.obolibrary.org/obo/MONDO_0003524,gastric gastrin-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0003523,gastrin-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0002414,gastric hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0000938,gastric leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003367,gastric leiomyosarcoma (disease),http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003592,gastric liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0001059,gastric lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0006225,gastric mantle cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0018876,mantle cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0006226,gastric mucosa-associated lymphoid tissue lymphoma,http://purl.obolibrary.org/obo/MONDO_0007650,MALT lymphoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003111,gastric neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0042493,gastric non-hodgkin lymphoma,http://purl.obolibrary.org/obo/MONDO_0018908,non-Hodgkin lymphoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0006229,gastric small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0001126,gastric ulcer (disease),http://purl.obolibrary.org/obo/MONDO_0004247,peptic ulcer disease,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0015078,gastroenteropancreatic neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0000777,gastrointestinal allergy,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease,http://purl.obolibrary.org/obo/UBERON_0001555,digestive tract
+http://purl.obolibrary.org/obo/MONDO_0004699,gastrointestinal lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0004490,gestational uterine corpus choriocarcinoma,http://purl.obolibrary.org/obo/MONDO_0020550,gestational choriocarcinoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002021,gingival disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001828,gingiva
+http://purl.obolibrary.org/obo/MONDO_0019722,glomerular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000074,renal glomerulus
+http://purl.obolibrary.org/obo/MONDO_0002462,glomerulonephritis (disease),http://purl.obolibrary.org/obo/MONDO_0001166,nephritis,http://purl.obolibrary.org/obo/UBERON_0000074,renal glomerulus
+http://purl.obolibrary.org/obo/MONDO_0004279,glossopharyngeal motor neuropathy,http://purl.obolibrary.org/obo/MONDO_0002316,motor peripheral neuropathy,http://purl.obolibrary.org/obo/UBERON_0001649,glossopharyngeal nerve
+http://purl.obolibrary.org/obo/MONDO_0002639,glossopharyngeal nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001649,glossopharyngeal nerve
+http://purl.obolibrary.org/obo/MONDO_0002781,glossopharyngeal nerve paralysis,http://purl.obolibrary.org/obo/MONDO_0002782,cranial nerve palsy,http://purl.obolibrary.org/obo/UBERON_0001649,glossopharyngeal nerve
+http://purl.obolibrary.org/obo/MONDO_0016372,glossopharyngeal neuralgia,http://purl.obolibrary.org/obo/MONDO_0021667,neuralgia,http://purl.obolibrary.org/obo/UBERON_0001649,glossopharyngeal nerve
+http://purl.obolibrary.org/obo/MONDO_0009414,glycogen storage disease due to hepatic glycogen synthase deficiency,http://purl.obolibrary.org/obo/MONDO_0017693,glycogen storage disease due to glycogen synthase deficiency,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0012693,glycogen storage disease due to muscle and heart glycogen synthase deficiency,http://purl.obolibrary.org/obo/MONDO_0017693,glycogen storage disease due to glycogen synthase deficiency,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0002259,gonadal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000991,gonad
+http://purl.obolibrary.org/obo/MONDO_0044990,hand disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002398,manus
+http://purl.obolibrary.org/obo/MONDO_0006239,head and neck paraganglioma,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0005042,head disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000033,head
+http://purl.obolibrary.org/obo/MONDO_0021059,head or neck disease/disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0005267,heart disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0003353,heart leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0003841,heart lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0003917,heart lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0002869,heart valve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000946,cardial valve
+http://purl.obolibrary.org/obo/MONDO_0021542,hemangioma of choroid,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0021543,hemangioma of gingiva,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001828,gingiva
+http://purl.obolibrary.org/obo/MONDO_0003194,hemangioma of lung,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003154,hemangioma of peripheral nerve,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001021,nerve
+http://purl.obolibrary.org/obo/MONDO_0021541,hemangioma of retina,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0006557,hemangioma of subcutaneous tissue,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0011818,superficial fascia
+http://purl.obolibrary.org/obo/MONDO_0007707,hemangiomas of small intestine,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0005570,hematological system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002390,hematopoietic system
+http://purl.obolibrary.org/obo/MONDO_0002515,hepatobiliary disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002423,hepatobiliary system
+http://purl.obolibrary.org/obo/MONDO_0003345,hilar cholangiocarcinoma,http://purl.obolibrary.org/obo/MONDO_0019087,cholangiocarcinoma,http://purl.obolibrary.org/obo/UBERON_0015423,hilar portion of hepatic duct
+http://purl.obolibrary.org/obo/MONDO_0044988,hip region disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001464,hip
+http://purl.obolibrary.org/obo/MONDO_0005800,hordeolum,http://purl.obolibrary.org/obo/MONDO_0004785,blepharitis,http://purl.obolibrary.org/obo/UBERON_0013229,eyelid gland
+http://purl.obolibrary.org/obo/MONDO_0001334,hypertrichosis of eyelid,http://purl.obolibrary.org/obo/MONDO_0019280,hypertrichosis (disease),http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0001810,hypoglossal nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001650,hypoglossal nerve
+http://purl.obolibrary.org/obo/MONDO_0005806,hypopharynx cancer,http://purl.obolibrary.org/obo/MONDO_0005517,pharynx cancer,http://purl.obolibrary.org/obo/UBERON_0001051,hypopharynx
+http://purl.obolibrary.org/obo/MONDO_0002150,hypothalamic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001898,hypothalamus
+http://purl.obolibrary.org/obo/MONDO_0001335,hypotrichosis of eyelid,http://purl.obolibrary.org/obo/MONDO_0003037,hypotrichosis,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0001148,iliac vein thrombophlebitis,http://purl.obolibrary.org/obo/MONDO_0002800,thrombophlebitis,http://purl.obolibrary.org/obo/UBERON_0005610,iliac vein
+http://purl.obolibrary.org/obo/MONDO_0005046,immune system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002405,immune system
+http://purl.obolibrary.org/obo/MONDO_0002467,inner ear disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001846,internal ear
+http://purl.obolibrary.org/obo/MONDO_0002051,integumentary system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002416,integumental system
+http://purl.obolibrary.org/obo/MONDO_0004065,intermediate cell type choroid melanoma,http://purl.obolibrary.org/obo/MONDO_0004062,intermediate cell type uveal melanoma,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0004066,intermediate cell type ciliary body melanoma,http://purl.obolibrary.org/obo/MONDO_0004062,intermediate cell type uveal melanoma,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0004063,intermediate cell type iris melanoma,http://purl.obolibrary.org/obo/MONDO_0004062,intermediate cell type uveal melanoma,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0003984,internal auditory canal lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0011859,internal acoustic meatus
+http://purl.obolibrary.org/obo/MONDO_0003722,internal auditory canal meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0011859,internal acoustic meatus
+http://purl.obolibrary.org/obo/MONDO_0004917,internal hordeolum,http://purl.obolibrary.org/obo/MONDO_0005800,hordeolum,http://purl.obolibrary.org/obo/UBERON_0001818,tarsal gland
+http://purl.obolibrary.org/obo/MONDO_0011385,intervertebral disc degenerative disorder,http://purl.obolibrary.org/obo/MONDO_0024236,degenerative disorder,http://purl.obolibrary.org/obo/UBERON_0001066,intervertebral disk
+http://purl.obolibrary.org/obo/MONDO_0005020,intestinal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0002883,intestinal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0002337,intra-abdominal hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0003684,abdominal cavity
+http://purl.obolibrary.org/obo/MONDO_0002328,intracranial hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0003142,intracranial primitive neuroectodermal tumor,http://purl.obolibrary.org/obo/MONDO_0005462,primitive neuroectodermal tumor,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0002772,intraventricular meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0004086,brain ventricle
+http://purl.obolibrary.org/obo/MONDO_0002289,iris disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0004064,iris melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0004188,iris spindle cell melanoma,http://purl.obolibrary.org/obo/MONDO_0006427,spindle cell melanoma,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0003771,jugular foramen meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0005456,jugular foramen
+http://purl.obolibrary.org/obo/MONDO_0021064,jugulotympanic paraganglioma,http://purl.obolibrary.org/obo/MONDO_0021052,parasympathetic paraganglioma,http://purl.obolibrary.org/obo/UBERON_0002517,basicranium
+http://purl.obolibrary.org/obo/MONDO_0005240,kidney disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0003373,kidney leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0000968,kidney lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0003591,kidney liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0001854,lacrimal apparatus disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001750,lacrimal apparatus
+http://purl.obolibrary.org/obo/MONDO_0024634,large intestine disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0004382,laryngeal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0000934,laryngeal leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0003374,laryngeal leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0015070,laryngeal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0006265,laryngeal small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0003588,larynx liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0003775,lateral ventricle meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0002285,telencephalic ventricle
+http://purl.obolibrary.org/obo/MONDO_0003291,leiomyoma cutis,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0021273,leiomyoma of ciliary body,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0016283,leiomyosarcoma of the cervix uteri,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0016262,leiomyosarcoma of the corpus uteri,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0001176,lens disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000965,lens of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0001543,lesion of sciatic nerve,http://purl.obolibrary.org/obo/MONDO_0024334,peripheral nerve lesion,http://purl.obolibrary.org/obo/UBERON_0001322,sciatic nerve
+http://purl.obolibrary.org/obo/MONDO_0004805,leukocyte disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/CL_0000738,leukocyte
+http://purl.obolibrary.org/obo/MONDO_0045044,ligament disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000211,ligament
+http://purl.obolibrary.org/obo/MONDO_0044967,limb disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002101,limb
+http://purl.obolibrary.org/obo/MONDO_0000491,limb ischemia,http://purl.obolibrary.org/obo/MONDO_0005053,ischemic disease,http://purl.obolibrary.org/obo/UBERON_0002101,limb
+http://purl.obolibrary.org/obo/MONDO_0004748,lip disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0001091,lipoma of colon,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0021630,lipoma of face,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001456,face
+http://purl.obolibrary.org/obo/MONDO_0000975,lipoma of spermatic cord,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0005352,spermatic cord
+http://purl.obolibrary.org/obo/MONDO_0021437,lipoma of stomach,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0003884,lipoma of the rectum,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002634,liposarcoma of bone,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0003589,liposarcoma of the ovary,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002387,liver angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0006267,liver cavernous hemangioma,http://purl.obolibrary.org/obo/MONDO_0003155,cavernous hemangioma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0006268,liver diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0018905,diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0005154,liver disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0002404,liver hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0004723,liver leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0003378,liver leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0000965,liver lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0004695,liver lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0015072,liver neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0002120,neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0002849,liver rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0015382,lower lip fistula,http://purl.obolibrary.org/obo/MONDO_0015476,cysts and fistulae of the face and oral cavity,http://purl.obolibrary.org/obo/UBERON_0001835,lower lip
+http://purl.obolibrary.org/obo/MONDO_0000270,lower respiratory tract disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001558,lower respiratory tract
+http://purl.obolibrary.org/obo/MONDO_0004828,lower urinary tract calculus,http://purl.obolibrary.org/obo/MONDO_0024647,urolithiasis,http://purl.obolibrary.org/obo/UBERON_0001556,lower urinary tract
+http://purl.obolibrary.org/obo/MONDO_0044339,lumbar disc degenerative disorder,http://purl.obolibrary.org/obo/MONDO_0011385,intervertebral disc degenerative disorder,http://purl.obolibrary.org/obo/UBERON_0006074,lumbar region of vertebral column
+http://purl.obolibrary.org/obo/MONDO_0044753,lumbar spinal stenosis,http://purl.obolibrary.org/obo/MONDO_0005965,spinal stenosis,http://purl.obolibrary.org/obo/UBERON_0006074,lumbar region of vertebral column
+http://purl.obolibrary.org/obo/MONDO_0004077,lumbosacral lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0006075,sacral region of vertebral column
+http://purl.obolibrary.org/obo/MONDO_0001829,lumbosacral plexus lesion,http://purl.obolibrary.org/obo/MONDO_0024432,nerve plexus disease,http://purl.obolibrary.org/obo/UBERON_0001815,lumbosacral nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0006041,lung carcinoid tumor,http://purl.obolibrary.org/obo/MONDO_0005369,carcinoid tumor (disease),http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0005275,lung disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003293,lung leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003357,lung leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003987,lung lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003638,lung meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0005454,lung neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0004928,lymph node disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000029,lymph node
+http://purl.obolibrary.org/obo/MONDO_0005833,lymphatic system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0006558,lymphatic part of lymphoid system
+http://purl.obolibrary.org/obo/MONDO_0044986,lymphoid system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002465,lymphoid system
+http://purl.obolibrary.org/obo/MONDO_0003004,macular degeneration,http://purl.obolibrary.org/obo/MONDO_0004580,retinal degeneration,http://purl.obolibrary.org/obo/UBERON_0000053,macula lutea
+http://purl.obolibrary.org/obo/MONDO_0003005,macular retinal edema,http://purl.obolibrary.org/obo/MONDO_0004037,retinal edema,http://purl.obolibrary.org/obo/UBERON_0000053,macula lutea
+http://purl.obolibrary.org/obo/MONDO_0005372,male infertility,http://purl.obolibrary.org/obo/MONDO_0005047,infertility disorder,http://purl.obolibrary.org/obo/UBERON_0000079,male reproductive system
+http://purl.obolibrary.org/obo/MONDO_0003150,male reproductive system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000079,male reproductive system
+http://purl.obolibrary.org/obo/MONDO_0002975,malignant breast melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003878,malignant choroid melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0003912,malignant ciliary body melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0002096,malignant conjunctival melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0004550,malignant cornea melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0004098,malignant melanocytic peripheral nerve sheath tumor of mediastinum,http://purl.obolibrary.org/obo/MONDO_0003863,malignant melanocytic neoplasm of the peripheral nerve sheath,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0015694,malignant melanoma of the mucosa,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000344,mucosa
+http://purl.obolibrary.org/obo/MONDO_0003805,malignant pericardial mesothelioma,http://purl.obolibrary.org/obo/MONDO_0006292,malignant mesothelioma (disease),http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0005512,malignant peritoneal mesothelioma,http://purl.obolibrary.org/obo/MONDO_0006292,malignant mesothelioma (disease),http://purl.obolibrary.org/obo/UBERON_0002358,peritoneum
+http://purl.obolibrary.org/obo/MONDO_0017604,marginal zone lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/CL_0000845,marginal zone B cell
+http://purl.obolibrary.org/obo/MONDO_0004457,maxillary sinus Schneiderian papilloma,http://purl.obolibrary.org/obo/MONDO_0006353,paranasal sinus Schneiderian papilloma,http://purl.obolibrary.org/obo/UBERON_0001764,maxillary sinus
+http://purl.obolibrary.org/obo/MONDO_0006577,maxillary sinus cholesteatoma,http://purl.obolibrary.org/obo/MONDO_0006530,cholesteatoma (disease),http://purl.obolibrary.org/obo/UBERON_0001764,maxillary sinus
+http://purl.obolibrary.org/obo/MONDO_0004914,median arcuate ligament syndrome,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0015215,median arcuate ligament
+http://purl.obolibrary.org/obo/MONDO_0003598,median nerve neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy,http://purl.obolibrary.org/obo/UBERON_0001148,median nerve
+http://purl.obolibrary.org/obo/MONDO_0043707,mediastinal diseases,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003255,mediastinal granular cell myoblastoma,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0004021,mediastinal malignant lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0004398,mediastinal schwannoma,http://purl.obolibrary.org/obo/MONDO_0002546,schwannoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003034,mediastinum angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0001096,mediastinum ganglioneuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005035,ganglioneuroblastoma (disease),http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003284,mediastinum leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003376,mediastinum leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0003601,mediastinum liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0001095,mediastinum neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0001426,mediastinum neurofibroma,http://purl.obolibrary.org/obo/MONDO_0016755,neurofibroma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0002851,mediastinum rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0021583,melanocytic skin neoplasm,http://purl.obolibrary.org/obo/MONDO_0021143,melanocytic neoplasm,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003761,meningeal melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000391,leptomeninx
+http://purl.obolibrary.org/obo/MONDO_0004512,meningeal melanomatosis,http://purl.obolibrary.org/obo/MONDO_0004141,melanomatosis,http://purl.obolibrary.org/obo/UBERON_0010743,meningeal cluster
+http://purl.obolibrary.org/obo/MONDO_0017079,meningoencephalocele,http://purl.obolibrary.org/obo/MONDO_0017078,cephalocele (disease),http://purl.obolibrary.org/obo/UBERON_0003547,brain meninx
+http://purl.obolibrary.org/obo/MONDO_0001116,mesenteric lymphadenitis,http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0002095,mesentery
+http://purl.obolibrary.org/obo/MONDO_0021643,mesenteric varices,http://purl.obolibrary.org/obo/MONDO_0008638,varicose disease,http://purl.obolibrary.org/obo/UBERON_0002095,mesentery
+http://purl.obolibrary.org/obo/MONDO_0015188,metabolic disease with intestinal involvement,http://purl.obolibrary.org/obo/MONDO_0005066,metabolic disease,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0044997,midbrain disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001891,midbrain
+http://purl.obolibrary.org/obo/MONDO_0003121,middle cranial fossa meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0003722,middle cranial fossa
+http://purl.obolibrary.org/obo/MONDO_0003276,middle ear disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0015071,middle ear neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0043219,migraine with brainstem aura,http://purl.obolibrary.org/obo/MONDO_0005475,migraine with aura,http://purl.obolibrary.org/obo/UBERON_0001633,basilar artery
+http://purl.obolibrary.org/obo/MONDO_0003767,mitral valve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002135,mitral valve
+http://purl.obolibrary.org/obo/MONDO_0004797,mononeuritis of lower limb,http://purl.obolibrary.org/obo/MONDO_0002121,mononeuritis simplex,http://purl.obolibrary.org/obo/UBERON_0002103,hindlimb
+http://purl.obolibrary.org/obo/MONDO_0020128,motor neuron disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/CL_0000100,motor neuron
+http://purl.obolibrary.org/obo/MONDO_0006858,mouth disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000165,mouth
+http://purl.obolibrary.org/obo/MONDO_0044992,mouth mucosa disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0003729,mouth mucosa
+http://purl.obolibrary.org/obo/MONDO_0003939,muscle tissue disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002385,muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0019119,muscular channelopathy,http://purl.obolibrary.org/obo/MONDO_0021016,channelopathy,http://purl.obolibrary.org/obo/UBERON_0002385,muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0005218,muscular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001630,muscle organ
+http://purl.obolibrary.org/obo/MONDO_0002081,musculoskeletal system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002204,musculoskeletal system
+http://purl.obolibrary.org/obo/MONDO_0024643,myocardial disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002349,myocardium
+http://purl.obolibrary.org/obo/MONDO_0024644,myocardial ischemia,http://purl.obolibrary.org/obo/MONDO_0005053,ischemic disease,http://purl.obolibrary.org/obo/UBERON_0002349,myocardium
+http://purl.obolibrary.org/obo/MONDO_0004746,myopathy of extraocular muscle,http://purl.obolibrary.org/obo/MONDO_0005336,myopathy,http://purl.obolibrary.org/obo/UBERON_0001601,extra-ocular muscle
+http://purl.obolibrary.org/obo/MONDO_0019283,nail anomaly,http://purl.obolibrary.org/obo/MONDO_0019277,epidermal appendage anomaly,http://purl.obolibrary.org/obo/UBERON_0001705,nail
+http://purl.obolibrary.org/obo/MONDO_0002884,nail disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001705,nail
+http://purl.obolibrary.org/obo/MONDO_0002232,nasal cavity disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0001130,nasal cavity lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0001129,nasal cavity olfactory neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0006329,olfactory neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0044984,nasolacrimal duct disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002392,nasolacrimal duct
+http://purl.obolibrary.org/obo/MONDO_0004821,nasopharyngeal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0004464,nephrogenic adenoma of the urethra,http://purl.obolibrary.org/obo/MONDO_0004191,nephrogenic adenoma,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0004190,nephrogenic adenoma of urinary bladder,http://purl.obolibrary.org/obo/MONDO_0004191,nephrogenic adenoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0024432,nerve plexus disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001810,nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0005071,nervous system disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0044745,nervous system injury,http://purl.obolibrary.org/obo/MONDO_0021178,injury,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0003926,neurilemmoma of the pleura,http://purl.obolibrary.org/obo/MONDO_0002546,schwannoma,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0003607,neuritis of upper limb,http://purl.obolibrary.org/obo/MONDO_0002122,neuritis,http://purl.obolibrary.org/obo/UBERON_0002102,forelimb
+http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease,http://purl.obolibrary.org/obo/MONDO_0024236,degenerative disorder,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003303,neurofibroma of gallbladder,http://purl.obolibrary.org/obo/MONDO_0016755,neurofibroma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0001789,neurofibroma of spinal cord,http://purl.obolibrary.org/obo/MONDO_0016755,neurofibroma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0004837,neurofibroma of the esophagus,http://purl.obolibrary.org/obo/MONDO_0016755,neurofibroma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004752,neurofibroma of the heart,http://purl.obolibrary.org/obo/MONDO_0016755,neurofibroma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0007450,neurohypophyseal diabetes insipidus,http://purl.obolibrary.org/obo/MONDO_0004782,diabetes insipidus,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0003256,neurohypophysis granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0002198,neurohypophysis
+http://purl.obolibrary.org/obo/MONDO_0045047,neurosarcoidosis,http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0043218,neurovascular disease,http://purl.obolibrary.org/obo/MONDO_0005071,nervous system disorder,http://purl.obolibrary.org/obo/UBERON_0002049,vasculature
+http://purl.obolibrary.org/obo/MONDO_0006321,non-functioning adrenal cortex adenoma,http://purl.obolibrary.org/obo/MONDO_0021119,non-functioning endocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0003603,non-functioning pituitary gland neoplasm,http://purl.obolibrary.org/obo/MONDO_0021119,non-functioning endocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0017451,non-syndromic brachydactyly of fingers,http://purl.obolibrary.org/obo/MONDO_0017424,non-syndromic brachydactyly,http://purl.obolibrary.org/obo/UBERON_0002398,manus
+http://purl.obolibrary.org/obo/MONDO_0017452,non-syndromic brachydactyly of toes,http://purl.obolibrary.org/obo/MONDO_0017424,non-syndromic brachydactyly,http://purl.obolibrary.org/obo/UBERON_0002387,pes
+http://purl.obolibrary.org/obo/MONDO_0015932,non-syndromic urogenital tract malformation of female,http://purl.obolibrary.org/obo/MONDO_0015619,non-syndromic urogenital tract malformation,http://purl.obolibrary.org/obo/UBERON_0003100,female organism
+http://purl.obolibrary.org/obo/MONDO_0015933,non-syndromic urogenital tract malformation of male,http://purl.obolibrary.org/obo/MONDO_0015619,non-syndromic urogenital tract malformation,http://purl.obolibrary.org/obo/UBERON_0003101,male organism
+http://purl.obolibrary.org/obo/MONDO_0002436,nose disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000004,nose
+http://purl.obolibrary.org/obo/MONDO_0045050,nuclear cataract,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease),http://purl.obolibrary.org/obo/UBERON_0000390,lens nucleus
+http://purl.obolibrary.org/obo/MONDO_0001847,nuclear senile cataract,http://purl.obolibrary.org/obo/MONDO_0004847,senile cataract,http://purl.obolibrary.org/obo/UBERON_0000390,lens nucleus
+http://purl.obolibrary.org/obo/MONDO_0006325,ocular melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0005878,ocular onchocerciasis,http://purl.obolibrary.org/obo/MONDO_0017137,onchocerciasis,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0001355,ocular siderosis,http://purl.obolibrary.org/obo/MONDO_0001436,hemosiderosis,http://purl.obolibrary.org/obo/UBERON_0000019,camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0005552,ocular vascular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002203,vasculature of eye
+http://purl.obolibrary.org/obo/MONDO_0001309,oculomotor nerve paralysis,http://purl.obolibrary.org/obo/MONDO_0002782,cranial nerve palsy,http://purl.obolibrary.org/obo/UBERON_0001643,oculomotor nerve
+http://purl.obolibrary.org/obo/MONDO_0001557,olecranon bursitis,http://purl.obolibrary.org/obo/MONDO_0002471,bursitis,http://purl.obolibrary.org/obo/UBERON_0006810,olecranon
+http://purl.obolibrary.org/obo/MONDO_0004446,olfactory groove meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0002772,olfactory sulcus
+http://purl.obolibrary.org/obo/MONDO_0002727,olfactory nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001579,olfactory nerve
+http://purl.obolibrary.org/obo/MONDO_0001898,optic choroid disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0003234,optic nerve astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0000941,cranial nerve II
+http://purl.obolibrary.org/obo/MONDO_0002135,optic nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000941,cranial nerve II
+http://purl.obolibrary.org/obo/MONDO_0003235,optic nerve glioma,http://purl.obolibrary.org/obo/MONDO_0021042,glioma,http://purl.obolibrary.org/obo/UBERON_0000941,cranial nerve II
+http://purl.obolibrary.org/obo/MONDO_0016167,optic pathway glioma,http://purl.obolibrary.org/obo/MONDO_0021042,glioma,http://purl.obolibrary.org/obo/UBERON_0001908,optic tract
+http://purl.obolibrary.org/obo/MONDO_0024649,optic tract astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0001908,optic tract
+http://purl.obolibrary.org/obo/MONDO_0024648,optic tract meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0001908,optic tract
+http://purl.obolibrary.org/obo/MONDO_0002580,orbit rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0004088,orbital region
+http://purl.obolibrary.org/obo/MONDO_0002880,ovarian adenosarcoma,http://purl.obolibrary.org/obo/MONDO_0005636,adenosarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003035,ovarian angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003695,ovarian clear cell adenofibroma,http://purl.obolibrary.org/obo/MONDO_0003460,clear cell adenofibroma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003694,ovarian clear cell cystadenofibroma,http://purl.obolibrary.org/obo/MONDO_0003693,clear cell cystadenofibroma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0005558,ovarian disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0044098,ovarian ectopic pregnancy,http://purl.obolibrary.org/obo/MONDO_0000755,ectopic pregnancy,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003812,ovarian endometrial cancer,http://purl.obolibrary.org/obo/MONDO_0002480,endometrioid tumor,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006335,ovarian endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0005461,endometrium adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003312,ovarian endometrioid stromal and related neoplasms,http://purl.obolibrary.org/obo/MONDO_0037742,endometrioid stromal and related neoplasms,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006337,ovarian endometriosis,http://purl.obolibrary.org/obo/MONDO_0005133,endometriosis (disease),http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002697,ovarian gonadoblastoma (disease),http://purl.obolibrary.org/obo/MONDO_0010768,gonadoblastoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0023283,ovarian granulosa cell tumor,http://purl.obolibrary.org/obo/MONDO_0006036,granulosa cell tumor,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003049,ovarian large-cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0005057,large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002227,ovarian lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002223,ovarian malignant mesothelioma,http://purl.obolibrary.org/obo/MONDO_0006292,malignant mesothelioma (disease),http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0000543,ovarian melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003887,ovarian mucinous adenofibroma,http://purl.obolibrary.org/obo/MONDO_0002398,mucinous adenofibroma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0004436,ovarian myxoid liposarcoma,http://purl.obolibrary.org/obo/MONDO_0013280,myxoid liposarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002481,ovarian neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006340,ovarian serous adenofibroma,http://purl.obolibrary.org/obo/MONDO_0024886,serous adenofibroma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0021657,ovarian sex cord-stromal tumor,http://purl.obolibrary.org/obo/MONDO_0006055,sex cord-stromal tumor,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003795,ovarian small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0037253,ovarian thecoma,http://purl.obolibrary.org/obo/MONDO_0037252,thecoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0003355,ovary leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002858,ovary rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0020179,palpebral nevus,http://purl.obolibrary.org/obo/MONDO_0005073,melanocytic nevus,http://purl.obolibrary.org/obo/UBERON_0001457,skin of eyelid
+http://purl.obolibrary.org/obo/MONDO_0002356,pancreas disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0002114,pancreas lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0003525,pancreatic gastrin-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0003523,gastrin-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0006347,pancreatic large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0005057,large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0006348,pancreatic small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000016,endocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0003261,papillary meningioma of the cerebellum,http://purl.obolibrary.org/obo/MONDO_0021088,papillary meningioma,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0001735,paranasal sinus disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0001743,paranasal sinus lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0018215,paraneoplastic neurologic syndrome,http://purl.obolibrary.org/obo/MONDO_0021073,paraneoplastic syndrome,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0044995,parasympathetic nervous system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000011,parasympathetic nervous system
+http://purl.obolibrary.org/obo/MONDO_0021052,parasympathetic paraganglioma,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://purl.obolibrary.org/obo/UBERON_0000011,parasympathetic nervous system
+http://purl.obolibrary.org/obo/MONDO_0001223,parathyroid gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001132,parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0000520,parietal lobe ependymal tumor,http://purl.obolibrary.org/obo/MONDO_0003266,ependymal tumor,http://purl.obolibrary.org/obo/UBERON_0001872,parietal lobe
+http://purl.obolibrary.org/obo/MONDO_0005899,parotid disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0001042,patellar tendinitis,http://purl.obolibrary.org/obo/MONDO_0004857,tendinitis,http://purl.obolibrary.org/obo/UBERON_0002446,patella
+http://purl.obolibrary.org/obo/MONDO_0005902,peanut allergic reaction,http://purl.obolibrary.org/obo/MONDO_0006872,nut allergic reaction,http://purl.obolibrary.org/obo/CL_0002303,pigmented ciliary epithelial cell
+http://purl.obolibrary.org/obo/MONDO_0004869,pelvic varices,http://purl.obolibrary.org/obo/MONDO_0008638,varicose disease,http://purl.obolibrary.org/obo/UBERON_0002355,pelvic region of trunk
+http://purl.obolibrary.org/obo/MONDO_0002036,penile disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0004504,penile urethral cancer,http://purl.obolibrary.org/obo/MONDO_0004192,urethra cancer,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0002935,penis basal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0000474,pericardium disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0003294,pericardium leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0002635,periodontal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001758,periodontium
+http://purl.obolibrary.org/obo/MONDO_0003680,periosteal chondrosarcoma,http://purl.obolibrary.org/obo/MONDO_0008977,chondrosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002515,periosteum
+http://purl.obolibrary.org/obo/MONDO_0003327,peripheral ganglioneuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005035,ganglioneuroblastoma (disease),http://purl.obolibrary.org/obo/UBERON_0000010,peripheral nervous system
+http://purl.obolibrary.org/obo/MONDO_0003620,peripheral nervous system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000010,peripheral nervous system
+http://purl.obolibrary.org/obo/MONDO_0002981,peripheral primitive neuroectodermal tumor of bone,http://purl.obolibrary.org/obo/MONDO_0018271,peripheral primitive neuroectodermal tumor,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0003171,pineal gland astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0001905,pineal body
+http://purl.obolibrary.org/obo/MONDO_0004440,pineal region meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0001905,pineal body
+http://purl.obolibrary.org/obo/MONDO_0003381,pituitary gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0004447,pituitary stalk meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0002434,pituitary stalk
+http://purl.obolibrary.org/obo/MONDO_0005917,placenta disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001987,placenta
+http://purl.obolibrary.org/obo/MONDO_0006375,placental hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001987,placenta
+http://purl.obolibrary.org/obo/MONDO_0004684,plantar fibromatosis,http://purl.obolibrary.org/obo/MONDO_0016037,superficial fibromatosis,http://purl.obolibrary.org/obo/UBERON_0008338,plantar part of pes
+http://purl.obolibrary.org/obo/MONDO_0001541,plantar nerve lesion,http://purl.obolibrary.org/obo/MONDO_0024334,peripheral nerve lesion,http://purl.obolibrary.org/obo/UBERON_0035109,plantar nerve
+http://purl.obolibrary.org/obo/MONDO_0009693,plasma cell myeloma,http://purl.obolibrary.org/obo/MONDO_0005170,myeloid neoplasm,http://purl.obolibrary.org/obo/CL_0000786,plasma cell
+http://purl.obolibrary.org/obo/MONDO_0002037,pleural disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0006378,pleural epithelioid mesothelioma,http://purl.obolibrary.org/obo/MONDO_0005599,malignant epithelioid mesothelioma,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0000969,pleural lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0006380,pleural sarcomatoid mesothelioma,http://purl.obolibrary.org/obo/MONDO_0006407,sarcomatoid mesothelioma,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0001339,portal vein thrombosis,http://purl.obolibrary.org/obo/MONDO_0000831,thrombotic disease,http://purl.obolibrary.org/obo/UBERON_0002017,portal vein
+http://purl.obolibrary.org/obo/MONDO_0003068,postauricular lymphadenitis,http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0016392,mastoid lymph node
+http://purl.obolibrary.org/obo/MONDO_0002919,posterior cranial fossa meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0008788,posterior cranial fossa
+http://purl.obolibrary.org/obo/MONDO_0044101,"pregnancy, cornual",http://purl.obolibrary.org/obo/MONDO_0000755,ectopic pregnancy,http://purl.obolibrary.org/obo/UBERON_0002247,uterine horn
+http://purl.obolibrary.org/obo/MONDO_0017814,primary bone lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0017907,primary lymphoma of the conjunctiva,http://purl.obolibrary.org/obo/MONDO_0017207,primary organ-specific lymphoma,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0041284,primary motor cortex epilepsy,http://purl.obolibrary.org/obo/MONDO_0005027,epilepsy,http://purl.obolibrary.org/obo/UBERON_0001384,primary motor cortex
+http://purl.obolibrary.org/obo/MONDO_0016263,primitive neuroectodermal tumor of the corpus uteri,http://purl.obolibrary.org/obo/MONDO_0005462,primitive neuroectodermal tumor,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003033,prostate angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0001776,prostate calculus,http://purl.obolibrary.org/obo/MONDO_0004828,lower urinary tract calculus,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0003105,prostate disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002574,prostate embryonal rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0009993,embryonal rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002452,prostate leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0003368,prostate leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0000996,prostate lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002477,prostate neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0006389,prostate rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0006390,prostate small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0003791,prostatic urethral cancer,http://purl.obolibrary.org/obo/MONDO_0004197,male urethral cancer,http://purl.obolibrary.org/obo/UBERON_0001335,prostatic urethra
+http://purl.obolibrary.org/obo/MONDO_0018957,pudendal neuralgia,http://purl.obolibrary.org/obo/MONDO_0021667,neuralgia,http://purl.obolibrary.org/obo/UBERON_0011390,pudendal nerve
+http://purl.obolibrary.org/obo/MONDO_0004207,pulmonary artery leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002012,pulmonary artery
+http://purl.obolibrary.org/obo/MONDO_0003960,pulmonary large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0005057,large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0001708,pulmonary sarcoidosis,http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0003628,pulmonary valve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002146,pulmonary valve
+http://purl.obolibrary.org/obo/MONDO_0004206,pulmonary vein leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002016,pulmonary vein
+http://purl.obolibrary.org/obo/MONDO_0001890,pulp erosion,http://purl.obolibrary.org/obo/MONDO_0002325,"tooth erosion, non-bacterial",http://purl.obolibrary.org/obo/UBERON_0001754,dental pulp
+http://purl.obolibrary.org/obo/MONDO_0002285,pupil disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001771,pupil
+http://purl.obolibrary.org/obo/MONDO_0006940,radial nerve lesion,http://purl.obolibrary.org/obo/MONDO_0024334,peripheral nerve lesion,http://purl.obolibrary.org/obo/UBERON_0001492,radial nerve
+http://purl.obolibrary.org/obo/MONDO_0001459,radial neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy,http://purl.obolibrary.org/obo/UBERON_0001492,radial nerve
+http://purl.obolibrary.org/obo/MONDO_0001593,rectal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0003796,rectum Kaposi sarcoma,http://purl.obolibrary.org/obo/MONDO_0005055,Kaposi's sarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0004125,rectum leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0003379,rectum leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002166,rectum lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002167,rectum malignant melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0003646,rectum neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002853,rectum rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0044347,red blood cell disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/CL_0000232,erythrocyte
+http://purl.obolibrary.org/obo/MONDO_0001876,renal artery atheroma,http://purl.obolibrary.org/obo/MONDO_0005311,atherosclerosis,http://purl.obolibrary.org/obo/UBERON_0001184,renal artery
+http://purl.obolibrary.org/obo/MONDO_0006053,renal leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0021568,renal tubule disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0009773,renal tubule
+http://purl.obolibrary.org/obo/MONDO_0005039,reproductive system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000990,reproductive system
+http://purl.obolibrary.org/obo/MONDO_0005087,respiratory system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001004,respiratory system
+http://purl.obolibrary.org/obo/MONDO_0004006,rete ovarii cystadenofibroma,http://purl.obolibrary.org/obo/MONDO_0003464,cystadenofibroma,http://purl.obolibrary.org/obo/UBERON_0010185,rete ovarii
+http://purl.obolibrary.org/obo/MONDO_0004349,retina lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0005283,retinal disease,http://purl.obolibrary.org/obo/MONDO_0005328,eye disease,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0001666,retinal dystrophies primarily involving Bruch's membrane,http://purl.obolibrary.org/obo/MONDO_0019118,inherited retinal dystrophy,http://purl.obolibrary.org/obo/UBERON_0003957,Bruch's membrane
+http://purl.obolibrary.org/obo/MONDO_0003343,retinal hemangioblastoma,http://purl.obolibrary.org/obo/MONDO_0016748,hemangioblastoma,http://purl.obolibrary.org/obo/UBERON_0004864,vasculature of retina
+http://purl.obolibrary.org/obo/MONDO_0001538,retinal ischemia,http://purl.obolibrary.org/obo/MONDO_0005053,ischemic disease,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0004561,retinal melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0003579,retinal nerve fibre layer disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001793,nerve fiber layer of retina
+http://purl.obolibrary.org/obo/MONDO_0024340,retinal neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0003370,retroperitoneal leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0001499,retroperitoneal lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0000551,retroperitoneal neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0016282,rhabdomyosarcoma of the cervix uteri,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0042967,rheumatic disease of mitral valve,http://purl.obolibrary.org/obo/MONDO_0005554,rheumatologic disorder,http://purl.obolibrary.org/obo/UBERON_0002135,mitral valve
+http://purl.obolibrary.org/obo/MONDO_0003627,rheumatic pulmonary valve disease,http://purl.obolibrary.org/obo/MONDO_0005554,rheumatologic disorder,http://purl.obolibrary.org/obo/UBERON_0002146,pulmonary valve
+http://purl.obolibrary.org/obo/MONDO_0006957,root caries,http://purl.obolibrary.org/obo/MONDO_0005276,dental caries,http://purl.obolibrary.org/obo/UBERON_0001753,cementum
+http://purl.obolibrary.org/obo/MONDO_0024454,sacral nerve plexus disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0034986,sacral nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0000518,sacrum chordoma,http://purl.obolibrary.org/obo/MONDO_0008978,chordoma (disease),http://purl.obolibrary.org/obo/UBERON_0003690,fused sacrum
+http://purl.obolibrary.org/obo/MONDO_0006402,salivary gland basal cell adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0001142,salivary gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0006405,salivary gland small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0044999,scalp disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000403,scalp
+http://purl.obolibrary.org/obo/MONDO_0003980,schwannoma of jugular foramen,http://purl.obolibrary.org/obo/MONDO_0002546,schwannoma,http://purl.obolibrary.org/obo/UBERON_0005456,jugular foramen
+http://purl.obolibrary.org/obo/MONDO_0002549,schwannoma of twelfth cranial nerve,http://purl.obolibrary.org/obo/MONDO_0002546,schwannoma,http://purl.obolibrary.org/obo/UBERON_0001650,hypoglossal nerve
+http://purl.obolibrary.org/obo/MONDO_0001400,schwannoma of ureter,http://purl.obolibrary.org/obo/MONDO_0002546,schwannoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0001269,scleral disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001773,sclera
+http://purl.obolibrary.org/obo/MONDO_0045003,scrotal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0003951,scrotal hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0002936,scrotum basal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0001652,scrotum melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0003635,sebaceous breast carcinoma,http://purl.obolibrary.org/obo/MONDO_0006962,sebaceous adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0019286,sebaceous gland anomaly,http://purl.obolibrary.org/obo/MONDO_0019277,epidermal appendage anomaly,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0006607,sebaceous gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0006609,seborrheic infantile dermatitis,http://purl.obolibrary.org/obo/MONDO_0006608,seborrheic dermatitis (disease),http://purl.obolibrary.org/obo/UBERON_0000403,scalp
+http://purl.obolibrary.org/obo/MONDO_0021260,sensory ganglionopathy,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001800,sensory ganglion
+http://purl.obolibrary.org/obo/MONDO_0002321,sensory peripheral neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy,http://purl.obolibrary.org/obo/UBERON_0001027,sensory nerve
+http://purl.obolibrary.org/obo/MONDO_0005128,sensory system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001032,sensory system
+http://purl.obolibrary.org/obo/MONDO_0003671,septal myocardial infarction,http://purl.obolibrary.org/obo/MONDO_0005068,myocardial infarction (disease),http://purl.obolibrary.org/obo/UBERON_0002099,cardiac septum
+http://purl.obolibrary.org/obo/MONDO_0006969,sialadenitis,http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0000469,sinoatrial node disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002351,sinoatrial node
+http://purl.obolibrary.org/obo/MONDO_0045004,skeletal ligament disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0008846,skeletal ligament
+http://purl.obolibrary.org/obo/MONDO_0020120,skeletal muscle disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001134,skeletal muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0005172,skeletal system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001434,skeletal system
+http://purl.obolibrary.org/obo/MONDO_0003029,skin angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0024481,skin appendage disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000021,cutaneous appendage
+http://purl.obolibrary.org/obo/MONDO_0005093,skin disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0001939,skin epithelioid hemangioma,http://purl.obolibrary.org/obo/MONDO_0003119,histiocytoid hemangioma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003110,skin hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0000964,skin lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0004429,skin meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0019288,skin pigmentation disease,http://purl.obolibrary.org/obo/MONDO_0006600,pigmentation disease,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0006611,skin sarcoidosis,http://purl.obolibrary.org/obo/MONDO_0019338,sarcoidosis,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0002998,skull base meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0002517,basicranium
+http://purl.obolibrary.org/obo/MONDO_0024654,skull disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0003129,skull
+http://purl.obolibrary.org/obo/MONDO_0008433,small cell lung carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0006416,small intestinal Burkitt lymphoma,http://purl.obolibrary.org/obo/MONDO_0007243,Burkitts lymphoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0004252,small intestinal L-cell glucagon-like peptide producing tumor,http://purl.obolibrary.org/obo/MONDO_0004211,L-cell glucagon-like peptide-producing neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0006417,small intestinal diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0018905,diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0006418,small intestinal enteropathy-associated T-cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0019473,enteropathy-associated T-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0006420,small intestinal mucosa-associated lymphoid tissue lymphoma,http://purl.obolibrary.org/obo/MONDO_0007650,MALT lymphoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0024635,small intestine disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0001229,small intestine diverticulitis,http://purl.obolibrary.org/obo/MONDO_0004235,diverticulitis,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0002092,small intestine leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0003360,small intestine leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0001852,small intestine lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0018510,small intestine neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0002756,solitary plasmacytoma of chest wall,http://purl.obolibrary.org/obo/MONDO_0005615,plasmacytoma,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0005964,sphenoid sinusitis,http://purl.obolibrary.org/obo/MONDO_0005961,sinusitis,http://purl.obolibrary.org/obo/UBERON_0001677,sphenoid bone
+http://purl.obolibrary.org/obo/MONDO_0003174,spinal cord astrocytoma,http://purl.obolibrary.org/obo/MONDO_0019781,astrocytoma (excluding glioblastoma),http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0002545,spinal cord disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0003473,spinal cord ependymoma,http://purl.obolibrary.org/obo/MONDO_0016698,ependymoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0002542,spinal cord glioma,http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0043797,spinal cord injury,http://purl.obolibrary.org/obo/MONDO_0021178,injury,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0001790,spinal cord lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0001892,spinal cord lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0001893,spinal cord melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0004024,spinal cord neuroblastoma,http://purl.obolibrary.org/obo/MONDO_0005072,neuroblastoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0002541,spinal cord oligodendroglioma,http://purl.obolibrary.org/obo/MONDO_0016695,oligodendroglioma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0005309,spinal fracture,http://purl.obolibrary.org/obo/MONDO_0005315,bone fracture,http://purl.obolibrary.org/obo/UBERON_0001130,vertebral column
+http://purl.obolibrary.org/obo/MONDO_0037747,spinal injury,http://purl.obolibrary.org/obo/MONDO_0021178,injury,http://purl.obolibrary.org/obo/UBERON_0001130,vertebral column
+http://purl.obolibrary.org/obo/MONDO_0001275,spinal meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0002376,spleen angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0002332,splenic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0002343,splenic hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0004104,splenic manifestation of hairy cell leukemia,http://purl.obolibrary.org/obo/MONDO_0018935,hairy cell leukemia,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0004107,splenic manifestation of leukemia,http://purl.obolibrary.org/obo/MONDO_0005059,leukemia (disease),http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0002966,splenic manifestation of prolymphocytic leukemia,http://purl.obolibrary.org/obo/MONDO_0001023,prolymphocytic leukemia,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0003988,sternum lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000975,sternum
+http://purl.obolibrary.org/obo/MONDO_0004298,stomach disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0020213,stromal corneal dystrophy,http://purl.obolibrary.org/obo/MONDO_0018102,corneal dystrophy (disease),http://purl.obolibrary.org/obo/UBERON_0001777,substantia propria of cornea
+http://purl.obolibrary.org/obo/MONDO_0019296,subcutaneous tissue disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0011818,superficial fascia
+http://purl.obolibrary.org/obo/MONDO_0003674,subendocardial myocardial infarction,http://purl.obolibrary.org/obo/MONDO_0005068,myocardial infarction (disease),http://purl.obolibrary.org/obo/UBERON_0005984,subendocardium layer
+http://purl.obolibrary.org/obo/MONDO_0003115,subglottic hemangioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0036068,subglottis
+http://purl.obolibrary.org/obo/MONDO_0003066,submandibular adenitis,http://purl.obolibrary.org/obo/MONDO_0002052,lymphadenitis (disease),http://purl.obolibrary.org/obo/UBERON_0001736,submandibular gland
+http://purl.obolibrary.org/obo/MONDO_0001597,submandibular gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001736,submandibular gland
+http://purl.obolibrary.org/obo/MONDO_0002687,superior mesenteric artery syndrome,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0001182,superior mesenteric artery
+http://purl.obolibrary.org/obo/MONDO_0003032,superior vena cava angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001585,anterior vena cava
+http://purl.obolibrary.org/obo/MONDO_0004208,superior vena cava leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001585,anterior vena cava
+http://purl.obolibrary.org/obo/MONDO_0015550,suprabasal epidermolysis bullosa simplex,http://purl.obolibrary.org/obo/MONDO_0017610,epidermolysis bullosa simplex,http://purl.obolibrary.org/obo/UBERON_0010402,epidermis suprabasal layer
+http://purl.obolibrary.org/obo/MONDO_0004312,suprasellar meningioma,http://purl.obolibrary.org/obo/MONDO_0016642,meningioma (disease),http://purl.obolibrary.org/obo/UBERON_0003689,sella turcica
+http://purl.obolibrary.org/obo/MONDO_0006615,sweat gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001820,sweat gland
+http://purl.obolibrary.org/obo/MONDO_0044993,sympathetic nervous system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000013,sympathetic nervous system
+http://purl.obolibrary.org/obo/MONDO_0021072,sympathetic paraganglioma,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://purl.obolibrary.org/obo/UBERON_0000013,sympathetic nervous system
+http://purl.obolibrary.org/obo/MONDO_0004519,synovial angioma,http://purl.obolibrary.org/obo/MONDO_0006500,hemangioma,http://purl.obolibrary.org/obo/UBERON_0007616,layer of synovial tissue
+http://purl.obolibrary.org/obo/MONDO_0005115,temporal lobe epilepsy,http://purl.obolibrary.org/obo/MONDO_0005027,epilepsy,http://purl.obolibrary.org/obo/UBERON_0001871,temporal lobe
+http://purl.obolibrary.org/obo/MONDO_0100010,tendinopathy,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000043,tendon
+http://purl.obolibrary.org/obo/MONDO_0024876,tendon sheath disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000304,tendon sheath
+http://purl.obolibrary.org/obo/MONDO_0004076,tendon sheath lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0000304,tendon sheath
+http://purl.obolibrary.org/obo/MONDO_0003124,testicular Leydig cell tumor,http://purl.obolibrary.org/obo/MONDO_0006266,Leydig cell tumor,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0002329,testicular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0002698,testicular gonadoblastoma (disease),http://purl.obolibrary.org/obo/MONDO_0010768,gonadoblastoma,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0003395,testicular granulosa cell tumor,http://purl.obolibrary.org/obo/MONDO_0006036,granulosa cell tumor,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0003125,testicular sex cord-stromal neoplasm,http://purl.obolibrary.org/obo/MONDO_0006055,sex cord-stromal tumor,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0004325,testicular thecoma,http://purl.obolibrary.org/obo/MONDO_0037252,thecoma,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0002860,testis rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0003081,thalamic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001897,dorsal plus ventral thalamus
+http://purl.obolibrary.org/obo/MONDO_0003546,third cranial nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001643,oculomotor nerve
+http://purl.obolibrary.org/obo/MONDO_0044342,thoracic disc degenerative disorder,http://purl.obolibrary.org/obo/MONDO_0011385,intervertebral disc degenerative disorder,http://purl.obolibrary.org/obo/UBERON_0006073,thoracic region of vertebral column
+http://purl.obolibrary.org/obo/MONDO_0000651,thoracic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000915,thoracic segment of trunk
+http://purl.obolibrary.org/obo/MONDO_0003047,thymic large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0005057,large cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0020516,thymic neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0002120,neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0019964,thymic neuroendocrine tumor,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0003393,thymus gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0002163,thymus lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0000951,thymus lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0004122,thymus small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0003027,thyroid gland angiosarcoma,http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0006462,thyroid gland diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/MONDO_0018905,diffuse large B-cell lymphoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0003240,thyroid gland disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0019962,thyroid lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0005320,tibia fracture,http://purl.obolibrary.org/obo/MONDO_0005315,bone fracture,http://purl.obolibrary.org/obo/UBERON_0000979,tibia
+http://purl.obolibrary.org/obo/MONDO_0006469,tibial adamantinoma,http://purl.obolibrary.org/obo/MONDO_0002422,adamantinoma,http://purl.obolibrary.org/obo/UBERON_0000979,tibia
+http://purl.obolibrary.org/obo/MONDO_0001127,tibialis tendinitis,http://purl.obolibrary.org/obo/MONDO_0004857,tendinitis,http://purl.obolibrary.org/obo/UBERON_0008230,tibialis
+http://purl.obolibrary.org/obo/MONDO_0000242,tinea barbae,http://purl.obolibrary.org/obo/MONDO_0004678,dermatophytosis,http://purl.obolibrary.org/obo/UBERON_0010167,beard
+http://purl.obolibrary.org/obo/MONDO_0001699,tinea manuum,http://purl.obolibrary.org/obo/MONDO_0004678,dermatophytosis,http://purl.obolibrary.org/obo/UBERON_0002398,manus
+http://purl.obolibrary.org/obo/MONDO_0005984,tinea pedis,http://purl.obolibrary.org/obo/MONDO_0004678,dermatophytosis,http://purl.obolibrary.org/obo/UBERON_0002387,pes
+http://purl.obolibrary.org/obo/MONDO_0001628,tinea unguium,http://purl.obolibrary.org/obo/MONDO_0004678,dermatophytosis,http://purl.obolibrary.org/obo/UBERON_0001705,nail
+http://purl.obolibrary.org/obo/MONDO_0001165,tongue disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0044885,tonsillar lipoma,http://purl.obolibrary.org/obo/MONDO_0005106,lipoma,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0044884,tonsillar lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0008007,tooth ankylosis,http://purl.obolibrary.org/obo/MONDO_0002257,ankylosis (disease),http://purl.obolibrary.org/obo/UBERON_0001091,calcareous tooth
+http://purl.obolibrary.org/obo/MONDO_0006999,tooth disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001091,calcareous tooth
+http://purl.obolibrary.org/obo/MONDO_0002318,trachea leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0002567,tracheal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0001417,tracheal lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0000471,tricuspid valve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002134,tricuspid valve
+http://purl.obolibrary.org/obo/MONDO_0003543,trigeminal nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001645,trigeminal nerve
+http://purl.obolibrary.org/obo/MONDO_0008599,trigeminal neuralgia,http://purl.obolibrary.org/obo/MONDO_0021667,neuralgia,http://purl.obolibrary.org/obo/UBERON_0001645,trigeminal nerve
+http://purl.obolibrary.org/obo/MONDO_0002555,trigeminal schwannoma,http://purl.obolibrary.org/obo/MONDO_0002546,schwannoma,http://purl.obolibrary.org/obo/UBERON_0001645,trigeminal nerve
+http://purl.obolibrary.org/obo/MONDO_0007002,trochlear nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001644,trochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0043762,tubal pregnancy,http://purl.obolibrary.org/obo/MONDO_0000755,ectopic pregnancy,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0004339,tuberculum sellae meningioma,http://purl.obolibrary.org/obo/MONDO_0002720,sella turcica neoplasm,http://purl.obolibrary.org/obo/UBERON_0035298,tuberculum sellae
+http://purl.obolibrary.org/obo/MONDO_0003648,tympanic membrane disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002364,tympanic membrane
+http://purl.obolibrary.org/obo/MONDO_0005322,ulna fracture,http://purl.obolibrary.org/obo/MONDO_0005315,bone fracture,http://purl.obolibrary.org/obo/UBERON_0001424,ulna
+http://purl.obolibrary.org/obo/MONDO_0001458,ulnar nerve lesion,http://purl.obolibrary.org/obo/MONDO_0024334,peripheral nerve lesion,http://purl.obolibrary.org/obo/UBERON_0001494,ulnar nerve
+http://purl.obolibrary.org/obo/MONDO_0007006,ulnar neuropathy,http://purl.obolibrary.org/obo/MONDO_0001397,mononeuropathy,http://purl.obolibrary.org/obo/UBERON_0001494,ulnar nerve
+http://purl.obolibrary.org/obo/MONDO_0044991,upper digestive tract disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0004908,upper digestive tract
+http://purl.obolibrary.org/obo/MONDO_0002130,upper limb mononeuronitis,http://purl.obolibrary.org/obo/MONDO_0002121,mononeuritis simplex,http://purl.obolibrary.org/obo/UBERON_0002102,forelimb
+http://purl.obolibrary.org/obo/MONDO_0004867,upper respiratory tract disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001557,upper respiratory tract
+http://purl.obolibrary.org/obo/MONDO_0001399,ureter leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0006482,ureter small cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0001926,ureteral disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0001977,ureteral lymphoma,http://purl.obolibrary.org/obo/MONDO_0005062,lymphoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0002222,urethra leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0004826,urethral calculus,http://purl.obolibrary.org/obo/MONDO_0024647,urolithiasis,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0004184,urethral disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0006026,urinary bladder disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0004114,urinary bladder small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/MONDO_0000402,small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0002118,urinary system disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001008,renal system
+http://purl.obolibrary.org/obo/MONDO_0004172,uterine corpus adenocarcinofibroma,http://purl.obolibrary.org/obo/MONDO_0002991,adenocarcinofibroma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003458,uterine corpus adenofibroma,http://purl.obolibrary.org/obo/MONDO_0006071,adenofibroma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002878,uterine corpus adenosarcoma,http://purl.obolibrary.org/obo/MONDO_0005636,adenosarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0004386,uterine corpus atypical polypoid adenomyoma,http://purl.obolibrary.org/obo/MONDO_0003236,atypical polypoid adenomyoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0001846,uterine corpus bizarre leiomyoma,http://purl.obolibrary.org/obo/MONDO_0003288,bizarre leiomyoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0004162,uterine corpus cellular leiomyoma,http://purl.obolibrary.org/obo/MONDO_0003296,cellular leiomyoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0000553,uterine corpus endometrial carcinoma,http://purl.obolibrary.org/obo/MONDO_0002447,endometrial carcinoma (disease),http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002923,uterine corpus endometrial stromal sarcoma,http://purl.obolibrary.org/obo/MONDO_0006745,endometrioid stromal sarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003782,uterine corpus epithelioid leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0003356,epithelioid leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0007886,uterine corpus leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003703,uterine corpus leiomyomatosis,http://purl.obolibrary.org/obo/MONDO_0003295,leiomyomatosis,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0003928,uterine corpus myxoid leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0003359,myxoid leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0021650,uterine corpus neuroendocrine neoplasm,http://purl.obolibrary.org/obo/MONDO_0019496,neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0016260,uterine corpus rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002654,uterine disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0003663,uterine ligament endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0005026,endometrioid adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0036262,uterine ligament
+http://purl.obolibrary.org/obo/MONDO_0003702,uterus intravascular leiomyomatosis,http://purl.obolibrary.org/obo/MONDO_0003614,intravenous leiomyomatosis,http://purl.obolibrary.org/obo/UBERON_0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0002661,uveal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0006486,uveal melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0003369,vagina leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0002881,vaginal adenosarcoma,http://purl.obolibrary.org/obo/MONDO_0005636,adenosarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0001433,vaginal disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0001536,vaginal leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0006489,vaginal melanoma,http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0016095,vaginal rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005212,rhabdomyosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0001535,vagus nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001759,vagus nerve
+http://purl.obolibrary.org/obo/MONDO_0044768,vagus nerve paraganglioma,http://purl.obolibrary.org/obo/MONDO_0000448,paraganglioma,http://purl.obolibrary.org/obo/UBERON_0001759,vagus nerve
+http://purl.obolibrary.org/obo/MONDO_0001498,varicocele,http://purl.obolibrary.org/obo/MONDO_0008638,varicose disease,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0005385,vascular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002049,vasculature
+http://purl.obolibrary.org/obo/MONDO_0004634,vein disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001638,vein
+http://purl.obolibrary.org/obo/MONDO_0001631,vertebral artery insufficiency,http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/UBERON_0001535,vertebral artery
+http://purl.obolibrary.org/obo/MONDO_0000812,vertebral column disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001130,vertebral column
+http://purl.obolibrary.org/obo/MONDO_0045002,vertebral disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0002412,vertebra
+http://purl.obolibrary.org/obo/MONDO_0037847,vertebral joint disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001468,intervertebral joint
+http://purl.obolibrary.org/obo/MONDO_0002643,vestibular disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001862,vestibular labyrinth
+http://purl.obolibrary.org/obo/MONDO_0001563,vestibulocochlear nerve disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001648,vestibulocochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0003584,visual cortex disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0000411,visual cortex
+http://purl.obolibrary.org/obo/MONDO_0001834,visual pathway disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001908,optic tract
+http://purl.obolibrary.org/obo/MONDO_0044137,vitreous body disorder,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001798,vitreous body
+http://purl.obolibrary.org/obo/MONDO_0004860,vitreous disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder,http://purl.obolibrary.org/obo/UBERON_0001797,vitreous humor
+http://purl.obolibrary.org/obo/MONDO_0002955,vulva basal cell carcinoma,http://purl.obolibrary.org/obo/MONDO_0005341,skin basal cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0006620,vulva fibroepithelial polyp,http://purl.obolibrary.org/obo/MONDO_0004026,skin tag,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0021642,vulval varices,http://purl.obolibrary.org/obo/MONDO_0008638,varicose disease,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0002192,vulvar angiokeratoma,http://purl.obolibrary.org/obo/MONDO_0003954,angiokeratoma of Fordyce,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003881,vulvar apocrine adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0003214,apocrine adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003995,vulvar childhood botryoid-type embryonal rhabdomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0003992,childhood botryoid rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003861,vulvar eccrine adenocarcinoma,http://purl.obolibrary.org/obo/MONDO_0024240,eccrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0004281,vulvar eccrine porocarcinoma,http://purl.obolibrary.org/obo/MONDO_0006189,eccrine porocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003253,vulvar granular cell tumor,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0006621,vulvar inverted follicular keratosis,http://purl.obolibrary.org/obo/MONDO_0006563,inverted follicular keratosis,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003298,vulvar leiomyoma,http://purl.obolibrary.org/obo/MONDO_0001572,leiomyoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003372,vulvar leiomyosarcoma,http://purl.obolibrary.org/obo/MONDO_0005058,leiomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0006491,vulvar lichen sclerosus,http://purl.obolibrary.org/obo/MONDO_0007899,lichen sclerosus et atrophicus,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003599,vulvar liposarcoma,http://purl.obolibrary.org/obo/MONDO_0005060,liposarcoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0002205,vulvar melanoma (disease),http://purl.obolibrary.org/obo/MONDO_0005105,melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0002188,vulvar nodular hidradenoma,http://purl.obolibrary.org/obo/MONDO_0002189,nodular hidradenoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0003636,vulvar sebaceous carcinoma,http://purl.obolibrary.org/obo/MONDO_0006962,sebaceous adenocarcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0006622,vulvar seborrheic keratosis,http://purl.obolibrary.org/obo/MONDO_0008420,seborrheic keratosis,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0002190,vulvar syringoma,http://purl.obolibrary.org/obo/MONDO_0002191,syringoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/location_top.csv
+++ b/src/patterns/location_top.csv
@@ -1,168 +1,220 @@
 iri,iri label,location,location label
-MONDO:0002636,accessory nerve disease,UBERON:0002019,accessory XI nerve
-MONDO:0002816,adrenal cortex disease,UBERON:0001235,adrenal cortex
-MONDO:0005495,adrenal gland disease,UBERON:0002369,adrenal gland
-MONDO:0003182,anterior horn disease,UBERON:0002257,ventral horn of spinal cord
-MONDO:0002519,anus disease,UBERON:0001245,anus
-MONDO:0005561,aortic disease,UBERON:0000947,aorta
-MONDO:0003803,aortic valve disease,UBERON:0002137,aortic valve
-MONDO:0000473,artery disease,UBERON:0001637,artery
-MONDO:0003816,articular cartilage disease,UBERON:0010996,articular cartilage of joint
-MONDO:0005476,atrioventricular node disease,UBERON:0002352,atrioventricular node
-MONDO:0002409,auditory system disease,UBERON:0016490,auditory system
-MONDO:0001292,autonomic nervous system disease,UBERON:0002410,autonomic nervous system
-MONDO:0003996,basal ganglia disease,UBERON:0010011,collection of basal ganglia
-MONDO:0002887,bile duct disease,UBERON:0002394,bile duct
-MONDO:0004868,biliary tract disease,UBERON:0001173,biliary tree
-MONDO:0006026,bladder disease,UBERON:0001255,urinary bladder
-MONDO:0005497,bone development disease,GO:0060348,bone development
-MONDO:0005381,bone disease,UBERON:0001474,bone element
-MONDO:0003225,bone marrow disease,UBERON:0002371,bone marrow
-MONDO:0005560,brain disease,UBERON:0000955,brain
-MONDO:0002657,breast disease,UBERON:0000310,breast
-MONDO:0001358,bronchial disease,UBERON:0002185,bronchus
-MONDO:0001574,capillary disease,UBERON:0001982,capillary
-MONDO:0004995,cardiovascular disease,UBERON:0004535,cardiovascular system
-MONDO:0005269,carotid artery disease,UBERON:0005396,carotid artery segment
-MONDO:0005569,cartilage disease,UBERON:0002418,cartilage tissue
-MONDO:0002031,cecal disease,UBERON:0001153,caecum
-MONDO:0002602,central nervous system disease,UBERON:0001017,central nervous system
-MONDO:0002427,cerebellar disease,UBERON:0002037,cerebellum
-MONDO:0002256,cervix disease,UBERON:0000002,uterine cervix
-MONDO:0001898,choroid disease,UBERON:0001776,optic choroid
-MONDO:0002970,ciliary body disease,UBERON:0001775,ciliary body
-MONDO:0003452,cochlear disease,UBERON:0001844,cochlea
-MONDO:0003409,colonic disease,UBERON:0001155,colon
-MONDO:0002886,common bile duct disease,UBERON:0001174,common bile duct
-MONDO:0005449,conduction system disorder,UBERON:0002350,conducting system of heart
-MONDO:0002932,conjunctival disease,UBERON:0001811,conjunctiva
-MONDO:0003900,connective tissue disease,UBERON:0002384,connective tissue
-MONDO:0000942,corneal disease,UBERON:0000964,cornea
-MONDO:0005010,coronary artery disease,UBERON:0001621,coronary artery
-MONDO:0003569,cranial nerve neuropathy,UBERON:0034713,cranial neuron projection bundle
-MONDO:0003394,dental pulp disease,UBERON:0001754,dental pulp
-MONDO:0021154,dermis disease,UBERON:0002067,dermis
-MONDO:0005728,diaphragm disease,UBERON:0001103,diaphragm
-MONDO:0021145,disease of genitourinary system,UBERON:0004122,genitourinary system
-MONDO:0002866,duodenal disease,UBERON:0002114,duodenum
-MONDO:0000470,endocardium disease,UBERON:0002165,endocardium
-MONDO:0001933,endocrine pancreas disease,UBERON:0000016,endocrine pancreas
-MONDO:0005151,endocrine system disease,UBERON:0000949,endocrine system
-MONDO:0000931,endometrial disease,UBERON:0001295,endometrium
-MONDO:0003749,esophageal disease,UBERON:0001043,esophagus
-MONDO:0004866,eustachian tube disease,UBERON:0002393,pharyngotympanic tube
-MONDO:0002776,external ear disease,UBERON:0001691,external ear
-MONDO:0000462,eye adnexa disease,UBERON:0035639,ocular adnexa
-MONDO:0005328,eye disease,UBERON:0000970,eye
-MONDO:0003382,eyelid disease,UBERON:0001711,eyelid
-MONDO:0002098,facial nerve disease,UBERON:0001647,facial nerve
-MONDO:0002156,fallopian tube disease,UBERON:0003889,fallopian tube
-MONDO:0002263,female reproductive system disease,UBERON:0000474,female reproductive system
-MONDO:0005281,gallbladder disease,UBERON:0002110,gall bladder
-MONDO:0004335,gastrointestinal system disease,UBERON:0005409,alimentary part of gastrointestinal system
-MONDO:0002021,gingival disease,UBERON:0001828,gingiva
-MONDO:0019722,glomerular disease,UBERON:0000074,renal glomerulus
-MONDO:0002639,glossopharyngeal nerve disease,UBERON:0001649,glossopharyngeal nerve
-MONDO:0002259,gonadal disease,UBERON:0000991,gonad
-MONDO:0002917,hair disease,UBERON:0001037,strand of hair
-MONDO:0021059,head and neck disease,UBERON:0007811,craniocervical region
-MONDO:0005042,head disease,UBERON:0000033,head
-MONDO:0005267,heart disease,UBERON:0000948,heart
-MONDO:0002869,heart valve disease,UBERON:0000946,cardial valve
-MONDO:0005570,hematological system disease,UBERON:0002390,hematopoietic system
-MONDO:0002515,hepatobiliary disease,UBERON:0002423,hepatobiliary system
-MONDO:0001810,hypoglossal nerve disease,UBERON:0001650,hypoglossal nerve
-MONDO:0005046,immune system disease,UBERON:0002405,immune system
-MONDO:0002467,inner ear disease,UBERON:0001846,internal ear
-MONDO:0002051,integumentary system disease,UBERON:0002416,integumental system
-MONDO:0005020,intestinal disease,UBERON:0000160,intestine
-MONDO:0002289,iris disease,UBERON:0001769,iris
-MONDO:0006816,joint disease,UBERON:0000982,skeletal joint
-MONDO:0005240,kidney disease,UBERON:0002113,kidney
-MONDO:0001854,lacrimal apparatus disease,UBERON:0001750,lacrimal apparatus
-MONDO:0004382,laryngeal disease,UBERON:0001737,larynx
-MONDO:0001176,lens disease,UBERON:0000965,lens of camera-type eye
-MONDO:0004805,leukocyte disease,CL:0000738,leukocyte
-MONDO:0004748,lip disease,UBERON:0001833,lip
-MONDO:0005154,liver disease,UBERON:0002107,liver
-MONDO:0000270,lower respiratory tract disease,UBERON:0001558,lower respiratory tract
-MONDO:0005275,lung disease,UBERON:0002048,lung
-MONDO:0004928,lymph node disease,UBERON:0000029,lymph node
-MONDO:0005833,lymphatic system disease,UBERON:0006558,lymphatic part of lymphoid system
-MONDO:0003150,male reproductive system disease,UBERON:0000079,male reproductive system
-MONDO:0003276,middle ear disease,UBERON:0001756,middle ear
-MONDO:0003767,mitral valve disease,UBERON:0002135,mitral valve
-MONDO:0020128,motor neuron disease,CL:0000100,motor neuron
-MONDO:0006858,mouth disease,UBERON:0000165,mouth
-MONDO:0003939,muscle tissue disease,UBERON:0002385,muscle tissue
-MONDO:0005218,muscular disease,UBERON:0001630,muscle organ
-MONDO:0002081,musculoskeletal system disease,UBERON:0002204,musculoskeletal system
-MONDO:0002884,nail disease,UBERON:0001705,nail
-MONDO:0002232,nasal cavity disease,UBERON:0001707,nasal cavity
-MONDO:0004821,nasopharyngeal disease,UBERON:0001728,nasopharynx
-MONDO:0005071,nervous system disease,UBERON:0001016,nervous system
-MONDO:0002436,nose disease,UBERON:0000004,nose
-MONDO:0002727,olfactory nerve disease,UBERON:0001579,olfactory nerve
-MONDO:0002135,optic nerve disease,UBERON:0000941,cranial nerve II
-MONDO:0005558,ovarian disease,UBERON:0000992,ovary
-MONDO:0002356,pancreas disease,UBERON:0001264,pancreas
-MONDO:0001735,paranasal sinus disease,UBERON:0001825,paranasal sinus
-MONDO:0001223,parathyroid gland disease,UBERON:0001132,parathyroid gland
-MONDO:0005899,parotid disease,UBERON:0001831,parotid gland
-MONDO:0002036,penile disease,UBERON:0000989,penis
-MONDO:0000474,pericardium disease,UBERON:0002407,pericardium
-MONDO:0002635,periodontal disease,UBERON:0001758,periodontium
-MONDO:0003620,peripheral nervous system disease,UBERON:0000010,peripheral nervous system
-MONDO:0003381,pituitary gland disease,UBERON:0000007,pituitary gland
-MONDO:0005917,placenta disease,UBERON:0001987,placenta
-MONDO:0002037,pleural disease,UBERON:0000977,pleura
-MONDO:0003105,prostate disease,UBERON:0002367,prostate gland
-MONDO:0003628,pulmonary valve disease,UBERON:0002146,pulmonary valve
-MONDO:0002285,pupil disease,UBERON:0001771,pupil
-MONDO:0001593,rectal disease,UBERON:0001052,rectum
-MONDO:0005039,reproductive system disease,UBERON:0000990,reproductive system
-MONDO:0005087,respiratory system disease,UBERON:0001004,respiratory system
-MONDO:0001142,salivary gland disease,UBERON:0001044,saliva-secreting gland
-MONDO:0001269,scleral disease,UBERON:0001773,sclera
-MONDO:0006607,sebaceous gland disease,UBERON:0001821,sebaceous gland
-MONDO:0005128,sensory system disease,UBERON:0001032,sensory system
-MONDO:0000469,sinoatrial node disease,UBERON:0002351,sinoatrial node
-MONDO:0020120,skeletal muscle disease,UBERON:0001134,skeletal muscle tissue
-MONDO:0005172,skeletal system disease,UBERON:0001434,skeletal system
-MONDO:0019293,skin vascular disease,UBERON:0035549,superficial vasculature
-MONDO:0002545,spinal cord disease,UBERON:0002240,spinal cord
-MONDO:0002332,splenic disease,UBERON:0002106,spleen
-MONDO:0004298,stomach disease,UBERON:0000945,stomach
-MONDO:0019296,subcutaneous tissue disease,UBERON:0011818,superficial fascia
-MONDO:0001597,submandibular gland disease,UBERON:0001736,submandibular gland
-MONDO:0006615,sweat gland disease,UBERON:0001820,sweat gland
-MONDO:0002329,testicular disease,UBERON:0000473,testis
-MONDO:0003081,thalamic disease,UBERON:0001897,dorsal plus ventral thalamus
-MONDO:0003546,third cranial nerve disease,UBERON:0001643,oculomotor nerve
-MONDO:0000651,thoracic disease,UBERON:0000915,thoracic segment of trunk
-MONDO:0003393,thymus gland disease,UBERON:0002370,thymus
-MONDO:0003240,thyroid gland disease,UBERON:0002046,thyroid gland
-MONDO:0001165,tongue disease,UBERON:0001723,tongue
-MONDO:0006999,tooth disease,UBERON:0001091,calcareous tooth
-MONDO:0002567,tracheal disease,UBERON:0003126,trachea
-MONDO:0000471,tricuspid valve disease,UBERON:0002134,tricuspid valve
-MONDO:0003543,trigeminal nerve disease,UBERON:0001645,trigeminal nerve
-MONDO:0007002,trochlear nerve disease,UBERON:0001644,trochlear nerve
-MONDO:0003648,tympanic membrane disease,UBERON:0002364,tympanic membrane
-MONDO:0004867,upper respiratory tract disease,UBERON:0001557,upper respiratory tract
-MONDO:0001926,ureteral disease,UBERON:0000056,ureter
-MONDO:0004184,urethral disease,UBERON:0000057,urethra
-MONDO:0002118,urinary system disease,UBERON:0001008,renal system
-MONDO:0002654,uterine disease,UBERON:0000995,uterus
-MONDO:0002661,uveal disease,UBERON:0001768,uvea
-MONDO:0001433,vaginal disease,UBERON:0000996,vagina
-MONDO:0001535,vagus nerve disease,UBERON:0001759,vagus nerve
-MONDO:0005385,vascular disease,UBERON:0002049,vasculature
-MONDO:0004634,vein disease,UBERON:0001638,vein
-MONDO:0000812,vertebral column disease,UBERON:0001130,vertebral column
-MONDO:0002643,vestibular disease,UBERON:0004681,vestibular system
-MONDO:0001563,vestibulocochlear nerve disease,UBERON:0001648,vestibulocochlear nerve
-MONDO:0021084,vision disorder,UBERON:0002104,visual system
-MONDO:0003584,visual cortex disease,UBERON:0000411,visual cortex
-MONDO:0001834,visual pathway disease,UBERON:0001908,optic tract
-MONDO:0004860,vitreous disease,UBERON:0001797,vitreous humor
+http://purl.obolibrary.org/obo/MONDO_0044965,abdominal and pelvic region disorder,http://purl.obolibrary.org/obo/UBERON_0002417,abdominal segment of trunk
+http://purl.obolibrary.org/obo/MONDO_0002636,accessory nerve disease,http://purl.obolibrary.org/obo/UBERON_0002019,accessory XI nerve
+http://purl.obolibrary.org/obo/MONDO_0002816,adrenal cortex disease,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0005495,adrenal gland disease,http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0003182,anterior horn disease,http://purl.obolibrary.org/obo/UBERON_0002257,ventral horn of spinal cord
+http://purl.obolibrary.org/obo/MONDO_0024468,anterior pituitary gland disease,http://purl.obolibrary.org/obo/UBERON_0002196,adenohypophysis
+http://purl.obolibrary.org/obo/MONDO_0002519,anus disease,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0005561,aortic disease,http://purl.obolibrary.org/obo/UBERON_0000947,aorta
+http://purl.obolibrary.org/obo/MONDO_0003803,aortic valve disease,http://purl.obolibrary.org/obo/UBERON_0002137,aortic valve
+http://purl.obolibrary.org/obo/MONDO_0024467,apocrine sweat gland disease,http://purl.obolibrary.org/obo/UBERON_0000382,apocrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0000473,arterial disorder,http://purl.obolibrary.org/obo/UBERON_0001637,artery
+http://purl.obolibrary.org/obo/MONDO_0006816,arthropathy,http://purl.obolibrary.org/obo/UBERON_0000982,skeletal joint
+http://purl.obolibrary.org/obo/MONDO_0003816,articular cartilage disease,http://purl.obolibrary.org/obo/UBERON_0010996,articular cartilage of joint
+http://purl.obolibrary.org/obo/MONDO_0005476,atrioventricular node disease,http://purl.obolibrary.org/obo/UBERON_0002352,atrioventricular node
+http://purl.obolibrary.org/obo/MONDO_0002409,auditory system disease,http://purl.obolibrary.org/obo/UBERON_0016490,auditory system
+http://purl.obolibrary.org/obo/MONDO_0001292,autonomic nervous system disease,http://purl.obolibrary.org/obo/UBERON_0002410,autonomic nervous system
+http://purl.obolibrary.org/obo/MONDO_0003996,basal ganglia disease,http://purl.obolibrary.org/obo/UBERON_0010011,collection of basal ganglia
+http://purl.obolibrary.org/obo/MONDO_0002887,bile duct disease,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0004868,biliary tract disease,http://purl.obolibrary.org/obo/UBERON_0001173,biliary tree
+http://purl.obolibrary.org/obo/MONDO_0005497,bone development disease,http://purl.obolibrary.org/obo/GO_0060348,bone development
+http://purl.obolibrary.org/obo/MONDO_0005381,bone disease,http://purl.obolibrary.org/obo/UBERON_0001474,bone element
+http://purl.obolibrary.org/obo/MONDO_0003225,bone marrow disease,http://purl.obolibrary.org/obo/UBERON_0002371,bone marrow
+http://purl.obolibrary.org/obo/MONDO_0005560,brain disease,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0002657,breast disease,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0001358,bronchial disease,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0001574,capillary disease,http://purl.obolibrary.org/obo/UBERON_0001982,capillary
+http://purl.obolibrary.org/obo/MONDO_0045001,cardiac ventricle disease,http://purl.obolibrary.org/obo/UBERON_0002082,cardiac ventricle
+http://purl.obolibrary.org/obo/MONDO_0004995,cardiovascular disease,http://purl.obolibrary.org/obo/UBERON_0004535,cardiovascular system
+http://purl.obolibrary.org/obo/MONDO_0005269,carotid artery disease,http://purl.obolibrary.org/obo/UBERON_0005396,carotid artery segment
+http://purl.obolibrary.org/obo/MONDO_0044998,carpal region disease,http://purl.obolibrary.org/obo/UBERON_0004452,carpal region
+http://purl.obolibrary.org/obo/MONDO_0005569,cartilage disease,http://purl.obolibrary.org/obo/UBERON_0002418,cartilage tissue
+http://purl.obolibrary.org/obo/MONDO_0002031,cecal disease,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0002602,central nervous system disease,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002427,cerebellar disease,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0044996,cerebral cortex disease,http://purl.obolibrary.org/obo/UBERON_0000956,cerebral cortex
+http://purl.obolibrary.org/obo/MONDO_0002256,cervix disease,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0002970,ciliary body disease,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0003452,cochlear disease,http://purl.obolibrary.org/obo/UBERON_0001844,cochlea
+http://purl.obolibrary.org/obo/MONDO_0003409,colonic disease,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0002886,common bile duct disease,http://purl.obolibrary.org/obo/UBERON_0001174,common bile duct
+http://purl.obolibrary.org/obo/MONDO_0005449,conduction system disorder,http://purl.obolibrary.org/obo/UBERON_0002350,conducting system of heart
+http://purl.obolibrary.org/obo/MONDO_0002932,conjunctival disease,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0001174,conjunctival vascular disease,http://purl.obolibrary.org/obo/UBERON_0010366,conjunctival vasculature
+http://purl.obolibrary.org/obo/MONDO_0003900,connective tissue disease,http://purl.obolibrary.org/obo/UBERON_0002384,connective tissue
+http://purl.obolibrary.org/obo/MONDO_0000942,corneal disease,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0005010,coronary artery disease,http://purl.obolibrary.org/obo/UBERON_0001621,coronary artery
+http://purl.obolibrary.org/obo/MONDO_0003569,cranial nerve neuropathy,http://purl.obolibrary.org/obo/UBERON_0034713,cranial neuron projection bundle
+http://purl.obolibrary.org/obo/MONDO_0003394,dental pulp disease,http://purl.obolibrary.org/obo/UBERON_0001754,dental pulp
+http://purl.obolibrary.org/obo/MONDO_0021154,dermis disease,http://purl.obolibrary.org/obo/UBERON_0002067,dermis
+http://purl.obolibrary.org/obo/MONDO_0005728,diaphragm disease,http://purl.obolibrary.org/obo/UBERON_0001103,diaphragm
+http://purl.obolibrary.org/obo/MONDO_0004335,digestive system disease,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0021205,disease of ear,http://purl.obolibrary.org/obo/UBERON_0001690,ear
+http://purl.obolibrary.org/obo/MONDO_0045013,disease of extraembryonic membrane,http://purl.obolibrary.org/obo/UBERON_0005631,extraembryonic membrane
+http://purl.obolibrary.org/obo/MONDO_0023369,disease of facial skeleton,http://purl.obolibrary.org/obo/UBERON_0011156,facial skeleton
+http://purl.obolibrary.org/obo/MONDO_0021145,disease of genitourinary system,http://purl.obolibrary.org/obo/UBERON_0004122,genitourinary system
+http://purl.obolibrary.org/obo/MONDO_0002022,disease of orbital region,http://purl.obolibrary.org/obo/UBERON_0004088,orbital region
+http://purl.obolibrary.org/obo/MONDO_0002917,disease of pilosebaceous unit,http://purl.obolibrary.org/obo/UBERON_0011932,pilosebaceous unit
+http://purl.obolibrary.org/obo/MONDO_0045043,disease of uterine broad ligament,http://purl.obolibrary.org/obo/UBERON_0012332,broad ligament of uterus
+http://purl.obolibrary.org/obo/MONDO_0024458,disease of visual system,http://purl.obolibrary.org/obo/UBERON_0002104,visual system
+http://purl.obolibrary.org/obo/MONDO_0024625,disorder of lacrimal gland,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0015141,disorder of medulla oblongata,http://purl.obolibrary.org/obo/UBERON_0001896,medulla oblongata
+http://purl.obolibrary.org/obo/MONDO_0003568,disorder of optic chiasm,http://purl.obolibrary.org/obo/UBERON_0000959,optic chiasma
+http://purl.obolibrary.org/obo/MONDO_0002866,duodenal disease,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0000470,endocardium disease,http://purl.obolibrary.org/obo/UBERON_0002165,endocardium
+http://purl.obolibrary.org/obo/MONDO_0001933,endocrine pancreas disease,http://purl.obolibrary.org/obo/UBERON_0000016,endocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0005151,endocrine system disease,http://purl.obolibrary.org/obo/UBERON_0000949,endocrine system
+http://purl.obolibrary.org/obo/MONDO_0000931,endometrial disease,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0002183,enthesopathy,http://purl.obolibrary.org/obo/UBERON_0035845,enthesis
+http://purl.obolibrary.org/obo/MONDO_0044972,eosinophil disease,http://purl.obolibrary.org/obo/CL_0000771,eosinophil
+http://purl.obolibrary.org/obo/MONDO_0003749,esophageal disease,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004866,eustachian tube disease,http://purl.obolibrary.org/obo/UBERON_0002393,pharyngotympanic tube
+http://purl.obolibrary.org/obo/MONDO_0002776,external ear disease,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0000462,eye adnexa disease,http://purl.obolibrary.org/obo/UBERON_0035639,ocular adnexa
+http://purl.obolibrary.org/obo/MONDO_0005328,eye disease,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0003382,eyelid disease,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0044987,face disease,http://purl.obolibrary.org/obo/UBERON_0001456,face
+http://purl.obolibrary.org/obo/MONDO_0002098,facial nerve disease,http://purl.obolibrary.org/obo/UBERON_0001647,facial nerve
+http://purl.obolibrary.org/obo/MONDO_0002156,fallopian tube disease,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0002263,female reproductive system disease,http://purl.obolibrary.org/obo/UBERON_0000474,female reproductive system
+http://purl.obolibrary.org/obo/MONDO_0044989,foot disease,http://purl.obolibrary.org/obo/UBERON_0002387,pes
+http://purl.obolibrary.org/obo/MONDO_0005281,gallbladder disease,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0002021,gingival disease,http://purl.obolibrary.org/obo/UBERON_0001828,gingiva
+http://purl.obolibrary.org/obo/MONDO_0019722,glomerular disease,http://purl.obolibrary.org/obo/UBERON_0000074,renal glomerulus
+http://purl.obolibrary.org/obo/MONDO_0002639,glossopharyngeal nerve disease,http://purl.obolibrary.org/obo/UBERON_0001649,glossopharyngeal nerve
+http://purl.obolibrary.org/obo/MONDO_0002259,gonadal disease,http://purl.obolibrary.org/obo/UBERON_0000991,gonad
+http://purl.obolibrary.org/obo/MONDO_0044990,hand disease,http://purl.obolibrary.org/obo/UBERON_0002398,manus
+http://purl.obolibrary.org/obo/MONDO_0005042,head disease,http://purl.obolibrary.org/obo/UBERON_0000033,head
+http://purl.obolibrary.org/obo/MONDO_0021059,head or neck disease/disorder,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0005267,heart disease,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0002869,heart valve disease,http://purl.obolibrary.org/obo/UBERON_0000946,cardial valve
+http://purl.obolibrary.org/obo/MONDO_0005570,hematological system disease,http://purl.obolibrary.org/obo/UBERON_0002390,hematopoietic system
+http://purl.obolibrary.org/obo/MONDO_0002515,hepatobiliary disease,http://purl.obolibrary.org/obo/UBERON_0002423,hepatobiliary system
+http://purl.obolibrary.org/obo/MONDO_0044988,hip region disease,http://purl.obolibrary.org/obo/UBERON_0001464,hip
+http://purl.obolibrary.org/obo/MONDO_0001810,hypoglossal nerve disease,http://purl.obolibrary.org/obo/UBERON_0001650,hypoglossal nerve
+http://purl.obolibrary.org/obo/MONDO_0002150,hypothalamic disease,http://purl.obolibrary.org/obo/UBERON_0001898,hypothalamus
+http://purl.obolibrary.org/obo/MONDO_0005046,immune system disease,http://purl.obolibrary.org/obo/UBERON_0002405,immune system
+http://purl.obolibrary.org/obo/MONDO_0002467,inner ear disease,http://purl.obolibrary.org/obo/UBERON_0001846,internal ear
+http://purl.obolibrary.org/obo/MONDO_0002051,integumentary system disease,http://purl.obolibrary.org/obo/UBERON_0002416,integumental system
+http://purl.obolibrary.org/obo/MONDO_0005020,intestinal disease,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0002289,iris disease,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0005240,kidney disease,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0001854,lacrimal apparatus disease,http://purl.obolibrary.org/obo/UBERON_0001750,lacrimal apparatus
+http://purl.obolibrary.org/obo/MONDO_0024634,large intestine disease,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0004382,laryngeal disease,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0001176,lens disease,http://purl.obolibrary.org/obo/UBERON_0000965,lens of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0004805,leukocyte disease,http://purl.obolibrary.org/obo/CL_0000738,leukocyte
+http://purl.obolibrary.org/obo/MONDO_0045044,ligament disease,http://purl.obolibrary.org/obo/UBERON_0000211,ligament
+http://purl.obolibrary.org/obo/MONDO_0044967,limb disorder,http://purl.obolibrary.org/obo/UBERON_0002101,limb
+http://purl.obolibrary.org/obo/MONDO_0004748,lip disease,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0005154,liver disease,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0000270,lower respiratory tract disease,http://purl.obolibrary.org/obo/UBERON_0001558,lower respiratory tract
+http://purl.obolibrary.org/obo/MONDO_0005275,lung disease,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0004928,lymph node disease,http://purl.obolibrary.org/obo/UBERON_0000029,lymph node
+http://purl.obolibrary.org/obo/MONDO_0005833,lymphatic system disease,http://purl.obolibrary.org/obo/UBERON_0006558,lymphatic part of lymphoid system
+http://purl.obolibrary.org/obo/MONDO_0044986,lymphoid system disease,http://purl.obolibrary.org/obo/UBERON_0002465,lymphoid system
+http://purl.obolibrary.org/obo/MONDO_0003150,male reproductive system disease,http://purl.obolibrary.org/obo/UBERON_0000079,male reproductive system
+http://purl.obolibrary.org/obo/MONDO_0043707,mediastinal diseases,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0044997,midbrain disease,http://purl.obolibrary.org/obo/UBERON_0001891,midbrain
+http://purl.obolibrary.org/obo/MONDO_0003276,middle ear disease,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0003767,mitral valve disease,http://purl.obolibrary.org/obo/UBERON_0002135,mitral valve
+http://purl.obolibrary.org/obo/MONDO_0020128,motor neuron disease,http://purl.obolibrary.org/obo/CL_0000100,motor neuron
+http://purl.obolibrary.org/obo/MONDO_0006858,mouth disease,http://purl.obolibrary.org/obo/UBERON_0000165,mouth
+http://purl.obolibrary.org/obo/MONDO_0044992,mouth mucosa disease,http://purl.obolibrary.org/obo/UBERON_0003729,mouth mucosa
+http://purl.obolibrary.org/obo/MONDO_0003939,muscle tissue disease,http://purl.obolibrary.org/obo/UBERON_0002385,muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0005218,muscular disease,http://purl.obolibrary.org/obo/UBERON_0001630,muscle organ
+http://purl.obolibrary.org/obo/MONDO_0002081,musculoskeletal system disease,http://purl.obolibrary.org/obo/UBERON_0002204,musculoskeletal system
+http://purl.obolibrary.org/obo/MONDO_0024643,myocardial disorder,http://purl.obolibrary.org/obo/UBERON_0002349,myocardium
+http://purl.obolibrary.org/obo/MONDO_0002884,nail disease,http://purl.obolibrary.org/obo/UBERON_0001705,nail
+http://purl.obolibrary.org/obo/MONDO_0002232,nasal cavity disease,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0044984,nasolacrimal duct disease,http://purl.obolibrary.org/obo/UBERON_0002392,nasolacrimal duct
+http://purl.obolibrary.org/obo/MONDO_0004821,nasopharyngeal disease,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0024432,nerve plexus disease,http://purl.obolibrary.org/obo/UBERON_0001810,nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0005071,nervous system disorder,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0002436,nose disease,http://purl.obolibrary.org/obo/UBERON_0000004,nose
+http://purl.obolibrary.org/obo/MONDO_0005552,ocular vascular disease,http://purl.obolibrary.org/obo/UBERON_0002203,vasculature of eye
+http://purl.obolibrary.org/obo/MONDO_0002727,olfactory nerve disease,http://purl.obolibrary.org/obo/UBERON_0001579,olfactory nerve
+http://purl.obolibrary.org/obo/MONDO_0001898,optic choroid disease,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0002135,optic nerve disease,http://purl.obolibrary.org/obo/UBERON_0000941,cranial nerve II
+http://purl.obolibrary.org/obo/MONDO_0005558,ovarian disease,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002356,pancreas disease,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0001735,paranasal sinus disease,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0044995,parasympathetic nervous system disease,http://purl.obolibrary.org/obo/UBERON_0000011,parasympathetic nervous system
+http://purl.obolibrary.org/obo/MONDO_0001223,parathyroid gland disease,http://purl.obolibrary.org/obo/UBERON_0001132,parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0005899,parotid disease,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0002036,penile disease,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0000474,pericardium disease,http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0002635,periodontal disease,http://purl.obolibrary.org/obo/UBERON_0001758,periodontium
+http://purl.obolibrary.org/obo/MONDO_0003620,peripheral nervous system disease,http://purl.obolibrary.org/obo/UBERON_0000010,peripheral nervous system
+http://purl.obolibrary.org/obo/MONDO_0003381,pituitary gland disease,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0005917,placenta disease,http://purl.obolibrary.org/obo/UBERON_0001987,placenta
+http://purl.obolibrary.org/obo/MONDO_0002037,pleural disease,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0003105,prostate disease,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0003628,pulmonary valve disease,http://purl.obolibrary.org/obo/UBERON_0002146,pulmonary valve
+http://purl.obolibrary.org/obo/MONDO_0002285,pupil disease,http://purl.obolibrary.org/obo/UBERON_0001771,pupil
+http://purl.obolibrary.org/obo/MONDO_0001593,rectal disease,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0044347,red blood cell disease,http://purl.obolibrary.org/obo/CL_0000232,erythrocyte
+http://purl.obolibrary.org/obo/MONDO_0021568,renal tubule disease,http://purl.obolibrary.org/obo/UBERON_0009773,renal tubule
+http://purl.obolibrary.org/obo/MONDO_0005039,reproductive system disease,http://purl.obolibrary.org/obo/UBERON_0000990,reproductive system
+http://purl.obolibrary.org/obo/MONDO_0005087,respiratory system disease,http://purl.obolibrary.org/obo/UBERON_0001004,respiratory system
+http://purl.obolibrary.org/obo/MONDO_0003579,retinal nerve fibre layer disorder,http://purl.obolibrary.org/obo/UBERON_0001793,nerve fiber layer of retina
+http://purl.obolibrary.org/obo/MONDO_0024454,sacral nerve plexus disease,http://purl.obolibrary.org/obo/UBERON_0034986,sacral nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0001142,salivary gland disease,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0044999,scalp disease,http://purl.obolibrary.org/obo/UBERON_0000403,scalp
+http://purl.obolibrary.org/obo/MONDO_0001269,scleral disease,http://purl.obolibrary.org/obo/UBERON_0001773,sclera
+http://purl.obolibrary.org/obo/MONDO_0045003,scrotal disease,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0006607,sebaceous gland disease,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0021260,sensory ganglionopathy,http://purl.obolibrary.org/obo/UBERON_0001800,sensory ganglion
+http://purl.obolibrary.org/obo/MONDO_0005128,sensory system disease,http://purl.obolibrary.org/obo/UBERON_0001032,sensory system
+http://purl.obolibrary.org/obo/MONDO_0000469,sinoatrial node disease,http://purl.obolibrary.org/obo/UBERON_0002351,sinoatrial node
+http://purl.obolibrary.org/obo/MONDO_0045004,skeletal ligament disease,http://purl.obolibrary.org/obo/UBERON_0008846,skeletal ligament
+http://purl.obolibrary.org/obo/MONDO_0020120,skeletal muscle disease,http://purl.obolibrary.org/obo/UBERON_0001134,skeletal muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0005172,skeletal system disease,http://purl.obolibrary.org/obo/UBERON_0001434,skeletal system
+http://purl.obolibrary.org/obo/MONDO_0024481,skin appendage disease,http://purl.obolibrary.org/obo/UBERON_0000021,cutaneous appendage
+http://purl.obolibrary.org/obo/MONDO_0005093,skin disease,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0024654,skull disorder,http://purl.obolibrary.org/obo/UBERON_0003129,skull
+http://purl.obolibrary.org/obo/MONDO_0024635,small intestine disease,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0002545,spinal cord disease,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0002332,splenic disease,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0004298,stomach disease,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0019296,subcutaneous tissue disease,http://purl.obolibrary.org/obo/UBERON_0011818,superficial fascia
+http://purl.obolibrary.org/obo/MONDO_0001597,submandibular gland disease,http://purl.obolibrary.org/obo/UBERON_0001736,submandibular gland
+http://purl.obolibrary.org/obo/MONDO_0006615,sweat gland disease,http://purl.obolibrary.org/obo/UBERON_0001820,sweat gland
+http://purl.obolibrary.org/obo/MONDO_0044993,sympathetic nervous system disease,http://purl.obolibrary.org/obo/UBERON_0000013,sympathetic nervous system
+http://purl.obolibrary.org/obo/MONDO_0100010,tendinopathy,http://purl.obolibrary.org/obo/UBERON_0000043,tendon
+http://purl.obolibrary.org/obo/MONDO_0024876,tendon sheath disorder,http://purl.obolibrary.org/obo/UBERON_0000304,tendon sheath
+http://purl.obolibrary.org/obo/MONDO_0002329,testicular disease,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0003081,thalamic disease,http://purl.obolibrary.org/obo/UBERON_0001897,dorsal plus ventral thalamus
+http://purl.obolibrary.org/obo/MONDO_0003546,third cranial nerve disease,http://purl.obolibrary.org/obo/UBERON_0001643,oculomotor nerve
+http://purl.obolibrary.org/obo/MONDO_0000651,thoracic disease,http://purl.obolibrary.org/obo/UBERON_0000915,thoracic segment of trunk
+http://purl.obolibrary.org/obo/MONDO_0003393,thymus gland disease,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0003240,thyroid gland disease,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0001165,tongue disease,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0006999,tooth disease,http://purl.obolibrary.org/obo/UBERON_0001091,calcareous tooth
+http://purl.obolibrary.org/obo/MONDO_0002567,tracheal disease,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0000471,tricuspid valve disease,http://purl.obolibrary.org/obo/UBERON_0002134,tricuspid valve
+http://purl.obolibrary.org/obo/MONDO_0003543,trigeminal nerve disease,http://purl.obolibrary.org/obo/UBERON_0001645,trigeminal nerve
+http://purl.obolibrary.org/obo/MONDO_0007002,trochlear nerve disease,http://purl.obolibrary.org/obo/UBERON_0001644,trochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0003648,tympanic membrane disease,http://purl.obolibrary.org/obo/UBERON_0002364,tympanic membrane
+http://purl.obolibrary.org/obo/MONDO_0044991,upper digestive tract disease,http://purl.obolibrary.org/obo/UBERON_0004908,upper digestive tract
+http://purl.obolibrary.org/obo/MONDO_0004867,upper respiratory tract disease,http://purl.obolibrary.org/obo/UBERON_0001557,upper respiratory tract
+http://purl.obolibrary.org/obo/MONDO_0001926,ureteral disease,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0004184,urethral disease,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0006026,urinary bladder disease,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0002118,urinary system disease,http://purl.obolibrary.org/obo/UBERON_0001008,renal system
+http://purl.obolibrary.org/obo/MONDO_0002654,uterine disease,http://purl.obolibrary.org/obo/UBERON_0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0002661,uveal disease,http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0001433,vaginal disease,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0001535,vagus nerve disease,http://purl.obolibrary.org/obo/UBERON_0001759,vagus nerve
+http://purl.obolibrary.org/obo/MONDO_0005385,vascular disease,http://purl.obolibrary.org/obo/UBERON_0002049,vasculature
+http://purl.obolibrary.org/obo/MONDO_0004634,vein disease,http://purl.obolibrary.org/obo/UBERON_0001638,vein
+http://purl.obolibrary.org/obo/MONDO_0000812,vertebral column disease,http://purl.obolibrary.org/obo/UBERON_0001130,vertebral column
+http://purl.obolibrary.org/obo/MONDO_0045002,vertebral disease,http://purl.obolibrary.org/obo/UBERON_0002412,vertebra
+http://purl.obolibrary.org/obo/MONDO_0037847,vertebral joint disease,http://purl.obolibrary.org/obo/UBERON_0001468,intervertebral joint
+http://purl.obolibrary.org/obo/MONDO_0002643,vestibular disease,http://purl.obolibrary.org/obo/UBERON_0001862,vestibular labyrinth
+http://purl.obolibrary.org/obo/MONDO_0001563,vestibulocochlear nerve disease,http://purl.obolibrary.org/obo/UBERON_0001648,vestibulocochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0003584,visual cortex disease,http://purl.obolibrary.org/obo/UBERON_0000411,visual cortex
+http://purl.obolibrary.org/obo/MONDO_0001834,visual pathway disease,http://purl.obolibrary.org/obo/UBERON_0001908,optic tract
+http://purl.obolibrary.org/obo/MONDO_0044137,vitreous body disorder,http://purl.obolibrary.org/obo/UBERON_0001798,vitreous body
+http://purl.obolibrary.org/obo/MONDO_0004860,vitreous disease,http://purl.obolibrary.org/obo/UBERON_0001797,vitreous humor

--- a/src/patterns/lymphoma.csv
+++ b/src/patterns/lymphoma.csv
@@ -1,0 +1,38 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0007650,MALT lymphoma,http://purl.obolibrary.org/obo/UBERON_0001961,mucosa-associated lymphoid tissue
+http://purl.obolibrary.org/obo/MONDO_0001888,anus lymphoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0001237,appendix lymphoma,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0001381,bladder lymphoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0003661,breast lymphoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002034,cecum lymphoma,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0002571,central nervous system lymphoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0003985,chest wall lymphoma,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0002035,colon lymphoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0024656,colorectal lymphoma,http://purl.obolibrary.org/obo/UBERON_0000059,large intestine
+http://purl.obolibrary.org/obo/MONDO_0001188,esophagus lymphoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0004034,eye lymphoma,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0004474,gallbladder lymphoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0001059,gastric lymphoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0004699,gastrointestinal lymphoma,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0003917,heart lymphoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0004695,liver lymphoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0003987,lung lymphoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0017604,marginal zone lymphoma,http://purl.obolibrary.org/obo/CL_0000845,marginal zone B cell
+http://purl.obolibrary.org/obo/MONDO_0004021,mediastinal malignant lymphoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0001130,nasal cavity lymphoma,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0002227,ovarian lymphoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002114,pancreas lymphoma,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0001743,paranasal sinus lymphoma,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0017814,primary bone lymphoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0000996,prostate lymphoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002166,rectum lymphoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0004349,retina lymphoma,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0001499,retroperitoneal lymphoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0001852,small intestine lymphoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0001892,spinal cord lymphoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0003988,sternum lymphoma,http://purl.obolibrary.org/obo/UBERON_0000975,sternum
+http://purl.obolibrary.org/obo/MONDO_0000951,thymus lymphoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0019962,thyroid lymphoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0044884,tonsillar lymphoma,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0001417,tracheal lymphoma,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0001977,ureteral lymphoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter

--- a/src/patterns/malignant.csv
+++ b/src/patterns/malignant.csv
@@ -1,28 +1,44 @@
 iri,iri label,neoplasm,neoplasm label
-MONDO:0004992,cancer,MONDO:0005070,neoplasm (disease)
-MONDO:0006517,childhood malignant neoplasm,MONDO:0021079,childhood neoplasm
-MONDO:0003252,granular cell cancer,MONDO:0006235,granular cell tumor
-MONDO:0000378,malignant Sertoli cell tumor,MONDO:0002696,Sertoli cell tumor
-MONDO:0000379,malignant Sertoli-leydig cell tumor,MONDO:0002479,Sertoli-leydig cell tumor
-MONDO:0002991,malignant adenofibroma,MONDO:0006071,adenofibroma
-MONDO:0006288,malignant adrenal gland pheochromocytoma,MONDO:0004974,adrenal gland pheochromocytoma
-MONDO:0003015,malignant biphasic mesothelioma,MONDO:0006109,malignant biphasic mesothelioma
-MONDO:0002489,malignant breast phyllodes tumor,MONDO:0021047,breast phyllodes tumor
-MONDO:0004650,malignant carotid body paraganglioma,MONDO:0021053,carotid body paraganglioma
-MONDO:0002402,malignant giant cell tumor,MONDO:0002171,giant cell tumor
-MONDO:0000898,malignant hemangioma,MONDO:0006500,hemangioma
-MONDO:0003633,malignant mesenchymoma,MONDO:0006854,mesenchymoma
-MONDO:0006292,malignant mesothelioma (disease),MONDO:0005065,mesothelioma
-MONDO:0005853,malignant mixed neoplasm,MONDO:0021043,mixed neoplasm
-MONDO:0002920,malignant ovarian Brenner tumor,MONDO:0002370,ovarian Brenner tumor
-MONDO:0002224,malignant ovarian cyst,MONDO:0003282,ovarian cyst (disease)
-MONDO:0016751,malignant perineurioma,MONDO:0019404,perineurioma
-MONDO:0005512,malignant peritoneal mesothelioma,MONDO:0006362,peritoneal mesothelioma (disease)
-MONDO:0000407,malignant pleural solitary fibrous tumor,MONDO:0021041,pleural solitary fibrous tumor
-MONDO:0004412,malignant spiradenoma,MONDO:0003448,spiradenoma
-MONDO:0003332,malignant struma ovarii,MONDO:0006980,struma ovarii
-MONDO:0003519,malignant syringoma,MONDO:0002191,syringoma
-MONDO:0003514,malignant teratoma,MONDO:0002601,teratoma
-MONDO:0003737,malignant testicular leydig cell tumor,MONDO:0003124,testicular leydig cell tumor
-MONDO:0006298,mediastinal malignant germ cell tumor,MONDO:0021067,mediastinal germ cell tumor
-MONDO:0003403,testicular non-seminomatous germ cell cancer,MONDO:0002873,testicular germ cell tumor non-seminomatous
+http://purl.obolibrary.org/obo/MONDO_0004992,cancer,http://purl.obolibrary.org/obo/MONDO_0005070,neoplasm (disease)
+http://purl.obolibrary.org/obo/MONDO_0006517,childhood malignant neoplasm,http://purl.obolibrary.org/obo/MONDO_0021079,childhood neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003113,extragonadal germ cell cancer,http://purl.obolibrary.org/obo/MONDO_0018201,extragonadal germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0003252,granular cell cancer,http://purl.obolibrary.org/obo/MONDO_0006235,granular cell tumor
+http://purl.obolibrary.org/obo/MONDO_0000377,malignant Leydig cell tumor,http://purl.obolibrary.org/obo/MONDO_0006266,Leydig cell tumor
+http://purl.obolibrary.org/obo/MONDO_0000378,malignant Sertoli cell tumor,http://purl.obolibrary.org/obo/MONDO_0002696,Sertoli cell tumor
+http://purl.obolibrary.org/obo/MONDO_0000379,malignant Sertoli-Leydig cell tumor,http://purl.obolibrary.org/obo/MONDO_0002479,Sertoli-Leydig cell tumor
+http://purl.obolibrary.org/obo/MONDO_0020542,malignant Sertoli-Leydig cell tumor of ovary,http://purl.obolibrary.org/obo/MONDO_0036595,ovarian sertoli-Leydig cell tumor
+http://purl.obolibrary.org/obo/MONDO_0006288,malignant adrenal gland pheochromocytoma,http://purl.obolibrary.org/obo/MONDO_0004974,adrenal gland pheochromocytoma
+http://purl.obolibrary.org/obo/MONDO_0002489,malignant breast phyllodes tumor,http://purl.obolibrary.org/obo/MONDO_0021047,breast phyllodes tumor
+http://purl.obolibrary.org/obo/MONDO_0004650,malignant carotid body paraganglioma,http://purl.obolibrary.org/obo/MONDO_0021053,carotid body paraganglioma
+http://purl.obolibrary.org/obo/MONDO_0037740,"malignant central nervous system mesenchymal, non-meningothelial neoplasm",http://purl.obolibrary.org/obo/MONDO_0003244,central nervous system mesenchymal non-meningothelial tumor
+http://purl.obolibrary.org/obo/MONDO_0021191,malignant ependymoma,http://purl.obolibrary.org/obo/MONDO_0016698,ependymoma
+http://purl.obolibrary.org/obo/MONDO_0018364,malignant epithelial tumor of ovary,http://purl.obolibrary.org/obo/MONDO_0002229,ovarian epithelial tumor
+http://purl.obolibrary.org/obo/MONDO_0006290,malignant germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0005040,germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0002402,malignant giant cell tumor,http://purl.obolibrary.org/obo/MONDO_0002171,giant cell tumor
+http://purl.obolibrary.org/obo/MONDO_0015917,malignant glioma,http://purl.obolibrary.org/obo/MONDO_0021042,glioma
+http://purl.obolibrary.org/obo/MONDO_0003340,malignant glomus tumor,http://purl.obolibrary.org/obo/MONDO_0018327,glomus tumor
+http://purl.obolibrary.org/obo/MONDO_0003633,malignant mesenchymoma,http://purl.obolibrary.org/obo/MONDO_0006854,mesenchymoma
+http://purl.obolibrary.org/obo/MONDO_0006292,malignant mesothelioma (disease),http://purl.obolibrary.org/obo/MONDO_0005065,mesothelioma
+http://purl.obolibrary.org/obo/MONDO_0024711,malignant mixed epithelial stromal tumor of the kidney,http://purl.obolibrary.org/obo/MONDO_0002386,mixed epithelial stromal tumor of the kidney
+http://purl.obolibrary.org/obo/MONDO_0005853,malignant mixed neoplasm,http://purl.obolibrary.org/obo/MONDO_0021043,mixed neoplasm
+http://purl.obolibrary.org/obo/MONDO_0002920,malignant ovarian Brenner tumor,http://purl.obolibrary.org/obo/MONDO_0002370,ovarian Brenner tumor
+http://purl.obolibrary.org/obo/MONDO_0002224,malignant ovarian cyst,http://purl.obolibrary.org/obo/MONDO_0003282,ovarian cyst (disease)
+http://purl.obolibrary.org/obo/MONDO_0024885,malignant ovarian serous tumor,http://purl.obolibrary.org/obo/MONDO_0037255,ovarian serous tumor
+http://purl.obolibrary.org/obo/MONDO_0016751,malignant perineurioma,http://purl.obolibrary.org/obo/MONDO_0019404,perineurioma
+http://purl.obolibrary.org/obo/MONDO_0003017,malignant peritoneal solitary fibrous tumor,http://purl.obolibrary.org/obo/MONDO_0037737,peritoneal solitary fibrous tumor
+http://purl.obolibrary.org/obo/MONDO_0037003,malignant phyllodes tumor,http://purl.obolibrary.org/obo/MONDO_0005078,phyllodes tumor
+http://purl.obolibrary.org/obo/MONDO_0000407,malignant pleural solitary fibrous tumor,http://purl.obolibrary.org/obo/MONDO_0021041,pleural solitary fibrous tumor
+http://purl.obolibrary.org/obo/MONDO_0018172,malignant sex cord stromal tumor of ovary,http://purl.obolibrary.org/obo/MONDO_0021657,ovarian sex cord-stromal tumor
+http://purl.obolibrary.org/obo/MONDO_0003332,malignant struma ovarii,http://purl.obolibrary.org/obo/MONDO_0006980,struma ovarii
+http://purl.obolibrary.org/obo/MONDO_0006883,malignant superior sulcus neoplasm,http://purl.obolibrary.org/obo/MONDO_0024813,pulmonary sulcus neoplasm
+http://purl.obolibrary.org/obo/MONDO_0003519,malignant syringoma,http://purl.obolibrary.org/obo/MONDO_0002191,syringoma
+http://purl.obolibrary.org/obo/MONDO_0002401,malignant tenosynovial giant cell tumor,http://purl.obolibrary.org/obo/MONDO_0002522,tenosynovial giant cell tumor
+http://purl.obolibrary.org/obo/MONDO_0003514,malignant teratoma,http://purl.obolibrary.org/obo/MONDO_0002601,teratoma
+http://purl.obolibrary.org/obo/MONDO_0003737,malignant testicular Leydig cell tumor,http://purl.obolibrary.org/obo/MONDO_0003124,testicular Leydig cell tumor
+http://purl.obolibrary.org/obo/MONDO_0003976,malignant type AB thymoma,http://purl.obolibrary.org/obo/MONDO_0016975,thymoma type AB
+http://purl.obolibrary.org/obo/MONDO_0006298,mediastinal malignant germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0021067,mediastinal germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0037743,mediastinal soft tissue cancer,http://purl.obolibrary.org/obo/MONDO_0003512,mediastinal mesenchymal tumor
+http://purl.obolibrary.org/obo/MONDO_0024880,metastatic malignant neoplasm,http://purl.obolibrary.org/obo/MONDO_0024883,metastatic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0024282,mucinous ovarian cancer,http://purl.obolibrary.org/obo/MONDO_0003756,ovarian mucinous neoplasm
+http://purl.obolibrary.org/obo/MONDO_0004682,retromolar area cancer,http://purl.obolibrary.org/obo/MONDO_0037744,neoplasm of retromolar area
+http://purl.obolibrary.org/obo/MONDO_0003403,testicular non-seminomatous germ cell cancer,http://purl.obolibrary.org/obo/MONDO_0006447,testicular non-seminomatous germ cell tumor

--- a/src/patterns/melanoma.csv
+++ b/src/patterns/melanoma.csv
@@ -1,0 +1,24 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0006081,anal melanoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0005012,cutaneous melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0045070,digestive system melanoma,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0001192,esophageal melanoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0000928,eyelid melanoma,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0004484,gallbladder melanoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0004064,iris melanoma,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0003761,leptomeningeal melanoma,http://purl.obolibrary.org/obo/UBERON_0000391,leptomeninx
+http://purl.obolibrary.org/obo/MONDO_0002975,malignant breast melanoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0003878,malignant choroid melanoma,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0003912,malignant ciliary body melanoma,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0002096,malignant conjunctival melanoma,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0004550,malignant cornea melanoma,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0015694,malignant melanoma of the mucosa,http://purl.obolibrary.org/obo/UBERON_0000344,mucosa
+http://purl.obolibrary.org/obo/MONDO_0006325,ocular melanoma,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0016747,primary melanoma of the central nervous system,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002167,rectum malignant melanoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0004561,retinal melanoma,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0001652,scrotum melanoma,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0001893,spinal cord melanoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0006486,uveal melanoma,http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0006489,vaginal melanoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0002205,vulvar melanoma (disease),http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/melanoma.yaml
+++ b/src/patterns/melanoma.yaml
@@ -1,13 +1,13 @@
-pattern_name: melanoma (disease) disease has location X
+pattern_name: melanoma disease has location X
 pattern_iri: http://purl.obolibrary.org/obo/mondo/melanoma_(disease)_disease_has_location_X
 
 description: >-
   This is auto-generated. Add your description here
 
-  Examples: [cutaneous melanoma (disease)](http://purl.obolibrary.org/obo/MONDO_0005012), [malignant breast melanoma](http://purl.obolibrary.org/obo/MONDO_0002975), [malignant melanoma of the mucosa](http://purl.obolibrary.org/obo/MONDO_0015694) (22 total)
+  Examples: [cutaneous melanoma](http://purl.obolibrary.org/obo/MONDO_0005012), [malignant breast melanoma](http://purl.obolibrary.org/obo/MONDO_0002975), [malignant melanoma of the mucosa](http://purl.obolibrary.org/obo/MONDO_0015694) (22 total)
 
 classes: 
-  melanoma (disease): "MONDO:0005105"
+  melanoma: "MONDO:0005105"
 
 
 relations: 
@@ -25,7 +25,7 @@ name:
 
 def:
   # Induced, frequency=0.18181818181818182, p=http://purl.obolibrary.org/obo/IAO_0000115 
-  text: "A melanoma (disease) that involves the %s."
+  text: "A melanoma that involves the %s."
   vars:
     - v0
 
@@ -36,12 +36,12 @@ annotationProperties:
 annotations:
   - annotationProperty: exact_synonym
     # Induced p=exact_synonym 
-    text: "%s melanoma (disease)"
+    text: "%s melanoma"
     vars:
       - v0
 
 
 equivalentTo:
-  text: "'melanoma (disease)' and ('disease has location' some %s)"
+  text: "'melanoma' and ('disease has location' some %s)"
   vars:
     - v0

--- a/src/patterns/neoplasm.csv
+++ b/src/patterns/neoplasm.csv
@@ -1,188 +1,213 @@
 iri,iri label,location,location label
-MONDO:0021082,Meckel diverticulum neoplasm,UBERON:0003705,Meckel's diverticulum
-MONDO:0021049,Vulvar Neoplasm,UBERON:0000997,mammalian vulva
-MONDO:0001884,abducens nerve neoplasm,UBERON:0001646,abducens nerve
-MONDO:0021227,adrenal gland neoplasm,UBERON:0002369,adrenal gland
-MONDO:0021237,adrenal medulla neoplasm,UBERON:0001236,adrenal medulla
-MONDO:0000921,ampulla of vater neoplasm,UBERON:0004913,hepatopancreatic ampulla
-MONDO:0003045,anal gland neoplasm,UBERON:0004760,gland of anal canal
-MONDO:0003046,anus neoplasm,UBERON:0001245,anus
-MONDO:0003686,apocrine sweat gland neoplasm,UBERON:0000382,apocrine sweat gland
-MONDO:0001236,appendiceal neoplasm,UBERON:0001154,vermiform appendix
-MONDO:0002366,autonomic nervous system neoplasm,UBERON:0002410,autonomic nervous system
-MONDO:0021114,bartholin gland neoplasm,UBERON:0000460,major vestibular gland
-MONDO:0005304,biliary tract neoplasm (disease),UBERON:0001173,biliary tree
-MONDO:0004987,bladder tumor,UBERON:0001255,urinary bladder
-MONDO:0021080,blood vessel neoplasm,UBERON:0001981,blood vessel
-MONDO:0005374,bone marrow neoplasm,UBERON:0002371,bone marrow
-MONDO:0003700,brachial plexus neoplasm,UBERON:0001814,brachial nerve plexus
-MONDO:0021211,brain neoplasm,UBERON:0000955,brain
-MONDO:0021228,brainstem neoplasm,UBERON:0002298,brainstem
-MONDO:0021100,breast neoplasm,UBERON:0000310,breast
-MONDO:0002807,bronchial neoplasm (disease),UBERON:0002185,bronchus
-MONDO:0021241,buccal mucosa neoplasm,UBERON:0006956,buccal mucosa
-MONDO:0003164,cauda equina neoplasm,UBERON:0012337,cauda equina
-MONDO:0005694,cecal neoplasm,UBERON:0001153,caecum
-MONDO:0006130,central nervous system neoplasm,UBERON:0001017,central nervous system
-MONDO:0002913,cerebellar neoplasm,UBERON:0002037,cerebellum
-MONDO:0002553,cerebellopontine angle tumor,UBERON:0014908,cerebellopontine angle
-MONDO:0021258,choroid neoplasm,UBERON:0001776,optic choroid
-MONDO:0021229,ciliary body neoplasm,UBERON:0001775,ciliary body
-MONDO:0005401,colonic neoplasm,UBERON:0001155,colon
-MONDO:0005335,colorectal neoplasm,UBERON:0012652,colorectum
-MONDO:0006709,common bile duct neoplasm,UBERON:0001174,common bile duct
-MONDO:0020204,conjunctival tumor,UBERON:0001811,conjunctiva
-MONDO:0021581,connective tissue neoplasm,UBERON:0002384,connective tissue
-MONDO:0002719,conus medullaris neoplasm,UBERON:0005437,conus medullaris
-MONDO:0021238,cornea neoplasm,UBERON:0000964,cornea
-MONDO:0021254,corpus uteri neoplasm,UBERON:0009853,body of uterus
-MONDO:0002435,cranial nerve III tumor,UBERON:0001643,oculomotor nerve
-MONDO:0002633,cranial nerve neoplasm,UBERON:0001785,cranial nerve
-MONDO:0002300,dermis tumor,UBERON:0002067,dermis
-MONDO:0021223,digestive system neoplasm,UBERON:0001007,digestive system
-MONDO:0021233,ear neoplasm,UBERON:0001690,ear
-MONDO:0002090,eccrine sweat gland neoplasm,UBERON:0000423,eccrine sweat gland
-MONDO:0002082,endocrine gland neoplasm,UBERON:0002368,endocrine gland
-MONDO:0006190,endolymphatic sac tumor (disease),UBERON:0002223,endolymphatic sac
-MONDO:0021251,endometrium neoplasm,UBERON:0001295,endometrium
-MONDO:0002297,epidermal appendage tumor,UBERON:0000021,cutaneous appendage
-MONDO:0003283,epididymal neoplasm,UBERON:0001301,epididymis
-MONDO:0004109,epiglottis neoplasm,UBERON:0000388,epiglottis
-MONDO:0001764,ethmoidal sinus neoplasm,UBERON:0002453,ethmoid sinus
-MONDO:0021235,external ear neoplasm,UBERON:0001691,external ear
-MONDO:0021220,eye neoplasm,UBERON:0000970,eye
-MONDO:0002235,eyelid neoplasm,UBERON:0001711,eyelid
-MONDO:0002101,facial nerve neoplasm,UBERON:0001647,facial nerve
-MONDO:0021092,fallopian tube neoplasm,UBERON:0003889,fallopian tube
-MONDO:0021148,female reproductive system neoplasm,UBERON:0000474,female reproductive system
-MONDO:0001421,frontal lobe neoplasm,UBERON:0016525,frontal lobe
-MONDO:0001757,frontal sinus neoplasm,UBERON:0001760,frontal sinus
-MONDO:0021253,gallbladder neoplasm,UBERON:0002110,gall bladder
-MONDO:0021085,gastric neoplasm,UBERON:0000945,stomach
-MONDO:0021086,gingival neoplasm,UBERON:0001828,gingiva
-MONDO:0021257,glomus jugulare neoplasm,UBERON:0034972,jugular body
-MONDO:0018327,glomus tumor,UBERON:0004739,pronephric glomerulus
-MONDO:0002638,glossopharyngeal nerve neoplasm,UBERON:0001649,glossopharyngeal nerve
-MONDO:0002353,glottis neoplasm,UBERON:0002486,glottis
-MONDO:0006036,granulosa cell tumor,CL:0000501,granulosa cell
-MONDO:0003413,hair follicle neoplasm,UBERON:0002073,hair follicle
-MONDO:0005586,head and neck neoplasia,UBERON:0007811,craniocervical region
-MONDO:0021209,heart neoplasm,UBERON:0000948,heart
-MONDO:0002334,hematopoietic and lymphoid system neoplasm,UBERON:0000178,blood
-MONDO:0002514,hepatobiliary neoplasm,UBERON:0002423,hepatobiliary system
-MONDO:0002550,hypoglossal nerve neoplasm,UBERON:0001650,hypoglossal nerve
-MONDO:0006801,ileal neoplasm,UBERON:0002116,ileum
-MONDO:0021118,intestinal neoplasm,UBERON:0000160,intestine
-MONDO:0021224,iris neoplasm,UBERON:0001769,iris
-MONDO:0002564,jejunal neoplasm,UBERON:0002115,jejunum
-MONDO:0021163,kidney neoplasm,UBERON:0002113,kidney
-MONDO:0021222,lacrimal gland neoplasm,UBERON:0001817,lacrimal gland
-MONDO:0021071,laryngeal neoplasm,UBERON:0001737,larynx
-MONDO:0021249,lip neoplasm,UBERON:0001833,lip
-MONDO:0004721,liver neoplasm,UBERON:0002107,liver
-MONDO:0004546,lumbar plexus neoplasm,UBERON:0034987,lumbar nerve plexus
-MONDO:0003639,lung hilum neoplasm,UBERON:0004886,lung hilus
-MONDO:0021117,lung neoplasm,UBERON:0002048,lung
-MONDO:0005841,maxillary neoplasm,UBERON:0011597,bone of upper jaw
-MONDO:0006850,maxillary sinus neoplasm,UBERON:0001764,maxillary sinus
-MONDO:0004756,nasal cavity neoplasm,UBERON:0001707,nasal cavity
-MONDO:0005375,nasopharyngeal neoplasm,UBERON:0001728,nasopharynx
-MONDO:0021389,neoplasm of aortic body,UBERON:0034971,aortic body
-MONDO:0021374,neoplasm of cerebrum,UBERON:0001893,telencephalon
-MONDO:0021388,neoplasm of chest wall,UBERON:0016435,chest wall
-MONDO:0021378,neoplasm of endocardium,UBERON:0002165,endocardium
-MONDO:0021379,neoplasm of epicardium,UBERON:0002348,epicardium
-MONDO:0021355,neoplasm of esophagus,UBERON:0001043,esophagus
-MONDO:0021579,neoplasm of femur,UBERON:0000981,femur
-MONDO:0021383,neoplasm of floor of mouth,UBERON:0003679,mouth floor
-MONDO:0021358,neoplasm of hypopharynx,UBERON:0001051,hypopharynx
-MONDO:0021580,neoplasm of jaw,UBERON:0001708,jaw skeleton
-MONDO:0021368,neoplasm of major salivary gland,UBERON:0001829,major salivary gland
-MONDO:0021386,neoplasm of mediastinum,UBERON:0003728,mediastinum
-MONDO:0021366,neoplasm of middle ear,UBERON:0001756,middle ear
-MONDO:0021370,neoplasm of minor salivary gland,UBERON:0001830,minor salivary gland
-MONDO:0021380,neoplasm of myocardium,UBERON:0002349,myocardium
-MONDO:0021351,neoplasm of neck,UBERON:0000974,neck
-MONDO:0021364,neoplasm of oropharynx,UBERON:0001729,oropharynx
-MONDO:0021373,neoplasm of parietal lobe,UBERON:0001872,parietal lobe
-MONDO:0021381,neoplasm of pericardium,UBERON:0002407,pericardium
-MONDO:0021372,neoplasm of temporal lobe,UBERON:0001871,temporal lobe
-MONDO:0021348,neoplasm of testis,UBERON:0000473,testis
-MONDO:0021350,neoplasm of thorax,UBERON:0000915,thoracic segment of trunk
-MONDO:0003100,nerve plexus neoplasm,UBERON:0001810,nerve plexus
-MONDO:0003103,nerve root neoplasm,UBERON:0002211,nerve root
-MONDO:0021248,nervous system neoplasm,UBERON:0001016,nervous system
-MONDO:0002482,nipple neoplasm,UBERON:0002030,nipple
-MONDO:0004709,occipital lobe neoplasm,UBERON:0002021,occipital lobe
-MONDO:0021192,odontogenic neoplasm,UBERON:0001091,calcareous tooth
-MONDO:0002722,olfactory nerve neoplasm,UBERON:0001579,olfactory nerve
-MONDO:0002640,optic nerve neoplasm,UBERON:0000941,cranial nerve II
-MONDO:0021245,oral cavity neoplasm,UBERON:0000167,oral cavity
-MONDO:0021068,ovarian neoplasm,UBERON:0000992,ovary
-MONDO:0005286,palatal neoplasm,UBERON:0001716,secondary palate
-MONDO:0020172,palpebral epidermal tumor,UBERON:0001457,skin of eyelid
-MONDO:0020176,palpebral sebaceous gland tumor,UBERON:0013231,sebaceous gland of eyelid
-MONDO:0021076,pancreatic exocrine neoplasm,UBERON:0000017,exocrine pancreas
-MONDO:0021040,pancreatic neoplasm,UBERON:0001264,pancreas
-MONDO:0005815,pancreatic neuroendocrine neoplasm,UBERON:0000016,endocrine pancreas
-MONDO:0005289,paranasal sinus neoplasm (disease),UBERON:0001825,paranasal sinus
-MONDO:0002219,paraurethral gland neoplasm,UBERON:0010145,paraurethral gland
-MONDO:0021243,parotid gland neoplasm,UBERON:0001831,parotid gland
-MONDO:0006895,penile neoplasm,UBERON:0000989,penis
-MONDO:0001406,peripheral nervous system neoplasm,UBERON:0000010,peripheral nervous system
-MONDO:0006901,peritoneal neoplasm,UBERON:0002358,peritoneum
-MONDO:0021246,pharynx neoplasm,UBERON:0006562,pharynx
-MONDO:0021232,pineal body neoplasm,UBERON:0001905,pineal body
-MONDO:0021218,placenta neoplasm,UBERON:0001987,placenta
-MONDO:0021065,pleural neoplasm,UBERON:0000977,pleura
-MONDO:0003257,posterior pituitary gland neoplasm,UBERON:0002198,neurohypophysis
-MONDO:0021259,prostate neoplasm,UBERON:0002367,prostate gland
-MONDO:0002165,rectal neoplasm,UBERON:0001052,rectum
-MONDO:0002423,rectosigmoid junction neoplasm,UBERON:0036214,rectosigmoid junction
-MONDO:0003719,renal pelvis neoplasm,UBERON:0001224,renal pelvis
-MONDO:0006054,reproductive system neoplasm,UBERON:0000990,reproductive system
-MONDO:0003192,rete ovarii neoplasm,UBERON:0010185,rete ovarii
-MONDO:0003562,rete testis neoplasm,UBERON:0003959,rete testis
-MONDO:0021231,retina neoplasm,UBERON:0000966,retina
-MONDO:0003319,scrotum neoplasm,UBERON:0001300,scrotum
-MONDO:0006963,sebaceous gland neoplasm,UBERON:0001821,sebaceous gland
-MONDO:0002790,seminal vesicle tumor,UBERON:0000998,seminal vesicle
-MONDO:0006971,sigmoid neoplasm,UBERON:0001159,sigmoid colon
-MONDO:0002848,skeletal muscle neoplasm,UBERON:0001134,skeletal muscle tissue
-MONDO:0002531,skin neoplasm,UBERON:0000014,zone of skin
-MONDO:0002785,skull base neoplasm,UBERON:0002517,basicranium
-MONDO:0004251,small intestine neoplasm,UBERON:0002108,small intestine
-MONDO:0004047,sphenoidal sinus neoplasm,UBERON:0001724,sphenoidal sinus
-MONDO:0002626,spinal accessory nerve neoplasm,UBERON:0009674,accessory XI nerve spinal component
-MONDO:0021234,spinal cord neoplasm,UBERON:0002240,spinal cord
-MONDO:0021578,sternal neoplasm,UBERON:0000975,sternum
-MONDO:0000933,subglottis neoplasm,UBERON:0036068,subglottis
-MONDO:0021242,sublingual gland neoplasm,UBERON:0001832,sublingual gland
-MONDO:0021244,submandibular gland neoplasm,UBERON:0001736,submandibular gland
-MONDO:0004427,supraglottis neoplasm,UBERON:0036263
-MONDO:0002381,sweat gland neoplasm,UBERON:0001820,sweat gland
-MONDO:0002528,synovium neoplasm,UBERON:0002018,synovial membrane of synovial joint
-MONDO:0005197,thymus neoplasm,UBERON:0002370,thymus
-MONDO:0015074,thyroid tumor,UBERON:0002046,thyroid gland
-MONDO:0021240,tongue neoplasm,UBERON:0001723,tongue
-MONDO:0021250,tonsil neoplasm,UBERON:0002372,tonsil
-MONDO:0021210,trachea neoplasm,UBERON:0003126,trachea
-MONDO:0001420,trigeminal nerve neoplasm,UBERON:0001645,trigeminal nerve
-MONDO:0002642,trochlear nerve neoplasm,UBERON:0001644,trochlear nerve
-MONDO:0002872,trophoblastic neoplasm,UBERON:0000088,trophoblast
-MONDO:0021354,tumor of adipose tissue,UBERON:0001013,adipose tissue
-MONDO:0021375,tumor of duodenum,UBERON:0002114,duodenum
-MONDO:0021385,tumor of extrahepatic bile duct,UBERON:0003703,extrahepatic bile duct
-MONDO:0016743,tumor of meninges,UBERON:0010743,meningeal cluster
-MONDO:0021360,tumor of parathyroid gland,UBERON:0001132,parathyroid gland
-MONDO:0021357,tumor of salivary gland,UBERON:0001044,saliva-secreting gland
-MONDO:0021353,tumor of uterus,UBERON:0000995,uterus
-MONDO:0021111,ureter neoplasm,UBERON:0000056,ureter
-MONDO:0021239,urethra neoplasm,UBERON:0000057,urethra
-MONDO:0021066,urinary system neoplasm,UBERON:0001008,renal system
-MONDO:0021230,uterine cervix neoplasm,UBERON:0000002,uterine cervix
-MONDO:0021629,uterine ligament neoplasm,UBERON:0036262
-MONDO:0021225,uvea neoplasm,UBERON:0001768,uvea
-MONDO:0021050,vaginal neoplasm,UBERON:0000996,vagina
-MONDO:0001608,vagus nerve neoplasm,UBERON:0001759,vagus nerve
-MONDO:0021221,vestibulocochlear nerve neoplasm,UBERON:0001648,vestibulocochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0021114,Bartholin gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0021082,Meckel diverticulum neoplasm,http://purl.obolibrary.org/obo/UBERON_0003705,Meckel's diverticulum
+http://purl.obolibrary.org/obo/MONDO_0001884,abducens nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001646,abducens nerve
+http://purl.obolibrary.org/obo/MONDO_0036591,adrenal cortex neoplasm,http://purl.obolibrary.org/obo/UBERON_0001235,adrenal cortex
+http://purl.obolibrary.org/obo/MONDO_0021227,adrenal gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0002369,adrenal gland
+http://purl.obolibrary.org/obo/MONDO_0021237,adrenal medulla neoplasm,http://purl.obolibrary.org/obo/UBERON_0001236,adrenal medulla
+http://purl.obolibrary.org/obo/MONDO_0000921,ampulla of vater neoplasm,http://purl.obolibrary.org/obo/UBERON_0004913,hepatopancreatic ampulla
+http://purl.obolibrary.org/obo/MONDO_0003045,anal gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0004760,gland of anal canal
+http://purl.obolibrary.org/obo/MONDO_0003046,anus neoplasm,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0003686,apocrine sweat gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0000382,apocrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0001236,appendiceal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0002366,autonomic nervous system neoplasm,http://purl.obolibrary.org/obo/UBERON_0002410,autonomic nervous system
+http://purl.obolibrary.org/obo/MONDO_0036779,axillary neoplasm,http://purl.obolibrary.org/obo/UBERON_0009472,axilla
+http://purl.obolibrary.org/obo/MONDO_0021662,bile duct neoplasm,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0005304,biliary tract neoplasm (disease),http://purl.obolibrary.org/obo/UBERON_0001173,biliary tree
+http://purl.obolibrary.org/obo/MONDO_0021080,blood vessel neoplasm,http://purl.obolibrary.org/obo/UBERON_0001981,blood vessel
+http://purl.obolibrary.org/obo/MONDO_0005374,bone marrow neoplasm,http://purl.obolibrary.org/obo/UBERON_0002371,bone marrow
+http://purl.obolibrary.org/obo/MONDO_0019060,bone neoplasm,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0003700,brachial plexus neoplasm,http://purl.obolibrary.org/obo/UBERON_0001814,brachial nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0021211,brain neoplasm,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0021228,brainstem neoplasm,http://purl.obolibrary.org/obo/UBERON_0002298,brainstem
+http://purl.obolibrary.org/obo/MONDO_0021100,breast neoplasm,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002807,bronchial neoplasm (disease),http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0021241,buccal mucosa neoplasm,http://purl.obolibrary.org/obo/UBERON_0006956,buccal mucosa
+http://purl.obolibrary.org/obo/MONDO_0024757,cardiovascular neoplasm,http://purl.obolibrary.org/obo/UBERON_0004535,cardiovascular system
+http://purl.obolibrary.org/obo/MONDO_0003164,cauda equina neoplasm,http://purl.obolibrary.org/obo/UBERON_0012337,cauda equina
+http://purl.obolibrary.org/obo/MONDO_0005694,cecal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0006130,central nervous system neoplasm,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002913,cerebellar neoplasm,http://purl.obolibrary.org/obo/UBERON_0002037,cerebellum
+http://purl.obolibrary.org/obo/MONDO_0002553,cerebellopontine angle tumor,http://purl.obolibrary.org/obo/UBERON_0014908,cerebellopontine angle
+http://purl.obolibrary.org/obo/MONDO_0021258,choroid neoplasm,http://purl.obolibrary.org/obo/UBERON_0001776,optic choroid
+http://purl.obolibrary.org/obo/MONDO_0021229,ciliary body neoplasm,http://purl.obolibrary.org/obo/UBERON_0001775,ciliary body
+http://purl.obolibrary.org/obo/MONDO_0024877,clitoris neoplasm,http://purl.obolibrary.org/obo/UBERON_0002411,clitoris
+http://purl.obolibrary.org/obo/MONDO_0005401,colonic neoplasm,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0005335,colorectal neoplasm,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0006709,common bile duct neoplasm,http://purl.obolibrary.org/obo/UBERON_0001174,common bile duct
+http://purl.obolibrary.org/obo/MONDO_0020204,conjunctival tumor,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0021581,connective tissue neoplasm,http://purl.obolibrary.org/obo/UBERON_0002384,connective tissue
+http://purl.obolibrary.org/obo/MONDO_0002719,conus medullaris neoplasm,http://purl.obolibrary.org/obo/UBERON_0005437,conus medullaris
+http://purl.obolibrary.org/obo/MONDO_0021238,cornea neoplasm,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0021254,corpus uteri neoplasm,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002633,cranial nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001785,cranial nerve
+http://purl.obolibrary.org/obo/MONDO_0002300,dermis tumor,http://purl.obolibrary.org/obo/UBERON_0002067,dermis
+http://purl.obolibrary.org/obo/MONDO_0021223,digestive system neoplasm,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0021233,ear neoplasm,http://purl.obolibrary.org/obo/UBERON_0001690,ear
+http://purl.obolibrary.org/obo/MONDO_0002090,eccrine sweat gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0000423,eccrine sweat gland
+http://purl.obolibrary.org/obo/MONDO_0002082,endocrine gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0002368,endocrine gland
+http://purl.obolibrary.org/obo/MONDO_0006190,endolymphatic sac tumor (disease),http://purl.obolibrary.org/obo/UBERON_0002223,endolymphatic sac
+http://purl.obolibrary.org/obo/MONDO_0003311,endometrial stromal tumor,http://purl.obolibrary.org/obo/UBERON_0002337,endometrial stroma
+http://purl.obolibrary.org/obo/MONDO_0021251,endometrium neoplasm,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0002297,epidermal appendage tumor,http://purl.obolibrary.org/obo/UBERON_0000021,cutaneous appendage
+http://purl.obolibrary.org/obo/MONDO_0003283,epididymal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001301,epididymis
+http://purl.obolibrary.org/obo/MONDO_0002713,epidural spinal canal neoplasm,http://purl.obolibrary.org/obo/UBERON_0003691,epidural space
+http://purl.obolibrary.org/obo/MONDO_0004109,epiglottis neoplasm,http://purl.obolibrary.org/obo/UBERON_0000388,epiglottis
+http://purl.obolibrary.org/obo/MONDO_0001764,ethmoidal sinus neoplasm,http://purl.obolibrary.org/obo/UBERON_0002453,ethmoid sinus
+http://purl.obolibrary.org/obo/MONDO_0021235,external ear neoplasm,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0021385,extrahepatic bile duct neoplasm,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0021220,eye neoplasm,http://purl.obolibrary.org/obo/UBERON_0010230,eyeball of camera-type eye
+http://purl.obolibrary.org/obo/MONDO_0002235,eyelid neoplasm,http://purl.obolibrary.org/obo/UBERON_0001711,eyelid
+http://purl.obolibrary.org/obo/MONDO_0002101,facial nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001647,facial nerve
+http://purl.obolibrary.org/obo/MONDO_0021092,fallopian tube neoplasm,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0021148,female reproductive system neoplasm,http://purl.obolibrary.org/obo/UBERON_0000474,female reproductive system
+http://purl.obolibrary.org/obo/MONDO_0001421,frontal lobe neoplasm,http://purl.obolibrary.org/obo/UBERON_0016525,frontal lobe
+http://purl.obolibrary.org/obo/MONDO_0001757,frontal sinus neoplasm,http://purl.obolibrary.org/obo/UBERON_0001760,frontal sinus
+http://purl.obolibrary.org/obo/MONDO_0021253,gallbladder neoplasm,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0021085,gastric neoplasm,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0021086,gingival neoplasm,http://purl.obolibrary.org/obo/UBERON_0001828,gingiva
+http://purl.obolibrary.org/obo/MONDO_0021257,glomus jugulare neoplasm,http://purl.obolibrary.org/obo/UBERON_0034972,jugular body
+http://purl.obolibrary.org/obo/MONDO_0002638,glossopharyngeal nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001649,glossopharyngeal nerve
+http://purl.obolibrary.org/obo/MONDO_0002353,glottis neoplasm,http://purl.obolibrary.org/obo/UBERON_0002486,glottis
+http://purl.obolibrary.org/obo/MONDO_0006036,granulosa cell tumor,http://purl.obolibrary.org/obo/CL_0000501,granulosa cell
+http://purl.obolibrary.org/obo/MONDO_0003413,hair follicle neoplasm,http://purl.obolibrary.org/obo/UBERON_0002073,hair follicle
+http://purl.obolibrary.org/obo/MONDO_0005586,head and neck neoplasm,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0021209,heart neoplasm,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0002334,hematopoietic and lymphoid system neoplasm,http://purl.obolibrary.org/obo/UBERON_0002390,hematopoietic system
+http://purl.obolibrary.org/obo/MONDO_0002514,hepatobiliary neoplasm,http://purl.obolibrary.org/obo/UBERON_0002423,hepatobiliary system
+http://purl.obolibrary.org/obo/MONDO_0002550,hypoglossal nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001650,hypoglossal nerve
+http://purl.obolibrary.org/obo/MONDO_0006799,hypothalamic neoplasm,http://purl.obolibrary.org/obo/UBERON_0001898,hypothalamus
+http://purl.obolibrary.org/obo/MONDO_0006801,ileal neoplasm,http://purl.obolibrary.org/obo/UBERON_0002116,ileum
+http://purl.obolibrary.org/obo/MONDO_0024320,inner ear neoplasm,http://purl.obolibrary.org/obo/UBERON_0001846,internal ear
+http://purl.obolibrary.org/obo/MONDO_0021118,intestinal neoplasm,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0021224,iris neoplasm,http://purl.obolibrary.org/obo/UBERON_0001769,iris
+http://purl.obolibrary.org/obo/MONDO_0002564,jejunal neoplasm,http://purl.obolibrary.org/obo/UBERON_0002115,jejunum
+http://purl.obolibrary.org/obo/MONDO_0021163,kidney neoplasm,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0021222,lacrimal gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0021071,laryngeal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0021249,lip neoplasm,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0004721,liver neoplasm,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0004546,lumbar plexus neoplasm,http://purl.obolibrary.org/obo/UBERON_0034987,lumbar nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0003639,lung hilum neoplasm,http://purl.obolibrary.org/obo/UBERON_0004886,lung hilus
+http://purl.obolibrary.org/obo/MONDO_0021117,lung neoplasm,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0024339,lymph node neoplasm,http://purl.obolibrary.org/obo/UBERON_0000029,lymph node
+http://purl.obolibrary.org/obo/MONDO_0036870,lymphatic vessel neoplasm,http://purl.obolibrary.org/obo/UBERON_0001473,lymphatic vessel
+http://purl.obolibrary.org/obo/MONDO_0024582,male reproductive system neoplasm,http://purl.obolibrary.org/obo/UBERON_0003135,male reproductive organ
+http://purl.obolibrary.org/obo/MONDO_0005841,maxillary neoplasm,http://purl.obolibrary.org/obo/UBERON_0011597,bone of upper jaw
+http://purl.obolibrary.org/obo/MONDO_0006850,maxillary sinus neoplasm,http://purl.obolibrary.org/obo/UBERON_0001764,maxillary sinus
+http://purl.obolibrary.org/obo/MONDO_0024888,mesonephric neoplasm,http://purl.obolibrary.org/obo/UBERON_0003074,mesonephric duct
+http://purl.obolibrary.org/obo/MONDO_0017588,nail tumor,http://purl.obolibrary.org/obo/UBERON_0001705,nail
+http://purl.obolibrary.org/obo/MONDO_0004756,nasal cavity neoplasm,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0005375,nasopharyngeal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001728,nasopharynx
+http://purl.obolibrary.org/obo/MONDO_0021389,neoplasm of aortic body,http://purl.obolibrary.org/obo/UBERON_0034971,aortic body
+http://purl.obolibrary.org/obo/MONDO_0021374,neoplasm of cerebral hemisphere,http://purl.obolibrary.org/obo/UBERON_0001869,cerebral hemisphere
+http://purl.obolibrary.org/obo/MONDO_0021388,neoplasm of chest wall,http://purl.obolibrary.org/obo/UBERON_0016435,chest wall
+http://purl.obolibrary.org/obo/MONDO_0021378,neoplasm of endocardium,http://purl.obolibrary.org/obo/UBERON_0002165,endocardium
+http://purl.obolibrary.org/obo/MONDO_0021379,neoplasm of epicardium,http://purl.obolibrary.org/obo/UBERON_0002348,epicardium
+http://purl.obolibrary.org/obo/MONDO_0021355,neoplasm of esophagus,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0021579,neoplasm of femur,http://purl.obolibrary.org/obo/UBERON_0000981,femur
+http://purl.obolibrary.org/obo/MONDO_0021383,neoplasm of floor of mouth,http://purl.obolibrary.org/obo/UBERON_0003679,mouth floor
+http://purl.obolibrary.org/obo/MONDO_0021358,neoplasm of hypopharynx,http://purl.obolibrary.org/obo/UBERON_0001051,hypopharynx
+http://purl.obolibrary.org/obo/MONDO_0021580,neoplasm of jaw,http://purl.obolibrary.org/obo/UBERON_0001708,jaw skeleton
+http://purl.obolibrary.org/obo/MONDO_0021368,neoplasm of major salivary gland,http://purl.obolibrary.org/obo/UBERON_0001829,major salivary gland
+http://purl.obolibrary.org/obo/MONDO_0021386,neoplasm of mediastinum,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0021366,neoplasm of middle ear,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0021370,neoplasm of minor salivary gland,http://purl.obolibrary.org/obo/UBERON_0001830,minor salivary gland
+http://purl.obolibrary.org/obo/MONDO_0021380,neoplasm of myocardium,http://purl.obolibrary.org/obo/UBERON_0002349,myocardium
+http://purl.obolibrary.org/obo/MONDO_0021351,neoplasm of neck,http://purl.obolibrary.org/obo/UBERON_0000974,neck
+http://purl.obolibrary.org/obo/MONDO_0021364,neoplasm of oropharynx,http://purl.obolibrary.org/obo/UBERON_0001729,oropharynx
+http://purl.obolibrary.org/obo/MONDO_0021373,neoplasm of parietal lobe,http://purl.obolibrary.org/obo/UBERON_0001872,parietal lobe
+http://purl.obolibrary.org/obo/MONDO_0021381,neoplasm of pericardium,http://purl.obolibrary.org/obo/UBERON_0002407,pericardium
+http://purl.obolibrary.org/obo/MONDO_0021372,neoplasm of temporal lobe,http://purl.obolibrary.org/obo/UBERON_0001871,temporal lobe
+http://purl.obolibrary.org/obo/MONDO_0021348,neoplasm of testis,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0021350,neoplasm of thorax,http://purl.obolibrary.org/obo/UBERON_0000915,thoracic segment of trunk
+http://purl.obolibrary.org/obo/MONDO_0003100,nerve plexus neoplasm,http://purl.obolibrary.org/obo/UBERON_0001810,nerve plexus
+http://purl.obolibrary.org/obo/MONDO_0003103,nerve root neoplasm,http://purl.obolibrary.org/obo/UBERON_0002211,nerve root
+http://purl.obolibrary.org/obo/MONDO_0021248,nervous system neoplasm,http://purl.obolibrary.org/obo/UBERON_0001016,nervous system
+http://purl.obolibrary.org/obo/MONDO_0002482,nipple neoplasm,http://purl.obolibrary.org/obo/UBERON_0002030,nipple
+http://purl.obolibrary.org/obo/MONDO_0002597,notochordal tumor,http://purl.obolibrary.org/obo/UBERON_0002328,notochord
+http://purl.obolibrary.org/obo/MONDO_0004709,occipital lobe neoplasm,http://purl.obolibrary.org/obo/UBERON_0002021,occipital lobe
+http://purl.obolibrary.org/obo/MONDO_0002435,oculomotor nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001643,oculomotor nerve
+http://purl.obolibrary.org/obo/MONDO_0021192,odontogenic neoplasm,http://purl.obolibrary.org/obo/UBERON_0001091,calcareous tooth
+http://purl.obolibrary.org/obo/MONDO_0002722,olfactory nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001579,olfactory nerve
+http://purl.obolibrary.org/obo/MONDO_0017587,onychomatricoma,http://purl.obolibrary.org/obo/UBERON_0002283,nail matrix
+http://purl.obolibrary.org/obo/MONDO_0002640,optic nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0000941,cranial nerve II
+http://purl.obolibrary.org/obo/MONDO_0021245,oral cavity neoplasm,http://purl.obolibrary.org/obo/UBERON_0000167,oral cavity
+http://purl.obolibrary.org/obo/MONDO_0024611,orbit neoplasm,http://purl.obolibrary.org/obo/UBERON_0001697,orbit of skull
+http://purl.obolibrary.org/obo/MONDO_0021068,ovarian neoplasm,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0005286,palatal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001716,secondary palate
+http://purl.obolibrary.org/obo/MONDO_0020172,palpebral epidermal tumor,http://purl.obolibrary.org/obo/UBERON_0001457,skin of eyelid
+http://purl.obolibrary.org/obo/MONDO_0020176,palpebral sebaceous gland tumor,http://purl.obolibrary.org/obo/UBERON_0013231,sebaceous gland of eyelid
+http://purl.obolibrary.org/obo/MONDO_0021076,pancreatic exocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000017,exocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0021040,pancreatic neoplasm,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0005815,pancreatic neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000016,endocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0005289,paranasal sinus neoplasm (disease),http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0002219,paraurethral gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0010145,paraurethral gland
+http://purl.obolibrary.org/obo/MONDO_0021243,parotid gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0006895,penile neoplasm,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0001406,peripheral nervous system neoplasm,http://purl.obolibrary.org/obo/UBERON_0000010,peripheral nervous system
+http://purl.obolibrary.org/obo/MONDO_0006901,peritoneal neoplasm,http://purl.obolibrary.org/obo/UBERON_0002358,peritoneum
+http://purl.obolibrary.org/obo/MONDO_0021246,pharynx neoplasm,http://purl.obolibrary.org/obo/UBERON_0006562,pharynx
+http://purl.obolibrary.org/obo/MONDO_0021232,pineal body neoplasm,http://purl.obolibrary.org/obo/UBERON_0001905,pineal body
+http://purl.obolibrary.org/obo/MONDO_0017611,pituitary tumor,http://purl.obolibrary.org/obo/UBERON_0000007,pituitary gland
+http://purl.obolibrary.org/obo/MONDO_0021218,placenta neoplasm,http://purl.obolibrary.org/obo/UBERON_0001987,placenta
+http://purl.obolibrary.org/obo/MONDO_0021065,pleural neoplasm,http://purl.obolibrary.org/obo/UBERON_0000977,pleura
+http://purl.obolibrary.org/obo/MONDO_0003257,posterior pituitary gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0002198,neurohypophysis
+http://purl.obolibrary.org/obo/MONDO_0021259,prostate neoplasm,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002165,rectal neoplasm,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0002423,rectosigmoid junction neoplasm,http://purl.obolibrary.org/obo/UBERON_0036214,rectosigmoid junction
+http://purl.obolibrary.org/obo/MONDO_0003719,renal pelvis neoplasm,http://purl.obolibrary.org/obo/UBERON_0001224,renal pelvis
+http://purl.obolibrary.org/obo/MONDO_0006054,reproductive system neoplasm,http://purl.obolibrary.org/obo/UBERON_0000990,reproductive system
+http://purl.obolibrary.org/obo/MONDO_0003192,rete ovarii neoplasm,http://purl.obolibrary.org/obo/UBERON_0010185,rete ovarii
+http://purl.obolibrary.org/obo/MONDO_0003562,rete testis neoplasm,http://purl.obolibrary.org/obo/UBERON_0003959,rete testis
+http://purl.obolibrary.org/obo/MONDO_0021231,retina neoplasm,http://purl.obolibrary.org/obo/UBERON_0000966,retina
+http://purl.obolibrary.org/obo/MONDO_0024645,retroperitoneal neoplasm,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0003319,scrotum neoplasm,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0006963,sebaceous gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0001821,sebaceous gland
+http://purl.obolibrary.org/obo/MONDO_0002790,seminal vesicle tumor,http://purl.obolibrary.org/obo/UBERON_0000998,seminal vesicle
+http://purl.obolibrary.org/obo/MONDO_0006055,sex cord-stromal tumor,http://purl.obolibrary.org/obo/UBERON_0005295,sex cord
+http://purl.obolibrary.org/obo/MONDO_0006971,sigmoid neoplasm,http://purl.obolibrary.org/obo/UBERON_0001159,sigmoid colon
+http://purl.obolibrary.org/obo/MONDO_0002848,skeletal muscle neoplasm,http://purl.obolibrary.org/obo/UBERON_0001134,skeletal muscle tissue
+http://purl.obolibrary.org/obo/MONDO_0002531,skin neoplasm,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0002785,skull base neoplasm,http://purl.obolibrary.org/obo/UBERON_0002517,basicranium
+http://purl.obolibrary.org/obo/MONDO_0024653,skull neoplasm,http://purl.obolibrary.org/obo/UBERON_0003129,skull
+http://purl.obolibrary.org/obo/MONDO_0004251,small intestine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0004047,sphenoidal sinus neoplasm,http://purl.obolibrary.org/obo/UBERON_0001724,sphenoidal sinus
+http://purl.obolibrary.org/obo/MONDO_0002626,spinal accessory nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0009674,accessory XI nerve spinal component
+http://purl.obolibrary.org/obo/MONDO_0021234,spinal cord neoplasm,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0036696,spleen neoplasm,http://purl.obolibrary.org/obo/UBERON_0002106,spleen
+http://purl.obolibrary.org/obo/MONDO_0021578,sternal neoplasm,http://purl.obolibrary.org/obo/UBERON_0000975,sternum
+http://purl.obolibrary.org/obo/MONDO_0000933,subglottis neoplasm,http://purl.obolibrary.org/obo/UBERON_0036068,subglottis
+http://purl.obolibrary.org/obo/MONDO_0021242,sublingual gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0001832,sublingual gland
+http://purl.obolibrary.org/obo/MONDO_0021244,submandibular gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0001736,submandibular gland
+http://purl.obolibrary.org/obo/MONDO_0004427,supraglottis neoplasm,http://purl.obolibrary.org/obo/UBERON_0036263,supraglottic part of larynx
+http://purl.obolibrary.org/obo/MONDO_0002381,sweat gland neoplasm,http://purl.obolibrary.org/obo/UBERON_0001820,sweat gland
+http://purl.obolibrary.org/obo/MONDO_0002528,synovium neoplasm,http://purl.obolibrary.org/obo/UBERON_0002018,synovial membrane of synovial joint
+http://purl.obolibrary.org/obo/MONDO_0005197,thymus neoplasm,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0015074,thyroid tumor,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0021240,tongue neoplasm,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0021250,tonsil neoplasm,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0021210,trachea neoplasm,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0001420,trigeminal nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001645,trigeminal nerve
+http://purl.obolibrary.org/obo/MONDO_0002642,trochlear nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001644,trochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0002872,trophoblastic neoplasm,http://purl.obolibrary.org/obo/UBERON_0000088,trophoblast
+http://purl.obolibrary.org/obo/MONDO_0021354,tumor of adipose tissue,http://purl.obolibrary.org/obo/UBERON_0001013,adipose tissue
+http://purl.obolibrary.org/obo/MONDO_0021375,tumor of duodenum,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0016743,tumor of meninges,http://purl.obolibrary.org/obo/UBERON_0010743,meningeal cluster
+http://purl.obolibrary.org/obo/MONDO_0021360,tumor of parathyroid gland,http://purl.obolibrary.org/obo/UBERON_0001132,parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0021357,tumor of salivary gland,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0021353,tumor of uterus,http://purl.obolibrary.org/obo/UBERON_0000995,uterus
+http://purl.obolibrary.org/obo/MONDO_0021111,ureter neoplasm,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0021239,urethra neoplasm,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0004987,urinary bladder neoplasm,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0021066,urinary system neoplasm,http://purl.obolibrary.org/obo/UBERON_0001008,renal system
+http://purl.obolibrary.org/obo/MONDO_0025370,urogenital neoplasm,http://purl.obolibrary.org/obo/UBERON_0004122,genitourinary system
+http://purl.obolibrary.org/obo/MONDO_0024337,urothelial neoplasm,http://purl.obolibrary.org/obo/UBERON_0000365,urothelium
+http://purl.obolibrary.org/obo/MONDO_0021230,uterine cervix neoplasm,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0021629,uterine ligament neoplasm,http://purl.obolibrary.org/obo/UBERON_0036262,uterine ligament
+http://purl.obolibrary.org/obo/MONDO_0021225,uvea neoplasm,http://purl.obolibrary.org/obo/UBERON_0001768,uvea
+http://purl.obolibrary.org/obo/MONDO_0021050,vaginal neoplasm,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0001608,vagus nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001759,vagus nerve
+http://purl.obolibrary.org/obo/MONDO_0024296,vascular neoplasm,http://purl.obolibrary.org/obo/UBERON_0007798,vascular system
+http://purl.obolibrary.org/obo/MONDO_0021221,vestibulocochlear nerve neoplasm,http://purl.obolibrary.org/obo/UBERON_0001648,vestibulocochlear nerve
+http://purl.obolibrary.org/obo/MONDO_0021049,vulvar neoplasm,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/neuroendocrine_neoplasm.csv
+++ b/src/patterns/neuroendocrine_neoplasm.csv
@@ -1,0 +1,22 @@
+iri,iri label,location,location label
+http://purl.obolibrary.org/obo/MONDO_0003504,anal canal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0024501,appendix neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0002485,breast neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0019963,bronchial endocrine tumor,http://purl.obolibrary.org/obo/UBERON_0002185,bronchus
+http://purl.obolibrary.org/obo/MONDO_0002882,colon neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0024503,digestive system neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0005409,alimentary part of gastrointestinal system
+http://purl.obolibrary.org/obo/MONDO_0024500,duodenal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002114,duodenum
+http://purl.obolibrary.org/obo/MONDO_0003649,esophageal neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0024502,gallbladder neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003111,gastric neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0015078,gastroenteropancreatic neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001007,digestive system
+http://purl.obolibrary.org/obo/MONDO_0002883,intestinal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0015070,laryngeal neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0005454,lung neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0015071,middle ear neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0002481,ovarian neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002477,prostate neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0003646,rectum neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0018510,small intestine neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0019964,thymic neuroendocrine tumor,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0021650,uterine corpus neuroendocrine neoplasm,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus

--- a/src/patterns/neuroendocrine_neoplasm_grade1.csv
+++ b/src/patterns/neuroendocrine_neoplasm_grade1.csv
@@ -1,0 +1,13 @@
+iri,iri label,location,location label
+http://purl.obolibrary.org/obo/MONDO_0006091,appendix neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0001154,vermiform appendix
+http://purl.obolibrary.org/obo/MONDO_0006093,ascending colon neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0001156,ascending colon
+http://purl.obolibrary.org/obo/MONDO_0006126,cecum neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0001153,caecum
+http://purl.obolibrary.org/obo/MONDO_0006155,colon neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0006162,colorectal neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0006227,gastric neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0006250,ileal neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0002116,ileum
+http://purl.obolibrary.org/obo/MONDO_0021533,intestinal neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0000160,intestine
+http://purl.obolibrary.org/obo/MONDO_0006257,jejunal neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0002115,jejunum
+http://purl.obolibrary.org/obo/MONDO_0021535,pancreatic neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0021534,rectal neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0000540,small intestinal neuroendocrine tumor G1,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine

--- a/src/patterns/postinfectious_disease.csv
+++ b/src/patterns/postinfectious_disease.csv
@@ -1,0 +1,1 @@
+iri,iri label,disease,disease label,feature,feature label

--- a/src/patterns/rare.csv
+++ b/src/patterns/rare.csv
@@ -1,69 +1,106 @@
 iri,iri label,disease,disease label
-MONDO:0020027,rare allergic disease,MONDO:0005271,allergic disease
-MONDO:0020028,rare allergic respiratory disease,MONDO:0000771,allergic respiratory disease
-MONDO:0015223,rare anemia,MONDO:0002280,anemia (disease)
-MONDO:0016234,rare arteriovenous malformation,MONDO:0001256,arteriovenous malformation
-MONDO:0018497,rare autonomic nervous system disorder,MONDO:0001292,autonomic nervous system disease
-MONDO:0015575,rare bacterial infectious disease,MONDO:0001026,bacterial infectious disease
-MONDO:0015116,rare biliary tract disease,MONDO:0004868,biliary tract disease
-MONDO:0019684,rare bone disease,MONDO:0005381,bone disease
-MONDO:0016274,rare cancer of cervix uteri,MONDO:0002974,cervical cancer
-MONDO:0016314,rare carcinoma of pancreas,MONDO:0005192,exocrine pancreatic carcinoma
-MONDO:0018501,rare carcinoma of stomach,MONDO:0004950,gastric carcinoma
-MONDO:0019996,rare cardiac disease,MONDO:0005267,heart disease
-MONDO:0016347,rare cardiac rhythm disease,MONDO:0007263,cardiac rhythm disease
-MONDO:0020224,rare cataract,MONDO:0005129,cataract (disease)
-MONDO:0020015,rare circulatory system disease,MONDO:0004995,cardiovascular disease
-MONDO:0020198,rare conjunctival disease,MONDO:0002932,conjunctival disease
-MONDO:0018887,rare cutaneous lupus erythematosus,MONDO:0005282,cutaneous lupus erythematosus
-MONDO:0016623,rare deficiency anemia,MONDO:0001639,deficiency anemia
-MONDO:0019515,rare dementia,MONDO:0001627,dementia
-MONDO:0015122,rare diabetes mellitus,MONDO:0005015,diabetes mellitus (disease)
-MONDO:0015886,rare diabetes mellitus type 1,MONDO:0005147,type 1 diabetes mellitus
-MONDO:0019049,rare dystonia,MONDO:0003441,dystonia (disease)
-MONDO:0020005,rare endocrine disease,MONDO:0005151,endocrine system disease
-MONDO:0015305,rare endometriosis,MONDO:0005133,endometriosis (disease)
-MONDO:0015139,rare epilepsy,MONDO:0005027,epilepsy
-MONDO:0020004,rare eye disease,MONDO:0005328,eye disease
-MONDO:0020026,rare female infertility,MONDO:0021124,female infertility
-MONDO:0018080,rare germ cell tumor,MONDO:0005040,germ cell tumor
-MONDO:0020037,rare gynecological tumor,MONDO:0021148,female reproductive system neoplasm
-MONDO:0017371,rare head and neck tumor,MONDO:0005586,head and neck neoplasia
-MONDO:0020011,rare headache disorder,MONDO:0021146,headache disorder
-MONDO:0020100,rare hemolytic anemia,MONDO:0003664,hemolytic anemia
-MONDO:0018928,rare hepatic disease,MONDO:0005154,liver disease
-MONDO:0015897,rare hyperparathyroidism,MONDO:0001741,hyperparathyroidism
-MONDO:0015894,rare hyperthyroidism,MONDO:0004425,hyperthyroidism
-MONDO:0015896,rare hypoparathyroidism,MONDO:0001220,hypoparathyroidism
-MONDO:0015893,rare hypothyroidism,MONDO:0005420,hypothyroidism
-MONDO:0020008,rare immune disease,MONDO:0005046,immune system disease
-MONDO:0019062,rare infectious disease,MONDO:0005550,infectious disease
-MONDO:0020024,rare infertility,MONDO:0005047,infertility
-MONDO:0015187,rare inflammatory bowel disease,MONDO:0005265,inflammatory bowel disease
-MONDO:0019491,rare intellectual disability,MONDO:0001071,intellectual disability
-MONDO:0015245,rare intestinal disease,MONDO:0005020,intestinal disease
-MONDO:0016766,rare lichen planus,MONDO:0006572,lichen planus
-MONDO:0020025,rare male infertility,MONDO:0005372,male infertility
-MONDO:0015870,rare malignant breast tumor,MONDO:0007254,breast cancer
-MONDO:0015143,rare movement disorder,MONDO:0005395,movement disorder
-MONDO:0015578,rare mycosis,MONDO:0002041,fungal infectious disease
-MONDO:0016645,rare neoplastic disease,MONDO:0005070,neoplasm (disease)
-MONDO:0015918,rare neurodegenerative disease,MONDO:0005559,neurodegenerative disease
-MONDO:0020009,rare neurologic disease,MONDO:0005071,nervous system disease
-MONDO:0017414,rare nevus,MONDO:0005073,melanocytic nevus
-MONDO:0015108,rare non-syndromic intellectual disability,MONDO:0000509,non-syndromic intellectual disability
-MONDO:0019059,rare parkinsonian disorder,MONDO:0021095,parkinsonian disorder
-MONDO:0020126,rare peripheral neuropathy,MONDO:0005244,peripheral neuropathy
-MONDO:0015680,rare pervasive developmental disorder,MONDO:0000594,pervasive developmental disorder
-MONDO:0019096,rare pulmonary hypertension,MONDO:0005149,pulmonary hypertension
-MONDO:0019750,rare renal disease,MONDO:0002118,urinary system disease
-MONDO:0020000,rare respiratory disease,MONDO:0005087,respiratory system disease
-MONDO:0019519,rare skin disease,MONDO:0005093,skin disease
-MONDO:0019045,rare sleep disorder,MONDO:0003406,sleep disorder
-MONDO:0015162,rare syndromic intellectual disability,MONDO:0000508,syndromic intellectual disability
-MONDO:0015125,rare thyroid disease,MONDO:0003240,thyroid gland disease
-MONDO:0015186,rare tumor of intestine,MONDO:0021118,intestinal neoplasm
-MONDO:0019298,rare urticaria,MONDO:0005492,urticaria
-MONDO:0016252,rare uterine cancer,MONDO:0002715,uterine cancer
-MONDO:0019048,rare vascular disease,MONDO:0005385,vascular disease
-MONDO:0015576,rare viral disease,MONDO:0005108,viral disease
+http://purl.obolibrary.org/obo/MONDO_0016250,rare adenocarcinoma of the breast,http://purl.obolibrary.org/obo/MONDO_0004988,breast adenocarcinoma
+http://purl.obolibrary.org/obo/MONDO_0020027,rare allergic disease,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0020028,rare allergic respiratory disease,http://purl.obolibrary.org/obo/MONDO_0000771,allergic respiratory disease
+http://purl.obolibrary.org/obo/MONDO_0015223,rare anemia,http://purl.obolibrary.org/obo/MONDO_0002280,anemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0016234,rare arteriovenous malformation,http://purl.obolibrary.org/obo/MONDO_0001256,arteriovenous hemangioma/malformation
+http://purl.obolibrary.org/obo/MONDO_0018497,rare autonomic nervous system disorder,http://purl.obolibrary.org/obo/MONDO_0001292,autonomic nervous system disease
+http://purl.obolibrary.org/obo/MONDO_0015575,rare bacterial infectious disease,http://purl.obolibrary.org/obo/MONDO_0005113,bacterial infectious disease
+http://purl.obolibrary.org/obo/MONDO_0015869,rare benign breast tumor,http://purl.obolibrary.org/obo/MONDO_0000620,breast benign neoplasm
+http://purl.obolibrary.org/obo/MONDO_0019965,rare benign ovarian tumor,http://purl.obolibrary.org/obo/MONDO_0000646,ovarian benign neoplasm
+http://purl.obolibrary.org/obo/MONDO_0015116,rare biliary tract disease,http://purl.obolibrary.org/obo/MONDO_0004868,biliary tract disease
+http://purl.obolibrary.org/obo/MONDO_0020116,rare blood coagulation disease,http://purl.obolibrary.org/obo/MONDO_0001531,blood coagulation disease
+http://purl.obolibrary.org/obo/MONDO_0015328,rare bone development disorder,http://purl.obolibrary.org/obo/MONDO_0005497,bone development disease
+http://purl.obolibrary.org/obo/MONDO_0019684,rare bone disease,http://purl.obolibrary.org/obo/MONDO_0005381,bone disease
+http://purl.obolibrary.org/obo/MONDO_0015868,rare breast tumor,http://purl.obolibrary.org/obo/MONDO_0021100,breast neoplasm
+http://purl.obolibrary.org/obo/MONDO_0016274,rare cancer of cervix uteri,http://purl.obolibrary.org/obo/MONDO_0002974,cervical cancer
+http://purl.obolibrary.org/obo/MONDO_0016314,rare carcinoma of pancreas,http://purl.obolibrary.org/obo/MONDO_0005192,exocrine pancreatic carcinoma
+http://purl.obolibrary.org/obo/MONDO_0018508,rare carcinoma of small intestine,http://purl.obolibrary.org/obo/MONDO_0005522,small intestine carcinoma
+http://purl.obolibrary.org/obo/MONDO_0018501,rare carcinoma of stomach,http://purl.obolibrary.org/obo/MONDO_0004950,gastric carcinoma
+http://purl.obolibrary.org/obo/MONDO_0019996,rare cardiac disease,http://purl.obolibrary.org/obo/MONDO_0005267,heart disease
+http://purl.obolibrary.org/obo/MONDO_0016347,rare cardiac rhythm disease,http://purl.obolibrary.org/obo/MONDO_0007263,cardiac rhythm disease
+http://purl.obolibrary.org/obo/MONDO_0015673,rare cardiac tumor,http://purl.obolibrary.org/obo/MONDO_0021209,heart neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020224,rare cataract,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease)
+http://purl.obolibrary.org/obo/MONDO_0036491,rare childhood malignant neoplasm,http://purl.obolibrary.org/obo/MONDO_0006517,childhood malignant neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020015,rare circulatory system disease,http://purl.obolibrary.org/obo/MONDO_0004995,cardiovascular disease
+http://purl.obolibrary.org/obo/MONDO_0020198,rare conjunctival disease,http://purl.obolibrary.org/obo/MONDO_0002932,conjunctival disease
+http://purl.obolibrary.org/obo/MONDO_0018887,rare cutaneous lupus erythematosus,http://purl.obolibrary.org/obo/MONDO_0005282,cutaneous lupus erythematosus
+http://purl.obolibrary.org/obo/MONDO_0019047,rare deafness,http://purl.obolibrary.org/obo/MONDO_0005365,hearing loss
+http://purl.obolibrary.org/obo/MONDO_0016623,rare deficiency anemia,http://purl.obolibrary.org/obo/MONDO_0001639,deficiency anemia
+http://purl.obolibrary.org/obo/MONDO_0019515,rare dementia,http://purl.obolibrary.org/obo/MONDO_0001627,dementia
+http://purl.obolibrary.org/obo/MONDO_0015122,rare diabetes mellitus,http://purl.obolibrary.org/obo/MONDO_0005015,diabetes mellitus (disease)
+http://purl.obolibrary.org/obo/MONDO_0015886,rare diabetes mellitus type 1,http://purl.obolibrary.org/obo/MONDO_0005147,type 1 diabetes mellitus
+http://purl.obolibrary.org/obo/MONDO_0020033,rare digestive tumor,http://purl.obolibrary.org/obo/MONDO_0021223,digestive system neoplasm
+http://purl.obolibrary.org/obo/MONDO_0021200,rare disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0015582,"rare disorder related with pregnancy, childbirth and puerperium",http://purl.obolibrary.org/obo/MONDO_0024575,pregnancy disorder
+http://purl.obolibrary.org/obo/MONDO_0019049,rare dystonia,http://purl.obolibrary.org/obo/MONDO_0003441,dystonic disorder
+http://purl.obolibrary.org/obo/MONDO_0020005,rare endocrine disease,http://purl.obolibrary.org/obo/MONDO_0005151,endocrine system disease
+http://purl.obolibrary.org/obo/MONDO_0015305,rare endometriosis,http://purl.obolibrary.org/obo/MONDO_0005133,endometriosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0015139,rare epilepsy,http://purl.obolibrary.org/obo/MONDO_0005027,epilepsy
+http://purl.obolibrary.org/obo/MONDO_0018512,rare epithelial tumor of colon,http://purl.obolibrary.org/obo/MONDO_0024479,epithelial tumor of colon
+http://purl.obolibrary.org/obo/MONDO_0018514,rare epithelial tumor of rectum,http://purl.obolibrary.org/obo/MONDO_0024476,epithelial neoplasm of rectum
+http://purl.obolibrary.org/obo/MONDO_0020004,rare eye disease,http://purl.obolibrary.org/obo/MONDO_0005328,eye disease
+http://purl.obolibrary.org/obo/MONDO_0015121,rare eye tumor,http://purl.obolibrary.org/obo/MONDO_0021220,eye neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020026,rare female infertility,http://purl.obolibrary.org/obo/MONDO_0021124,female infertility
+http://purl.obolibrary.org/obo/MONDO_0018080,rare germ cell tumor,http://purl.obolibrary.org/obo/MONDO_0005040,germ cell tumor
+http://purl.obolibrary.org/obo/MONDO_0020037,rare gynecological tumor,http://purl.obolibrary.org/obo/MONDO_0021148,female reproductive system neoplasm
+http://purl.obolibrary.org/obo/MONDO_0017371,rare head and neck tumor,http://purl.obolibrary.org/obo/MONDO_0005586,head and neck neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020011,rare headache disorder,http://purl.obolibrary.org/obo/MONDO_0021146,headache disorder
+http://purl.obolibrary.org/obo/MONDO_0020100,rare hemolytic anemia,http://purl.obolibrary.org/obo/MONDO_0003664,hemolytic anemia
+http://purl.obolibrary.org/obo/MONDO_0015117,rare hepatic and biliary tract tumor,http://purl.obolibrary.org/obo/MONDO_0002514,hepatobiliary neoplasm
+http://purl.obolibrary.org/obo/MONDO_0018928,rare hepatic disease,http://purl.obolibrary.org/obo/MONDO_0005154,liver disease
+http://purl.obolibrary.org/obo/MONDO_0016363,rare hereditary hemochromatosis,http://purl.obolibrary.org/obo/MONDO_0006507,hereditary hemochromatosis
+http://purl.obolibrary.org/obo/MONDO_0015897,rare hyperparathyroidism,http://purl.obolibrary.org/obo/MONDO_0001741,hyperparathyroidism
+http://purl.obolibrary.org/obo/MONDO_0015894,rare hyperthyroidism,http://purl.obolibrary.org/obo/MONDO_0004425,hyperthyroidism
+http://purl.obolibrary.org/obo/MONDO_0015896,rare hypoparathyroidism,http://purl.obolibrary.org/obo/MONDO_0001220,hypoparathyroidism
+http://purl.obolibrary.org/obo/MONDO_0015893,rare hypothyroidism,http://purl.obolibrary.org/obo/MONDO_0005420,hypothyroidism
+http://purl.obolibrary.org/obo/MONDO_0020008,rare immune disease,http://purl.obolibrary.org/obo/MONDO_0005046,immune system disease
+http://purl.obolibrary.org/obo/MONDO_0019062,rare infectious disease,http://purl.obolibrary.org/obo/MONDO_0005550,infectious disease
+http://purl.obolibrary.org/obo/MONDO_0020024,rare infertility,http://purl.obolibrary.org/obo/MONDO_0005047,infertility disorder
+http://purl.obolibrary.org/obo/MONDO_0015187,rare inflammatory bowel disease,http://purl.obolibrary.org/obo/MONDO_0005265,inflammatory bowel disease
+http://purl.obolibrary.org/obo/MONDO_0019491,rare intellectual disability,http://purl.obolibrary.org/obo/MONDO_0001071,intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0015245,rare intestinal disease,http://purl.obolibrary.org/obo/MONDO_0005020,intestinal disease
+http://purl.obolibrary.org/obo/MONDO_0015224,rare intoxication,http://purl.obolibrary.org/obo/MONDO_0029000,poisoning
+http://purl.obolibrary.org/obo/MONDO_0020192,rare lacrimal system disease,http://purl.obolibrary.org/obo/MONDO_0001854,lacrimal apparatus disease
+http://purl.obolibrary.org/obo/MONDO_0016766,rare lichen planus,http://purl.obolibrary.org/obo/MONDO_0006572,lichen planus
+http://purl.obolibrary.org/obo/MONDO_0020025,rare male infertility,http://purl.obolibrary.org/obo/MONDO_0005372,male infertility
+http://purl.obolibrary.org/obo/MONDO_0015870,rare malignant breast tumor,http://purl.obolibrary.org/obo/MONDO_0007254,breast cancer
+http://purl.obolibrary.org/obo/MONDO_0015143,rare movement disorder,http://purl.obolibrary.org/obo/MONDO_0005395,movement disorder
+http://purl.obolibrary.org/obo/MONDO_0015578,rare mycosis,http://purl.obolibrary.org/obo/MONDO_0002041,fungal infectious disease
+http://purl.obolibrary.org/obo/MONDO_0016645,rare neoplastic disease,http://purl.obolibrary.org/obo/MONDO_0023370,neoplastic disease or syndrome
+http://purl.obolibrary.org/obo/MONDO_0015918,rare neurodegenerative disease,http://purl.obolibrary.org/obo/MONDO_0005559,neurodegenerative disease
+http://purl.obolibrary.org/obo/MONDO_0020009,rare neurologic disease,http://purl.obolibrary.org/obo/MONDO_0005071,nervous system disorder
+http://purl.obolibrary.org/obo/MONDO_0017414,rare nevus,http://purl.obolibrary.org/obo/MONDO_0005073,melanocytic nevus
+http://purl.obolibrary.org/obo/MONDO_0015108,rare non-syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0000509,non-syndromic intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0017797,rare odontologic tumor,http://purl.obolibrary.org/obo/MONDO_0021192,odontogenic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020017,rare otorhinolaryngologic disease,http://purl.obolibrary.org/obo/MONDO_0024623,otorhinolaryngologic disease
+http://purl.obolibrary.org/obo/MONDO_0020151,rare palpebral disease,http://purl.obolibrary.org/obo/MONDO_0003382,eyelid disease
+http://purl.obolibrary.org/obo/MONDO_0015112,rare pancreatic disease,http://purl.obolibrary.org/obo/MONDO_0002356,pancreas disease
+http://purl.obolibrary.org/obo/MONDO_0015577,rare parasitic disease,http://purl.obolibrary.org/obo/MONDO_0005135,parasitic infection
+http://purl.obolibrary.org/obo/MONDO_0015076,rare parathyroid tumor,http://purl.obolibrary.org/obo/MONDO_0021360,tumor of parathyroid gland
+http://purl.obolibrary.org/obo/MONDO_0019059,rare parkinsonian disorder,http://purl.obolibrary.org/obo/MONDO_0021095,parkinsonian disorder
+http://purl.obolibrary.org/obo/MONDO_0020126,rare peripheral neuropathy,http://purl.obolibrary.org/obo/MONDO_0005244,peripheral neuropathy
+http://purl.obolibrary.org/obo/MONDO_0015680,rare pervasive developmental disorder,http://purl.obolibrary.org/obo/MONDO_0000594,pervasive developmental disorder
+http://purl.obolibrary.org/obo/MONDO_0015899,rare primary hyperaldosteronism,http://purl.obolibrary.org/obo/MONDO_0001422,primary aldosteronism
+http://purl.obolibrary.org/obo/MONDO_0019096,rare pulmonary hypertension,http://purl.obolibrary.org/obo/MONDO_0005149,pulmonary hypertension
+http://purl.obolibrary.org/obo/MONDO_0019750,rare renal disease,http://purl.obolibrary.org/obo/MONDO_0005240,kidney disease
+http://purl.obolibrary.org/obo/MONDO_0019749,rare renal tumor,http://purl.obolibrary.org/obo/MONDO_0021163,kidney neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020000,rare respiratory disease,http://purl.obolibrary.org/obo/MONDO_0005087,respiratory system disease
+http://purl.obolibrary.org/obo/MONDO_0015940,rare rheumatologic disease,http://purl.obolibrary.org/obo/MONDO_0005554,rheumatologic disorder
+http://purl.obolibrary.org/obo/MONDO_0019519,rare skin disease,http://purl.obolibrary.org/obo/MONDO_0005093,skin disease
+http://purl.obolibrary.org/obo/MONDO_0019045,rare sleep disorder,http://purl.obolibrary.org/obo/MONDO_0003406,sleep-wake disorder
+http://purl.obolibrary.org/obo/MONDO_0019099,rare soft tissue tumor,http://purl.obolibrary.org/obo/MONDO_0006424,soft tissue neoplasm
+http://purl.obolibrary.org/obo/MONDO_0015162,rare syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0000508,syndromic intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0015125,rare thyroid disease,http://purl.obolibrary.org/obo/MONDO_0003240,thyroid gland disease
+http://purl.obolibrary.org/obo/MONDO_0020031,rare tumor,http://purl.obolibrary.org/obo/MONDO_0005070,neoplasm (disease)
+http://purl.obolibrary.org/obo/MONDO_0015186,rare tumor of intestine,http://purl.obolibrary.org/obo/MONDO_0021118,intestinal neoplasm
+http://purl.obolibrary.org/obo/MONDO_0017632,rare tumor of liver and intrahepatic biliary tract,http://purl.obolibrary.org/obo/MONDO_0024477,liver and intrahepatic bile duct neoplasm
+http://purl.obolibrary.org/obo/MONDO_0016679,rare tumor of neuroepithelial tissue,http://purl.obolibrary.org/obo/MONDO_0021193,neuroepithelial neoplasm
+http://purl.obolibrary.org/obo/MONDO_0015882,rare tumor of pancreas,http://purl.obolibrary.org/obo/MONDO_0021040,pancreatic neoplasm
+http://purl.obolibrary.org/obo/MONDO_0018505,rare tumor of small intestine,http://purl.obolibrary.org/obo/MONDO_0004251,small intestine neoplasm
+http://purl.obolibrary.org/obo/MONDO_0020032,rare urinary tract tumor,http://purl.obolibrary.org/obo/MONDO_0021066,urinary system neoplasm
+http://purl.obolibrary.org/obo/MONDO_0019298,rare urticaria,http://purl.obolibrary.org/obo/MONDO_0005492,urticaria (disease)
+http://purl.obolibrary.org/obo/MONDO_0016252,rare uterine cancer,http://purl.obolibrary.org/obo/MONDO_0002715,uterine cancer
+http://purl.obolibrary.org/obo/MONDO_0019048,rare vascular disease,http://purl.obolibrary.org/obo/MONDO_0005385,vascular disease
+http://purl.obolibrary.org/obo/MONDO_0016228,rare vascular tumor,http://purl.obolibrary.org/obo/MONDO_0024296,vascular neoplasm
+http://purl.obolibrary.org/obo/MONDO_0015576,rare viral disease,http://purl.obolibrary.org/obo/MONDO_0005108,viral infectious disease

--- a/src/patterns/rare_genetic.csv
+++ b/src/patterns/rare_genetic.csv
@@ -1,2 +1,2 @@
 iri,iri label,disease,disease label
-MONDO:0015972,rare constitutional anemia,MONDO:0002280,anemia (disease)
+http://purl.obolibrary.org/obo/MONDO_0015972,rare constitutional anemia,http://purl.obolibrary.org/obo/MONDO_0002280,anemia (disease)

--- a/src/patterns/rhabdomyosarcoma.csv
+++ b/src/patterns/rhabdomyosarcoma.csv
@@ -1,0 +1,16 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0002864,anus rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0002859,breast rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002850,central nervous system rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0002577,extrahepatic bile duct rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0002856,gallbladder rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0002849,liver rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0002851,mediastinum rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0002580,orbit rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0004088,orbital region
+http://purl.obolibrary.org/obo/MONDO_0002858,ovary rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006389,prostate rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002853,rectum rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0016282,rhabdomyosarcoma of the cervix uteri,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0002860,testis rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0016260,uterine corpus rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0016095,vaginal rhabdomyosarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina

--- a/src/patterns/rhabdomyosarcoma.yaml
+++ b/src/patterns/rhabdomyosarcoma.yaml
@@ -1,4 +1,4 @@
-pattern_name: rhabdomyosarcoma (disease) disease has location X
+pattern_name: rhabdomyosarcoma disease has location X
 pattern_iri: http://purl.obolibrary.org/obo/mondo/rhabdomyosarcoma_(disease)_disease_has_location_X
 
 description: >-
@@ -7,7 +7,7 @@ description: >-
   Examples: [rhabdomyosarcoma of the cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016282), [breast rhabdomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0002859), [testis rhabdomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0002860) (15 total)
 
 classes: 
-  rhabdomyosarcoma (disease): "MONDO:0005212"
+  rhabdomyosarcoma: "MONDO:0005212"
 
 
 relations: 
@@ -36,7 +36,7 @@ annotationProperties:
 annotations:
   - annotationProperty: exact_synonym
     # Induced p=exact_synonym 
-    text: "%s rhabdomyosarcoma (disease)"
+    text: "%s rhabdomyosarcoma"
     vars:
       - v0
   - annotationProperty: related_synonym
@@ -47,6 +47,6 @@ annotations:
 
 
 equivalentTo:
-  text: "'rhabdomyosarcoma (disease)' and ('disease has location' some %s)"
+  text: "'rhabdomyosarcoma' and ('disease has location' some %s)"
   vars:
     - v0

--- a/src/patterns/sarcoma.csv
+++ b/src/patterns/sarcoma.csv
@@ -1,44 +1,43 @@
 iri,iri label,location,location label
-MONDO:0019480,Langerhans cell sarcoma,CL:0000453,Langerhans cell
-MONDO:0002865,anus sarcoma,UBERON:0001245,anus
-MONDO:0002862,bile duct sarcoma,UBERON:0002394,bile duct
-MONDO:0001374,bladder sarcoma,UBERON:0001255,urinary bladder
-MONDO:0002216,brain sarcoma,UBERON:0000955,brain
-MONDO:0002490,breast sarcoma,UBERON:0000310,breast
-MONDO:0002217,central nervous system sarcoma,UBERON:0001017,central nervous system
-MONDO:0007300,cerebral sarcoma,UBERON:0001893,telencephalon
-MONDO:0003352,colon sarcoma,UBERON:0001155,colon
-MONDO:0004380,dendritic cell sarcoma,CL:0000451,dendritic cell
-MONDO:0001204,esophagus sarcoma,UBERON:0001043,esophagus
-MONDO:0005764,follicular dendritic cell sarcoma,CL:0000442,follicular dendritic cell
-MONDO:0002857,gallbladder sarcoma,UBERON:0002110,gall bladder
-MONDO:0003354,heart sarcoma,UBERON:0000948,heart
-MONDO:0002930,kidney sarcoma,UBERON:0002113,kidney
-MONDO:0002448,larynx sarcoma,UBERON:0001737,larynx
-MONDO:0004330,leptomeninges sarcoma,UBERON:0000391,leptomeninx
-MONDO:0005060,liposarcoma,UBERON:0001833,lip
-MONDO:0002397,liver sarcoma,UBERON:0002107,liver
-MONDO:0002426,lung sarcoma,UBERON:0002048,lung
-MONDO:0019024,mast cell sarcoma,CL:0000097,mast cell
-MONDO:0002852,mediastinum sarcoma,UBERON:0003728,mediastinum
-MONDO:0004308,meninges sarcoma,UBERON:0010743,meningeal cluster
-MONDO:0004943,orbit sarcoma,UBERON:0001697,orbit of skull
-MONDO:0009807,osteosarcoma (disease),UBERON:0008883,osteoid
-MONDO:0002225,ovary sarcoma,UBERON:0000992,ovary
-MONDO:0002117,pancreas sarcoma,UBERON:0001264,pancreas
-MONDO:0001758,paranasal sinus sarcoma,UBERON:0001825,paranasal sinus
-MONDO:0001387,penis sarcoma,UBERON:0000989,penis
-MONDO:0002854,prostate sarcoma,UBERON:0002367,prostate gland
-MONDO:0002168,rectum sarcoma,UBERON:0001052,rectum
-MONDO:0009975,reticulum cell sarcoma,CL:0000432,reticular cell
-MONDO:0001501,retroperitoneal sarcoma,UBERON:0003693,retroperitoneal space
-MONDO:0016280,sarcoma of cervix uteri,UBERON:0000002,uterine cervix
-MONDO:0006414,skin sarcoma,UBERON:0000014,zone of skin
-MONDO:0001894,spinal cord sarcoma,UBERON:0002240,spinal cord
-MONDO:0002861,testis sarcoma,UBERON:0000473,testis
-MONDO:0003028,thyroid sarcoma,UBERON:0002046,thyroid gland
-MONDO:0001418,trachea sarcoma,UBERON:0003126,trachea
-MONDO:0005210,uterine sarcoma,UBERON:0009853,body of uterus
-MONDO:0002140,vagina sarcoma,UBERON:0000996,vagina
-MONDO:0005329,vascular sarcoma,UBERON:0001981,blood vessel
-MONDO:0005214,vulva sarcoma,UBERON:0000997,mammalian vulva
+http://purl.obolibrary.org/obo/MONDO_0019480,Langerhans cell sarcoma,http://purl.obolibrary.org/obo/CL_0000453,Langerhans cell
+http://purl.obolibrary.org/obo/MONDO_0016982,angiosarcoma (disease),http://purl.obolibrary.org/obo/UBERON_0001981,blood vessel
+http://purl.obolibrary.org/obo/MONDO_0002865,anus sarcoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0002862,bile duct sarcoma,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0001374,bladder sarcoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0002216,brain sarcoma,http://purl.obolibrary.org/obo/UBERON_0000955,brain
+http://purl.obolibrary.org/obo/MONDO_0002490,breast sarcoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0002217,central nervous system sarcoma,http://purl.obolibrary.org/obo/UBERON_0001017,central nervous system
+http://purl.obolibrary.org/obo/MONDO_0007300,cerebral sarcoma,http://purl.obolibrary.org/obo/UBERON_0001893,telencephalon
+http://purl.obolibrary.org/obo/MONDO_0003352,colon sarcoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0004380,dendritic cell sarcoma,http://purl.obolibrary.org/obo/CL_0000451,dendritic cell
+http://purl.obolibrary.org/obo/MONDO_0001204,esophagus sarcoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0024658,extrahepatic bile duct sarcoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0005764,follicular dendritic cell sarcoma,http://purl.obolibrary.org/obo/CL_0000442,follicular dendritic cell
+http://purl.obolibrary.org/obo/MONDO_0002857,gallbladder sarcoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0003354,heart sarcoma,http://purl.obolibrary.org/obo/UBERON_0000948,heart
+http://purl.obolibrary.org/obo/MONDO_0002930,kidney sarcoma,http://purl.obolibrary.org/obo/UBERON_0002113,kidney
+http://purl.obolibrary.org/obo/MONDO_0002448,laryngeal sarcoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0004330,leptomeningeal sarcoma,http://purl.obolibrary.org/obo/UBERON_0000391,leptomeninx
+http://purl.obolibrary.org/obo/MONDO_0002397,liver sarcoma,http://purl.obolibrary.org/obo/UBERON_0002107,liver
+http://purl.obolibrary.org/obo/MONDO_0002426,lung sarcoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0019024,mast cell sarcoma,http://purl.obolibrary.org/obo/CL_0000097,mast cell
+http://purl.obolibrary.org/obo/MONDO_0002852,mediastinum sarcoma,http://purl.obolibrary.org/obo/UBERON_0003728,mediastinum
+http://purl.obolibrary.org/obo/MONDO_0004308,meningeal sarcoma,http://purl.obolibrary.org/obo/UBERON_0010743,meningeal cluster
+http://purl.obolibrary.org/obo/MONDO_0004943,orbit sarcoma,http://purl.obolibrary.org/obo/UBERON_0001697,orbit of skull
+http://purl.obolibrary.org/obo/MONDO_0002225,ovarian sarcoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0002117,pancreas sarcoma,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0001758,paranasal sinus sarcoma,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0001387,penile sarcoma,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0002854,prostate sarcoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0002168,rectum sarcoma,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0001501,retroperitoneal sarcoma,http://purl.obolibrary.org/obo/UBERON_0003693,retroperitoneal space
+http://purl.obolibrary.org/obo/MONDO_0016280,sarcoma of cervix uteri,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0006414,skin sarcoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0003361,small intestinal sarcoma,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0001894,spinal cord sarcoma,http://purl.obolibrary.org/obo/UBERON_0002240,spinal cord
+http://purl.obolibrary.org/obo/MONDO_0002861,testis sarcoma,http://purl.obolibrary.org/obo/UBERON_0000473,testis
+http://purl.obolibrary.org/obo/MONDO_0003028,thyroid sarcoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0001418,trachea sarcoma,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0005210,uterine corpus sarcoma,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0002140,vagina sarcoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0005214,vulva sarcoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/small_cell_carcinoma.csv
+++ b/src/patterns/small_cell_carcinoma.csv
@@ -1,0 +1,17 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0004120,Bartholin gland small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0006142,cervical small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0003978,colon small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0006197,endometrial small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0004116,esophageal small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0006219,gallbladder small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0006229,gastric small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0006265,laryngeal small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0003795,ovarian small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0006348,pancreatic small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0000016,endocrine pancreas
+http://purl.obolibrary.org/obo/MONDO_0006390,prostate small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0006405,salivary gland small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0008433,small cell lung carcinoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0004122,thymus small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0006482,ureter small cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0004114,urinary bladder small cell neuroendocrine carcinoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder

--- a/src/patterns/specific_infectious_disease_by_agent.csv
+++ b/src/patterns/specific_infectious_disease_by_agent.csv
@@ -1,0 +1,303 @@
+iri,iri label,agent,agent label,disease,disease label
+http://purl.obolibrary.org/obo/MONDO_0005629,Acanthamoeba keratitis,http://purl.obolibrary.org/obo/NCBITaxon_5754,Acanthamoeba,http://purl.obolibrary.org/obo/MONDO_0003085,keratitis
+http://purl.obolibrary.org/obo/MONDO_0006635,Acinetobacter infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_469,Acinetobacter,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006636,Actinobacillus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_713,Actinobacillus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006921,Actinomycetales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_2037,Actinomycetales,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005117,Aeromonas hydrophila infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_644,Aeromonas hydrophila,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001262,African histoplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_149546,Histoplasma capsulatum var. duboisii,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000310,Alkhurma hemorrhagic fever,http://purl.obolibrary.org/obo/NCBITaxon_172148,Alkhumra hemorrhagic fever virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005643,Alphavirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11019,Alphavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006922,Anaplasmataceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_942,Anaplasmataceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005650,Arenaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11617,Arenaviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005652,Arterivirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11046,Arterivirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005656,Ascaridida infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6249,Ascaridida,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000789,Atlantic cod allergy,http://purl.obolibrary.org/obo/NCBITaxon_8049,Gadus morhua,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0000790,Atlantic salmon allergy,http://purl.obolibrary.org/obo/NCBITaxon_8030,Salmo salar,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0006923,Bacillaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_186817,Bacillaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006705,Bacteroidaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_815,Bacteroidaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006671,Bacteroides infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_816,Bacteroides,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000343,Barmah forest virus disease,http://purl.obolibrary.org/obo/NCBITaxon_11020,Barmah Forest virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006924,Bartonellaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_772,Bartonellaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006706,Bifidobacteriales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_85004,Bifidobacteriales,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001353,Bordetella parapertussis infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_519,Bordetella parapertussis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006681,Borrelia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_138,Borrelia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001190,Brucella suis brucellosis,http://purl.obolibrary.org/obo/NCBITaxon_29461,Brucella suis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0021641,Bunyaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11571,Bunyaviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000327,Buruli ulcer disease,http://purl.obolibrary.org/obo/NCBITaxon_1809,Mycobacterium ulcerans,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0042488,Cestode infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6199,Cestoda,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005491,Chagas cardiomyopathy,http://purl.obolibrary.org/obo/NCBITaxon_5693,Trypanosoma cruzi,http://purl.obolibrary.org/obo/MONDO_0004994,cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0001444,Chagas disease,http://purl.obolibrary.org/obo/NCBITaxon_5693,Trypanosoma cruzi,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006697,Chlamydophila infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_83553,Chlamydophila,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005704,Ciliophora infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_5878,Ciliophora,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000705,Clostridium difficile colitis,http://purl.obolibrary.org/obo/NCBITaxon_1496,Clostridioides difficile,http://purl.obolibrary.org/obo/MONDO_0005292,colitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0005708,Colorado tick fever,http://purl.obolibrary.org/obo/NCBITaxon_46839,Colorado tick fever virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005723,Cryptococcal meningitis,http://purl.obolibrary.org/obo/NCBITaxon_5207,Cryptococcus neoformans,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0006708,Desulfovibrionaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_194924,Desulfovibrionaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005730,Dictyocaulus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_29171,Dictyocaulus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005120,Drosophila C virus infection,http://purl.obolibrary.org/obo/NCBITaxon_64279,Drosophila C virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005737,Ebola hemorrhagic fever,http://purl.obolibrary.org/obo/NCBITaxon_186536,Ebolavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005740,Echovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_33758,Echovirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005745,Enoplea infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_119088,Enoplea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005121,Enterococcus faecalis infection,http://purl.obolibrary.org/obo/NCBITaxon_1351,Enterococcus faecalis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005111,Epstein-Barr virus infection,http://purl.obolibrary.org/obo/NCBITaxon_10376,Human gammaherpesvirus 4,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006751,Erysipelothrix infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1647,Erysipelothrix,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006752,Erysipelothrix rhusiopathiae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1648,Erysipelothrix rhusiopathiae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005762,Filoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11266,Filoviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005763,Flaviviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11050,Flaviviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006925,Fusobacteriaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_203492,Fusobacteriaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006765,Fusobacterium infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_848,Fusobacterium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005109,HIV infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_12721,Human immunodeficiency virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005780,Hantavirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11598,Hantavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006781,Helicobacter pylori infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_210,Helicobacter pylori,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0017942,Hendra virus infection,http://purl.obolibrary.org/obo/NCBITaxon_63330,Hendra henipavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005785,Henipavirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_260964,Henipavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005786,Hepadnaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10404,Hepadnaviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005794,Herpesviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10292,Herpesviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0002099,Histoplasma capsulatum infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_5037,Histoplasma capsulatum,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000981,Histoplasma pericarditis,http://purl.obolibrary.org/obo/NCBITaxon_5036,Histoplasma,http://purl.obolibrary.org/obo/MONDO_0005904,pericarditis (disease)
+http://purl.obolibrary.org/obo/MONDO_0030603,Klebsiella infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_570,Klebsiella,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0030602,Klebsiella pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_570,Klebsiella,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0017881,Kyasanur forest disease,http://purl.obolibrary.org/obo/NCBITaxon_33743,Kyasanur forest disease virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006836,Listeria meningitis,http://purl.obolibrary.org/obo/NCBITaxon_1639,Listeria monocytogenes,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0019632,Lyme disease,http://purl.obolibrary.org/obo/NCBITaxon_139,Borreliella burgdorferi,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005856,Mononegavirales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11157,Mononegavirales,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006878,Moraxellaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_468,Moraxellaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005857,Morbillivirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11229,Morbillivirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001137,Murray valley encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11079,Murray Valley encephalitis virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0019377,Mycoplasma encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_2104,Mycoplasma pneumoniae,http://purl.obolibrary.org/obo/MONDO_0020067,infectious encephalitis
+http://purl.obolibrary.org/obo/MONDO_0005871,Nematoda infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6231,Nematoda,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0024416,Neorickettsia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_33993,Neorickettsia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005876,Nidovirales infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_76804,Nidovirales,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000342,O'nyong'nyong fever,http://purl.obolibrary.org/obo/NCBITaxon_11027,O'nyong-nyong virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000345,Oropouche fever,http://purl.obolibrary.org/obo/NCBITaxon_118655,Oropouche virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0018984,Oroya fever,http://purl.obolibrary.org/obo/NCBITaxon_774,Bartonella bacilliformis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005889,Orthomyxoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11308,Orthomyxoviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005896,Paramyxoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11158,Paramyxoviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0025371,Parvoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10780,Parvoviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005122,Pectobacterium carotovorum infection,http://purl.obolibrary.org/obo/NCBITaxon_122277,Pectobacterium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0024412,Peptostreptococcus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1257,Peptostreptococcus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005909,Pestivirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11095,Pestivirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000276,Powassan encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11083,Powassan virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006929,Proteus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_583,Proteus <enterobacteria>,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005141,Pseudomonas infection,http://purl.obolibrary.org/obo/NCBITaxon_286,Pseudomonas,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0019186,Q fever,http://purl.obolibrary.org/obo/NCBITaxon_777,Coxiella burnetii,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000331,Rickettsia helvetica spotted fever,http://purl.obolibrary.org/obo/NCBITaxon_35789,Rickettsia helvetica,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006927,Rickettsiaceae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_775,Rickettsiaceae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005949,Roseolovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_40272,Roseolovirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000344,Ross river fever,http://purl.obolibrary.org/obo/NCBITaxon_11029,Ross River virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005194,Rotavirus infection,http://purl.obolibrary.org/obo/NCBITaxon_10912,Rotavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005950,Salmonella gastroenteritis,http://purl.obolibrary.org/obo/NCBITaxon_590,Salmonella,http://purl.obolibrary.org/obo/MONDO_0002269,gastroenteritis
+http://purl.obolibrary.org/obo/MONDO_0044351,Schistosoma intercalatum infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6187,Schistosoma intercalatum,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0044344,Schistosoma japonicum infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6182,Schistosoma japonicum,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0044345,Schistosoma mansoni infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6183,Schistosoma mansoni,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000773,Timothy grass allergy,http://purl.obolibrary.org/obo/NCBITaxon_15957,Phleum pratense,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0005985,Togaviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11018,Togaviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005986,Torovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11155,Torovirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0007000,Treponema infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_157,Treponema,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0042458,Trichinella spiralis infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6334,Trichinella spiralis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0030708,Trichomonas cervicitis,http://purl.obolibrary.org/obo/NCBITaxon_5722,Trichomonas vaginalis,http://purl.obolibrary.org/obo/MONDO_0002345,cervicitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0030706,Trichomonas cystitis,http://purl.obolibrary.org/obo/NCBITaxon_5722,Trichomonas vaginalis,http://purl.obolibrary.org/obo/MONDO_0006032,cystitis
+http://purl.obolibrary.org/obo/MONDO_0030705,Trichomonas prostatitis,http://purl.obolibrary.org/obo/NCBITaxon_5722,Trichomonas vaginalis,http://purl.obolibrary.org/obo/MONDO_0005280,prostatitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0030906,Trichomonas tenax infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_43075,Trichomonas tenax,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005993,Trichomonas vaginitis urogenital infection,http://purl.obolibrary.org/obo/NCBITaxon_5722,Trichomonas vaginalis,http://purl.obolibrary.org/obo/MONDO_0021145,disease of genitourinary system
+http://purl.obolibrary.org/obo/MONDO_0007007,Ureaplasma urethritis,http://purl.obolibrary.org/obo/NCBITaxon_2129,Ureaplasma,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006005,Venezuelan equine encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11036,Venezuelan equine encephalitis virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0002282,West Nile fever,http://purl.obolibrary.org/obo/NCBITaxon_11082,West Nile virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0019376,West-Nile encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11082,West Nile virus,http://purl.obolibrary.org/obo/MONDO_0020067,infectious encephalitis
+http://purl.obolibrary.org/obo/MONDO_0005116,Whipple disease,http://purl.obolibrary.org/obo/NCBITaxon_2039,Tropheryma whipplei,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0018661,Zika virus disease,http://purl.obolibrary.org/obo/NCBITaxon_64320,Zika virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000295,acanthocephaliasis,http://purl.obolibrary.org/obo/NCBITaxon_10232,Acanthocephala,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0043479,adenoviridae infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10508,Adenoviridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005641,aleutian mink disease,http://purl.obolibrary.org/obo/NCBITaxon_28314,Aleutian mink disease virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0017282,alveolar echinococcosis,http://purl.obolibrary.org/obo/NCBITaxon_6211,Echinococcus multilocularis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0025303,anaplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_768,Anaplasma,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005645,ancylostomiasis,http://purl.obolibrary.org/obo/NCBITaxon_29169,Ancylostoma,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005119,anthrax infection,http://purl.obolibrary.org/obo/NCBITaxon_1392,Bacillus anthracis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000779,apple allergy,http://purl.obolibrary.org/obo/NCBITaxon_3750,Malus domestica,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0000780,apricot allergy,http://purl.obolibrary.org/obo/NCBITaxon_36596,Prunus armeniaca,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0043314,aquarium granuloma,http://purl.obolibrary.org/obo/NCBITaxon_1781,Mycobacterium marinum,http://purl.obolibrary.org/obo/MONDO_0005093,skin disease
+http://purl.obolibrary.org/obo/MONDO_0005654,ascariasis,http://purl.obolibrary.org/obo/NCBITaxon_6252,Ascaris lumbricoides,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005655,ascaridiasis,http://purl.obolibrary.org/obo/NCBITaxon_46684,Ascaridia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005661,babesiosis,http://purl.obolibrary.org/obo/NCBITaxon_5864,Babesia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000758,bacillary angiomatosis,http://purl.obolibrary.org/obo/NCBITaxon_773,Bartonella,http://purl.obolibrary.org/obo/MONDO_0024461,angiomatosis
+http://purl.obolibrary.org/obo/MONDO_0006668,bacterial conjunctivitis,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0002932,conjunctival disease
+http://purl.obolibrary.org/obo/MONDO_0006669,bacterial endocarditis (disease),http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0005025,endocarditis (disease)
+http://purl.obolibrary.org/obo/MONDO_0002842,bacterial gastritis,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0004966,gastritis (disease)
+http://purl.obolibrary.org/obo/MONDO_0005113,bacterial infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006670,bacterial meningitis,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0004652,bacterial pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0005664,bartonellosis,http://purl.obolibrary.org/obo/NCBITaxon_773,Bartonella,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000302,basidiobolomycosis,http://purl.obolibrary.org/obo/NCBITaxon_4859,Basidiobolus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000297,baylisascariasis,http://purl.obolibrary.org/obo/NCBITaxon_6259,Baylisascaris procyonis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001714,bejel,http://purl.obolibrary.org/obo/NCBITaxon_53436,Treponema pallidum subsp. endemicum,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005672,blastomycosis,http://purl.obolibrary.org/obo/NCBITaxon_5039,Blastomyces dermatitidis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0037872,bordetellosis,http://purl.obolibrary.org/obo/NCBITaxon_517,Bordetella,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0043953,burkholderia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_32008,Burkholderia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000791,carp allergy,http://purl.obolibrary.org/obo/NCBITaxon_7962,Cyprinus carpio,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0017941,chikungunya,http://purl.obolibrary.org/obo/NCBITaxon_37124,Chikungunya virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0021697,chlamydia infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_810,Chlamydia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005701,chlamydia trachomatis infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_813,Chlamydia trachomatis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0015766,cholera,http://purl.obolibrary.org/obo/NCBITaxon_666,Vibrio cholerae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005706,coccidioidomycosis,http://purl.obolibrary.org/obo/NCBITaxon_5501,Coccidioides immitis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0017381,congenital herpes simplex virus infection,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0016511,infectious embryofetopathy
+http://purl.obolibrary.org/obo/MONDO_0042971,congenital herpes virus infection,http://purl.obolibrary.org/obo/NCBITaxon_10292,Herpesviridae,http://purl.obolibrary.org/obo/MONDO_0016511,infectious embryofetopathy
+http://purl.obolibrary.org/obo/MONDO_0005724,cryptococcosis,http://purl.obolibrary.org/obo/NCBITaxon_5207,Cryptococcus neoformans,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0015474,cryptosporidiosis,http://purl.obolibrary.org/obo/NCBITaxon_5806,Cryptosporidium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006718,cutaneous syphilis,http://purl.obolibrary.org/obo/NCBITaxon_160,Treponema pallidum,http://purl.obolibrary.org/obo/MONDO_0024295,skin disease caused by bacterial infection
+http://purl.obolibrary.org/obo/MONDO_0005725,cyclosporiasis,http://purl.obolibrary.org/obo/NCBITaxon_44417,Cyclospora,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0016212,cyclosporosis,http://purl.obolibrary.org/obo/NCBITaxon_88456,Cyclospora cayetanensis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0024354,cytomegalovirus pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_10358,Cytomegalovirus,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0000878,cytomegalovirus retinitis,http://purl.obolibrary.org/obo/NCBITaxon_10358,Cytomegalovirus,http://purl.obolibrary.org/obo/MONDO_0002708,retinitis
+http://purl.obolibrary.org/obo/MONDO_0017280,demodicidosis,http://purl.obolibrary.org/obo/NCBITaxon_188544,Demodex,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005502,dengue disease,http://purl.obolibrary.org/obo/NCBITaxon_12637,Dengue virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005729,dicrocoeliasis,http://purl.obolibrary.org/obo/NCBITaxon_57077,Dicrocoelium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0024608,dientamoebiasis,http://purl.obolibrary.org/obo/NCBITaxon_43351,Dientamoeba,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000298,dioctophymiasis,http://purl.obolibrary.org/obo/NCBITaxon_513045,Dioctophyme renale,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005731,dipetalonemiasis,http://purl.obolibrary.org/obo/NCBITaxon_42231,Mansonella perstans,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0041259,diphtheritic myocarditis,http://purl.obolibrary.org/obo/NCBITaxon_1717,Corynebacterium diphtheriae,http://purl.obolibrary.org/obo/MONDO_0004496,myocarditis
+http://purl.obolibrary.org/obo/MONDO_0015260,diphyllobothriasis,http://purl.obolibrary.org/obo/NCBITaxon_28844,Diphyllobothrium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0015636,dirofilariasis,http://purl.obolibrary.org/obo/NCBITaxon_6286,Dirofilaria,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0016472,dracunculiasis,http://purl.obolibrary.org/obo/NCBITaxon_318479,Dracunculus medinensis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005738,echinococcosis,http://purl.obolibrary.org/obo/NCBITaxon_6209,Echinococcus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0044346,echinococcus granulosus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_6210,Echinococcus granulosus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005739,echinostomiasis,http://purl.obolibrary.org/obo/NCBITaxon_404429,Echinostomatoidea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005746,enterobiasis,http://purl.obolibrary.org/obo/NCBITaxon_51028,Enterobius vermicularis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005747,enterovirus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_12059,Enterovirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0025485,feline acquired immunodeficiency syndrome,http://purl.obolibrary.org/obo/NCBITaxon_11673,Feline immunodeficiency virus,http://purl.obolibrary.org/obo/MONDO_0024912,cat disease
+http://purl.obolibrary.org/obo/MONDO_0023147,fetal parainfluenza virus type 3 syndrome,http://purl.obolibrary.org/obo/NCBITaxon_11216,Human respirovirus 3,http://purl.obolibrary.org/obo/MONDO_0016511,infectious embryofetopathy
+http://purl.obolibrary.org/obo/MONDO_0017453,fetal parvovirus syndrome,http://purl.obolibrary.org/obo/NCBITaxon_10798,Human parvovirus B19,http://purl.obolibrary.org/obo/MONDO_0016511,infectious embryofetopathy
+http://purl.obolibrary.org/obo/MONDO_0002843,fungal gastritis,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi,http://purl.obolibrary.org/obo/MONDO_0004966,gastritis (disease)
+http://purl.obolibrary.org/obo/MONDO_0002041,fungal infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005766,fungal lung infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi,http://purl.obolibrary.org/obo/MONDO_0005275,lung disease
+http://purl.obolibrary.org/obo/MONDO_0006764,fungal meningitis,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0016426,fusariosis,http://purl.obolibrary.org/obo/NCBITaxon_5506,Fusarium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005774,glanders,http://purl.obolibrary.org/obo/NCBITaxon_13373,Burkholderia mallei,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001719,gonococcal bursitis,http://purl.obolibrary.org/obo/NCBITaxon_485,Neisseria gonorrhoeae,http://purl.obolibrary.org/obo/MONDO_0002471,bursitis
+http://purl.obolibrary.org/obo/MONDO_0021160,gonococcal cystitis,http://purl.obolibrary.org/obo/NCBITaxon_485,Neisseria gonorrhoeae,http://purl.obolibrary.org/obo/MONDO_0006032,cystitis
+http://purl.obolibrary.org/obo/MONDO_0004774,gonococcal iridocyclitis,http://purl.obolibrary.org/obo/NCBITaxon_485,Neisseria gonorrhoeae,http://purl.obolibrary.org/obo/MONDO_0004773,iridocyclitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0021161,gonococcal prostatitis,http://purl.obolibrary.org/obo/NCBITaxon_485,Neisseria gonorrhoeae,http://purl.obolibrary.org/obo/MONDO_0005280,prostatitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0021159,gonococcal salpingitis,http://purl.obolibrary.org/obo/NCBITaxon_485,Neisseria gonorrhoeae,http://purl.obolibrary.org/obo/MONDO_0003619,salpingitis
+http://purl.obolibrary.org/obo/MONDO_0006926,haemophilus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_724,Haemophilus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000889,haemophilus meningitis,http://purl.obolibrary.org/obo/NCBITaxon_727,Haemophilus influenzae,http://purl.obolibrary.org/obo/MONDO_0006670,bacterial meningitis
+http://purl.obolibrary.org/obo/MONDO_0005344,hepatitis B,http://purl.obolibrary.org/obo/NCBITaxon_10407,Hepatitis B virus,http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis
+http://purl.obolibrary.org/obo/MONDO_0005231,hepatitis C,http://purl.obolibrary.org/obo/NCBITaxon_11103,Hepatitis C virus,http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis
+http://purl.obolibrary.org/obo/MONDO_0005789,hepatitis D,http://purl.obolibrary.org/obo/NCBITaxon_12475,Hepatitis delta virus,http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis
+http://purl.obolibrary.org/obo/MONDO_0005788,hepatitis E,http://purl.obolibrary.org/obo/NCBITaxon_12461,Hepatitis E virus,http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis
+http://purl.obolibrary.org/obo/MONDO_0004712,herpes simplex dermatitis,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0002406,dermatitis
+http://purl.obolibrary.org/obo/MONDO_0012521,herpes simplex encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0020067,infectious encephalitis
+http://purl.obolibrary.org/obo/MONDO_0004609,herpes simplex infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005792,herpes simplex virus gingivostomatitis,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0004842,stomatitis
+http://purl.obolibrary.org/obo/MONDO_0015288,herpes simplex virus keratitis,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0003085,keratitis
+http://purl.obolibrary.org/obo/MONDO_0003769,herpetic gastritis,http://purl.obolibrary.org/obo/NCBITaxon_10292,Herpesviridae,http://purl.obolibrary.org/obo/MONDO_0002270,viral gastritis
+http://purl.obolibrary.org/obo/MONDO_0004616,herpetic whitlow,http://purl.obolibrary.org/obo/NCBITaxon_10294,Simplexvirus,http://purl.obolibrary.org/obo/MONDO_0005898,paronychia (disease)
+http://purl.obolibrary.org/obo/MONDO_0001191,hirudiniasis,http://purl.obolibrary.org/obo/NCBITaxon_55824,Hirudinea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0018312,histoplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_5036,Histoplasma,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001471,histoplasmosis meningitis,http://purl.obolibrary.org/obo/NCBITaxon_5037,Histoplasma capsulatum,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0001263,histoplasmosis retinitis,http://purl.obolibrary.org/obo/NCBITaxon_5037,Histoplasma capsulatum,http://purl.obolibrary.org/obo/MONDO_0002708,retinitis
+http://purl.obolibrary.org/obo/MONDO_0000806,horned turban snail allergy,http://purl.obolibrary.org/obo/NCBITaxon_63673,Turbo cornutus,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0005801,human T-lymphotropic virus 1 infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11908,Human T-lymphotropic virus 1,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005187,human herpesvirus 8 infection,http://purl.obolibrary.org/obo/NCBITaxon_37296,Human gammaherpesvirus 8,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005161,human papilloma virus infection,http://purl.obolibrary.org/obo/NCBITaxon_10566,Human papillomavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005805,hypodermyiasis,http://purl.obolibrary.org/obo/NCBITaxon_7387,Oestridae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0024410,infection caused by Bifidobacterium,http://purl.obolibrary.org/obo/NCBITaxon_1678,Bifidobacterium,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005550,infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_1,root,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0018769,isosporiasis,http://purl.obolibrary.org/obo/NCBITaxon_482538,Cystoisospora belli,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0019378,la Crosse encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11577,La Crosse virus,http://purl.obolibrary.org/obo/MONDO_0020067,infectious encephalitis
+http://purl.obolibrary.org/obo/MONDO_0005124,leprosy,http://purl.obolibrary.org/obo/NCBITaxon_1769,Mycobacterium leprae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005825,leptospirosis,http://purl.obolibrary.org/obo/NCBITaxon_171,Leptospira,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005828,listeriosis,http://purl.obolibrary.org/obo/NCBITaxon_1639,Listeria monocytogenes,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001449,lymphocytic choriomeningitis,http://purl.obolibrary.org/obo/NCBITaxon_11623,Lymphocytic choriomeningitis mammarenavirus,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0041095,malignant otitis externa caused by Pseudomonas aeruginosa,http://purl.obolibrary.org/obo/NCBITaxon_287,Pseudomonas aeruginosa,http://purl.obolibrary.org/obo/MONDO_0001050,malignant otitis externa
+http://purl.obolibrary.org/obo/MONDO_0002266,malt worker's lung,http://purl.obolibrary.org/obo/NCBITaxon_5052,Aspergillus,http://purl.obolibrary.org/obo/MONDO_0004553,extrinsic allergic alveolitis
+http://purl.obolibrary.org/obo/MONDO_0004619,measles,http://purl.obolibrary.org/obo/NCBITaxon_11234,Measles morbillivirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0017775,melioidosis,http://purl.obolibrary.org/obo/NCBITaxon_28450,Burkholderia pseudomallei,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0041535,mesenteric lymphadenitis due to Yersinia infection,http://purl.obolibrary.org/obo/NCBITaxon_633,Yersinia pseudotuberculosis,http://purl.obolibrary.org/obo/MONDO_0001116,mesenteric lymphadenitis
+http://purl.obolibrary.org/obo/MONDO_0000294,mesocestoidiasis,http://purl.obolibrary.org/obo/NCBITaxon_53467,Mesocestoides,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005846,microsporidiosis,http://purl.obolibrary.org/obo/NCBITaxon_6029,Microsporidia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000989,mumps infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11161,Mumps virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005866,mycobacterium avium complex disease,http://purl.obolibrary.org/obo/NCBITaxon_37162,Mycobacterium avium complex,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0017832,mycobacterium xenopi infection,http://purl.obolibrary.org/obo/NCBITaxon_1789,Mycobacterium xenopi,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0042433,mycotic endocarditis,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi,http://purl.obolibrary.org/obo/MONDO_0005025,endocarditis (disease)
+http://purl.obolibrary.org/obo/MONDO_0042497,mycotoxicosis,http://purl.obolibrary.org/obo/NCBITaxon_4751,Fungi,http://purl.obolibrary.org/obo/MONDO_0029000,poisoning
+http://purl.obolibrary.org/obo/MONDO_0017776,nocardiosis,http://purl.obolibrary.org/obo/NCBITaxon_1817,Nocardia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005880,oesophagostomiasis,http://purl.obolibrary.org/obo/NCBITaxon_52564,Oesophagostomum,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000301,ophthalmomyiasis,http://purl.obolibrary.org/obo/NCBITaxon_123737,Oestrus ovis,http://purl.obolibrary.org/obo/MONDO_0019147,myiasis
+http://purl.obolibrary.org/obo/MONDO_0005895,paragonimiasis,http://purl.obolibrary.org/obo/NCBITaxon_34504,Paragonimus westermani,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0042974,parainfluenza virus type 3 infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_11216,Human respirovirus 3,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000307,parasitic Ichthyosporea infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_127916,Ichthyosporea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005901,pasteurellosis,http://purl.obolibrary.org/obo/NCBITaxon_745,Pasteurella,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000785,peach allergy,http://purl.obolibrary.org/obo/NCBITaxon_3760,Prunus persica,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0000304,penicilliosis,http://purl.obolibrary.org/obo/NCBITaxon_37727,Talaromyces marneffei,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005077,pertussis,http://purl.obolibrary.org/obo/NCBITaxon_520,Bordetella pertussis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005908,peste des petits ruminants infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_31604,Small ruminant morbillivirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000292,philophthalmiasis,http://purl.obolibrary.org/obo/NCBITaxon_685953,Philophthalmus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000786,plum allergy,http://purl.obolibrary.org/obo/NCBITaxon_3758,Prunus domestica,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0005114,pneumococcal infection,http://purl.obolibrary.org/obo/NCBITaxon_1313,Streptococcus pneumoniae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006913,pneumococcal meningitis,http://purl.obolibrary.org/obo/NCBITaxon_1313,Streptococcus pneumoniae,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0025598,pneumonia caused by chlamydia,http://purl.obolibrary.org/obo/NCBITaxon_810,Chlamydia,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0024618,poliovirus infection,http://purl.obolibrary.org/obo/NCBITaxon_138950,Enterovirus C,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000793,rainbow trout allergy,http://purl.obolibrary.org/obo/NCBITaxon_8022,Oncorhynchus mykiss,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0005946,rhinosporidiosis,http://purl.obolibrary.org/obo/NCBITaxon_90339,Rhinosporidium seeberi,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005947,rickettsial pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_775,Rickettsiaceae,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0006956,rickettsiosis,http://purl.obolibrary.org/obo/NCBITaxon_780,Rickettsia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0004656,rubella,http://purl.obolibrary.org/obo/NCBITaxon_11041,Rubella virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0004525,scabies,http://purl.obolibrary.org/obo/NCBITaxon_52283,Sarcoptes scabiei,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005954,screw worm infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_115425,Cochliomyia hominivorax,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000332,sennetsu fever,http://purl.obolibrary.org/obo/NCBITaxon_951,Neorickettsia sennetsu,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005957,setariasis,http://purl.obolibrary.org/obo/NCBITaxon_48796,Setaria <nematode>,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005091,severe acute respiratory syndrome,http://purl.obolibrary.org/obo/NCBITaxon_227859,SARS coronavirus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0025484,simian acquired immunodeficiency syndrome,http://purl.obolibrary.org/obo/NCBITaxon_11723,Simian immunodeficiency virus,http://purl.obolibrary.org/obo/MONDO_0025102,monkey disease
+http://purl.obolibrary.org/obo/MONDO_0005163,simian immunodeficiency virus infection,http://purl.obolibrary.org/obo/NCBITaxon_11723,Simian immunodeficiency virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0024295,skin disease caused by bacterial infection,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0024294,skin disease caused by infection
+http://purl.obolibrary.org/obo/MONDO_0004651,smallpox,http://purl.obolibrary.org/obo/NCBITaxon_10255,Variola virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005963,sparganosis,http://purl.obolibrary.org/obo/NCBITaxon_46580,Spirometra,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005969,st. Louis encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11080,St. Louis encephalitis virus,http://purl.obolibrary.org/obo/MONDO_0020067,infectious encephalitis
+http://purl.obolibrary.org/obo/MONDO_0005970,staphylococcal pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_1279,Staphylococcus,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0020545,staphylococcal toxic-shock syndrome,http://purl.obolibrary.org/obo/NCBITaxon_1279,Staphylococcus,http://purl.obolibrary.org/obo/MONDO_0001881,toxic shock syndrome
+http://purl.obolibrary.org/obo/MONDO_0041879,staphylococcus aureus pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_1280,Staphylococcus aureus,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0021680,streptococcal infection,http://purl.obolibrary.org/obo/NCBITaxon_1301,Streptococcus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001316,streptococcal meningitis,http://purl.obolibrary.org/obo/NCBITaxon_1301,Streptococcus,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0005972,streptococcal pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_1313,Streptococcus pneumoniae,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0020544,streptococcal toxic-shock syndrome,http://purl.obolibrary.org/obo/NCBITaxon_1301,Streptococcus,http://purl.obolibrary.org/obo/MONDO_0001881,toxic shock syndrome
+http://purl.obolibrary.org/obo/MONDO_0005460,swine influenza,http://purl.obolibrary.org/obo/NCBITaxon_12845,Swine influenza virus,http://purl.obolibrary.org/obo/MONDO_0005812,influenza
+http://purl.obolibrary.org/obo/MONDO_0005976,syphilis,http://purl.obolibrary.org/obo/NCBITaxon_160,Treponema pallidum,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000937,syphilitic encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_157,Treponema,http://purl.obolibrary.org/obo/MONDO_0019956,encephalitis
+http://purl.obolibrary.org/obo/MONDO_0000936,syphilitic meningitis,http://purl.obolibrary.org/obo/NCBITaxon_157,Treponema,http://purl.obolibrary.org/obo/MONDO_0004796,infectious meningitis
+http://purl.obolibrary.org/obo/MONDO_0005526,tetanus,http://purl.obolibrary.org/obo/NCBITaxon_1513,Clostridium tetani,http://purl.obolibrary.org/obo/MONDO_0020010,infectious disease of the nervous system
+http://purl.obolibrary.org/obo/MONDO_0000299,thelaziasis,http://purl.obolibrary.org/obo/NCBITaxon_103826,Thelazia,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005980,tick infestation,http://purl.obolibrary.org/obo/NCBITaxon_297308,Ixodoidea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000803,tiger prawn allergy,http://purl.obolibrary.org/obo/NCBITaxon_6687,Penaeus monodon,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0005982,tinea infection,http://purl.obolibrary.org/obo/NCBITaxon_41013,Tinea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000787,tomato allergy,http://purl.obolibrary.org/obo/NCBITaxon_4081,Solanum lycopersicum,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0005987,toxascariasis,http://purl.obolibrary.org/obo/NCBITaxon_59263,Toxascaris,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005988,toxocariasis,http://purl.obolibrary.org/obo/NCBITaxon_6264,Toxocara,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005989,toxoplasmosis,http://purl.obolibrary.org/obo/NCBITaxon_5811,Toxoplasma gondii,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005991,trench fever,http://purl.obolibrary.org/obo/NCBITaxon_803,Bartonella quintana,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005992,trichinosis,http://purl.obolibrary.org/obo/NCBITaxon_6333,Trichinella,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0030720,trichomonal vulvovaginitis,http://purl.obolibrary.org/obo/NCBITaxon_5722,Trichomonas vaginalis,http://purl.obolibrary.org/obo/MONDO_0007019,vulvovaginitis
+http://purl.obolibrary.org/obo/MONDO_0000306,trichosporonosis,http://purl.obolibrary.org/obo/NCBITaxon_5552,Trichosporon,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005994,trichostrongyloidiasis,http://purl.obolibrary.org/obo/NCBITaxon_6314,Trichostrongyloidea,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005995,trichostrongylosis,http://purl.obolibrary.org/obo/NCBITaxon_6318,Trichostrongylus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005996,trichuriasis,http://purl.obolibrary.org/obo/NCBITaxon_36087,Trichuris trichiura,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0005998,trombiculiasis,http://purl.obolibrary.org/obo/NCBITaxon_92251,Trombiculidae,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0000940,trypanosomiasis,http://purl.obolibrary.org/obo/NCBITaxon_5690,Trypanosoma,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0006000,tuberculous peritonitis,http://purl.obolibrary.org/obo/NCBITaxon_1773,Mycobacterium tuberculosis,http://purl.obolibrary.org/obo/MONDO_0004522,peritonitis
+http://purl.obolibrary.org/obo/MONDO_0018077,tularemia,http://purl.obolibrary.org/obo/NCBITaxon_263,Francisella tularensis,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0007014,vibrio infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_662,Vibrio,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0043297,vibrio vulnificus infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_672,Vibrio vulnificus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0043541,viral conjunctivitis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0003799,conjunctivitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0005200,viral dilated cardiomyopathy,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0005021,dilated cardiomyopathy
+http://purl.obolibrary.org/obo/MONDO_0006009,viral encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0019956,encephalitis
+http://purl.obolibrary.org/obo/MONDO_0003846,viral esophagitis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0001409,esophagitis (disease)
+http://purl.obolibrary.org/obo/MONDO_0002270,viral gastritis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0004966,gastritis (disease)
+http://purl.obolibrary.org/obo/MONDO_0006011,viral hepatitis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0002251,hepatitis
+http://purl.obolibrary.org/obo/MONDO_0005108,viral infectious disease,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0001507,viral labyrinthitis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0002008,labyrinthitis
+http://purl.obolibrary.org/obo/MONDO_0002646,viral laryngitis,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0002647,laryngitis
+http://purl.obolibrary.org/obo/MONDO_0006012,viral pneumonia,http://purl.obolibrary.org/obo/NCBITaxon_10239,Viruses,http://purl.obolibrary.org/obo/MONDO_0005249,pneumonia
+http://purl.obolibrary.org/obo/MONDO_0006013,visna disease,http://purl.obolibrary.org/obo/NCBITaxon_11741,Visna/maedi virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0019380,western equine encephalitis,http://purl.obolibrary.org/obo/NCBITaxon_11039,Western equine encephalitis virus,http://purl.obolibrary.org/obo/MONDO_0020067,infectious encephalitis
+http://purl.obolibrary.org/obo/MONDO_0000804,white shrimp allergy,http://purl.obolibrary.org/obo/NCBITaxon_122378,Litopenaeus schmitti,http://purl.obolibrary.org/obo/MONDO_0005271,allergic disease
+http://purl.obolibrary.org/obo/MONDO_0006019,yaws,http://purl.obolibrary.org/obo/NCBITaxon_168,Treponema pallidum subsp. pertenue,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0020502,yellow fever,http://purl.obolibrary.org/obo/NCBITaxon_11089,Yellow fever virus,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0044746,zoonotic bacterial infection,http://purl.obolibrary.org/obo/NCBITaxon_2,Bacteria,http://purl.obolibrary.org/obo/MONDO_0025481,zoonoses

--- a/src/patterns/squamous_cell_carcinoma.csv
+++ b/src/patterns/squamous_cell_carcinoma.csv
@@ -1,0 +1,64 @@
+iri,iri label,v0,v0 label
+http://purl.obolibrary.org/obo/MONDO_0004053,Bartholin gland squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000460,major vestibular gland
+http://purl.obolibrary.org/obo/MONDO_0003490,ampulla of vater squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0004913,hepatopancreatic ampulla
+http://purl.obolibrary.org/obo/MONDO_0004132,anal canal squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000159,anal canal
+http://purl.obolibrary.org/obo/MONDO_0001470,anal margin squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0012336,perianal skin
+http://purl.obolibrary.org/obo/MONDO_0006082,anal squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001245,anus
+http://purl.obolibrary.org/obo/MONDO_0002760,bladder squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001255,urinary bladder
+http://purl.obolibrary.org/obo/MONDO_0000514,bone squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002481,bone tissue
+http://purl.obolibrary.org/obo/MONDO_0006143,cervical squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000002,uterine cervix
+http://purl.obolibrary.org/obo/MONDO_0006165,colorectal squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0012652,colorectum
+http://purl.obolibrary.org/obo/MONDO_0006173,conjunctival squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001811,conjunctiva
+http://purl.obolibrary.org/obo/MONDO_0001740,cornea squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000964,cornea
+http://purl.obolibrary.org/obo/MONDO_0006198,endometrial squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001295,endometrium
+http://purl.obolibrary.org/obo/MONDO_0005580,esophageal squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001043,esophagus
+http://purl.obolibrary.org/obo/MONDO_0002416,ethmoid sinus squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002453,ethmoid sinus
+http://purl.obolibrary.org/obo/MONDO_0003501,external ear squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001691,external ear
+http://purl.obolibrary.org/obo/MONDO_0006203,extrahepatic bile duct squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0003703,extrahepatic bile duct
+http://purl.obolibrary.org/obo/MONDO_0003503,fallopian tube squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0003889,fallopian tube
+http://purl.obolibrary.org/obo/MONDO_0002301,frontal sinus squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001760,frontal sinus
+http://purl.obolibrary.org/obo/MONDO_0006220,gallbladder squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002110,gall bladder
+http://purl.obolibrary.org/obo/MONDO_0006230,gastric squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000945,stomach
+http://purl.obolibrary.org/obo/MONDO_0004080,glottis squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002486,glottis
+http://purl.obolibrary.org/obo/MONDO_0010150,head and neck squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0007811,craniocervical region
+http://purl.obolibrary.org/obo/MONDO_0044638,hypopharynx squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001051,hypopharynx
+http://purl.obolibrary.org/obo/MONDO_0003492,lacrimal gland squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001817,lacrimal gland
+http://purl.obolibrary.org/obo/MONDO_0005595,laryngeal squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001737,larynx
+http://purl.obolibrary.org/obo/MONDO_0004394,maxillary sinus squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001764,maxillary sinus
+http://purl.obolibrary.org/obo/MONDO_0006303,middle ear squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001756,middle ear
+http://purl.obolibrary.org/obo/MONDO_0006059,nasal cavity squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001707,nasal cavity
+http://purl.obolibrary.org/obo/MONDO_0004958,oral cavity squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000165,mouth
+http://purl.obolibrary.org/obo/MONDO_0044704,oropharynx squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001729,oropharynx
+http://purl.obolibrary.org/obo/MONDO_0003494,ovarian squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000992,ovary
+http://purl.obolibrary.org/obo/MONDO_0044705,paranasal sinus squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001825,paranasal sinus
+http://purl.obolibrary.org/obo/MONDO_0006358,parotid gland squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001831,parotid gland
+http://purl.obolibrary.org/obo/MONDO_0000993,prostate squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002367,prostate gland
+http://purl.obolibrary.org/obo/MONDO_0003497,renal pelvis squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001224,renal pelvis
+http://purl.obolibrary.org/obo/MONDO_0044740,salivary gland squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001044,saliva-secreting gland
+http://purl.obolibrary.org/obo/MONDO_0001651,scrotum squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001300,scrotum
+http://purl.obolibrary.org/obo/MONDO_0002529,skin squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000014,zone of skin
+http://purl.obolibrary.org/obo/MONDO_0001995,sphenoid sinus squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001724,sphenoidal sinus
+http://purl.obolibrary.org/obo/MONDO_0003500,squamous cell bile duct carcinoma,http://purl.obolibrary.org/obo/UBERON_0002394,bile duct
+http://purl.obolibrary.org/obo/MONDO_0006056,squamous cell breast carcinoma,http://purl.obolibrary.org/obo/UBERON_0000310,breast
+http://purl.obolibrary.org/obo/MONDO_0021431,squamous cell carcinoma of buccal mucosa,http://purl.obolibrary.org/obo/UBERON_0006956,buccal mucosa
+http://purl.obolibrary.org/obo/MONDO_0018513,squamous cell carcinoma of colon,http://purl.obolibrary.org/obo/UBERON_0001155,colon
+http://purl.obolibrary.org/obo/MONDO_0021429,squamous cell carcinoma of floor of mouth,http://purl.obolibrary.org/obo/UBERON_0003679,mouth floor
+http://purl.obolibrary.org/obo/MONDO_0021427,squamous cell carcinoma of lip,http://purl.obolibrary.org/obo/UBERON_0001833,lip
+http://purl.obolibrary.org/obo/MONDO_0018521,squamous cell carcinoma of pancreas,http://purl.obolibrary.org/obo/UBERON_0001264,pancreas
+http://purl.obolibrary.org/obo/MONDO_0018352,squamous cell carcinoma of penis,http://purl.obolibrary.org/obo/UBERON_0000989,penis
+http://purl.obolibrary.org/obo/MONDO_0018515,squamous cell carcinoma of rectum,http://purl.obolibrary.org/obo/UBERON_0001052,rectum
+http://purl.obolibrary.org/obo/MONDO_0016266,squamous cell carcinoma of the corpus uteri,http://purl.obolibrary.org/obo/UBERON_0009853,body of uterus
+http://purl.obolibrary.org/obo/MONDO_0018509,squamous cell carcinoma of the small intestine,http://purl.obolibrary.org/obo/UBERON_0002108,small intestine
+http://purl.obolibrary.org/obo/MONDO_0005097,squamous cell lung carcinoma,http://purl.obolibrary.org/obo/UBERON_0002048,lung
+http://purl.obolibrary.org/obo/MONDO_0004291,subglottis squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0036068,subglottis
+http://purl.obolibrary.org/obo/MONDO_0004293,supraglottis squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0036263,supraglottic part of larynx
+http://purl.obolibrary.org/obo/MONDO_0003493,thymus squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002370,thymus
+http://purl.obolibrary.org/obo/MONDO_0006467,thyroid gland squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002046,thyroid gland
+http://purl.obolibrary.org/obo/MONDO_0000500,tongue squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0001723,tongue
+http://purl.obolibrary.org/obo/MONDO_0000535,tonsil squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002372,tonsil
+http://purl.obolibrary.org/obo/MONDO_0006470,tonsillar squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0002373,palatine tonsil
+http://purl.obolibrary.org/obo/MONDO_0001419,trachea squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0003126,trachea
+http://purl.obolibrary.org/obo/MONDO_0003502,ureter squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000056,ureter
+http://purl.obolibrary.org/obo/MONDO_0002764,urethra squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000057,urethra
+http://purl.obolibrary.org/obo/MONDO_0006490,vaginal squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000996,vagina
+http://purl.obolibrary.org/obo/MONDO_0024609,vulvar squamous cell carcinoma,http://purl.obolibrary.org/obo/UBERON_0000997,mammalian vulva

--- a/src/patterns/syndromic.csv
+++ b/src/patterns/syndromic.csv
@@ -1,33 +1,34 @@
 iri,iri label,disease,disease label
-MONDO:0015150,complex hereditary spastic paraplegia,MONDO:0019064,hereditary spastic paraplegia
-MONDO:0016463,syndromic agammaglobulinemia,MONDO:0015977,agammaglobulinemia
-MONDO:0020148,syndromic aniridia,MONDO:0019172,aniridia
-MONDO:0015246,syndromic anorectal malformation,MONDO:0019938,anorectal malformation
-MONDO:0020225,syndromic cataract,MONDO:0005129,cataract (disease)
-MONDO:0020215,syndromic corneal dystrophy,MONDO:0018102,corneal dystrophy (disease)
-MONDO:0015338,syndromic craniosynostosis,MONDO:0015469,craniosynostosis
-MONDO:0015218,syndromic developmental defect of the eye,MONDO:0020145,developmental defect of the eye
-MONDO:0015216,syndromic diaphragmatic or abdominal wall malformation,MONDO:0020021,diaphragmatic or abdominal wall malformation
-MONDO:0009105,syndromic diarrhea,MONDO:0001673,diarrhea
-MONDO:0002254,syndromic disease,MONDO:0000001,disease
-MONDO:0015208,syndromic esophageal malformation,MONDO:0019513,esophageal malformation
-MONDO:0015210,syndromic gastroduodenal malformation,MONDO:0019998,gastroduodenal malformation
-MONDO:0018609,syndromic hereditary optic neuropathy,MONDO:0020249,hereditary optic neuropathy
-MONDO:0020210,syndromic hyperopia,MONDO:0004891,hyperopia
-MONDO:0015778,syndromic hypothyroidism,MONDO:0005420,hypothyroidism
-MONDO:0020269,syndromic ichthyosis associated with ocular features,MONDO:0020268,ichthyosis associated with ocular features
-MONDO:0000508,syndromic intellectual disability,MONDO:0001071,intellectual disability
-MONDO:0015212,syndromic intestinal malformation,MONDO:0019999,intestinal malformation
-MONDO:0020211,syndromic keratoconus,MONDO:0015486,keratoconus (disease)
-MONDO:0019520,syndromic lymphedema,MONDO:0019297,lymphedema
-MONDO:0016073,syndromic microphthalmia,MONDO:0021129,microphthalmia
-MONDO:0020208,syndromic myopia,MONDO:0001384,myopia (disease)
-MONDO:0019285,syndromic nail anomaly,MONDO:0019283,nail anomaly
-MONDO:0016565,syndromic obesity,MONDO:0011122,obesity (disease)
-MONDO:0017305,syndromic oculocutaneous albinism,MONDO:0018910,oculocutaneous albinism
-MONDO:0017264,syndromic recessive X-linked ichthyosis,MONDO:0010622,recessive X-linked ichthyosis
-MONDO:0019721,syndromic renal or urinary tract malformation,MONDO:0019719,renal or urinary tract malformation
-MONDO:0015222,syndromic respiratory or mediastinal malformation,MONDO:0020023,respiratory or mediastinal malformation
-MONDO:0020240,syndromic retinitis pigmentosa,MONDO:0019200,retinitis pigmentosa
-MONDO:0015620,syndromic urogenital tract malformation,MONDO:0019356,urogenital tract malformation
-MONDO:0015846,syndromic uterovaginal malformation,MONDO:0015828,uterovaginal malformation
+http://purl.obolibrary.org/obo/MONDO_0015150,complex hereditary spastic paraplegia,http://purl.obolibrary.org/obo/MONDO_0019064,hereditary spastic paraplegia
+http://purl.obolibrary.org/obo/MONDO_0017263,inherited ichthyosis syndromic form,http://purl.obolibrary.org/obo/MONDO_0015947,inherited ichthyosis
+http://purl.obolibrary.org/obo/MONDO_0016463,syndromic agammaglobulinemia,http://purl.obolibrary.org/obo/MONDO_0015977,agammaglobulinemia
+http://purl.obolibrary.org/obo/MONDO_0020148,syndromic aniridia,http://purl.obolibrary.org/obo/MONDO_0019172,aniridia
+http://purl.obolibrary.org/obo/MONDO_0015246,syndromic anorectal malformation,http://purl.obolibrary.org/obo/MONDO_0019938,anorectal malformation
+http://purl.obolibrary.org/obo/MONDO_0020225,syndromic cataract,http://purl.obolibrary.org/obo/MONDO_0005129,cataract (disease)
+http://purl.obolibrary.org/obo/MONDO_0020215,syndromic corneal dystrophy,http://purl.obolibrary.org/obo/MONDO_0018102,corneal dystrophy (disease)
+http://purl.obolibrary.org/obo/MONDO_0015338,syndromic craniosynostosis,http://purl.obolibrary.org/obo/MONDO_0015469,craniosynostosis
+http://purl.obolibrary.org/obo/MONDO_0015218,syndromic developmental defect of the eye,http://purl.obolibrary.org/obo/MONDO_0020145,developmental defect of the eye
+http://purl.obolibrary.org/obo/MONDO_0015216,syndromic diaphragmatic or abdominal wall malformation,http://purl.obolibrary.org/obo/MONDO_0020021,diaphragmatic or abdominal wall malformation
+http://purl.obolibrary.org/obo/MONDO_0002254,syndromic disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0015905,syndromic dyslipidemia,http://purl.obolibrary.org/obo/MONDO_0002525,inherited lipid metabolism disorder
+http://purl.obolibrary.org/obo/MONDO_0015208,syndromic esophageal malformation,http://purl.obolibrary.org/obo/MONDO_0019513,esophageal malformation
+http://purl.obolibrary.org/obo/MONDO_0015210,syndromic gastroduodenal malformation,http://purl.obolibrary.org/obo/MONDO_0019998,gastroduodenal malformation
+http://purl.obolibrary.org/obo/MONDO_0018609,syndromic hereditary optic neuropathy,http://purl.obolibrary.org/obo/MONDO_0020249,hereditary optic neuropathy
+http://purl.obolibrary.org/obo/MONDO_0020210,syndromic hyperopia,http://purl.obolibrary.org/obo/MONDO_0004891,hyperopia
+http://purl.obolibrary.org/obo/MONDO_0015778,syndromic hypothyroidism,http://purl.obolibrary.org/obo/MONDO_0005420,hypothyroidism
+http://purl.obolibrary.org/obo/MONDO_0020269,syndromic ichthyosis associated with ocular features,http://purl.obolibrary.org/obo/MONDO_0020268,ichthyosis associated with ocular features
+http://purl.obolibrary.org/obo/MONDO_0000508,syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0001071,intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0015212,syndromic intestinal malformation,http://purl.obolibrary.org/obo/MONDO_0019999,intestinal malformation
+http://purl.obolibrary.org/obo/MONDO_0020211,syndromic keratoconus,http://purl.obolibrary.org/obo/MONDO_0015486,keratoconus (disease)
+http://purl.obolibrary.org/obo/MONDO_0019520,syndromic lymphedema,http://purl.obolibrary.org/obo/MONDO_0019297,lymphedema
+http://purl.obolibrary.org/obo/MONDO_0016073,syndromic microphthalmia,http://purl.obolibrary.org/obo/MONDO_0021129,microphthalmia
+http://purl.obolibrary.org/obo/MONDO_0020208,syndromic myopia,http://purl.obolibrary.org/obo/MONDO_0001384,myopia (disease)
+http://purl.obolibrary.org/obo/MONDO_0019285,syndromic nail anomaly,http://purl.obolibrary.org/obo/MONDO_0019283,nail anomaly
+http://purl.obolibrary.org/obo/MONDO_0016565,syndromic obesity,http://purl.obolibrary.org/obo/MONDO_0011122,obesity (disease)
+http://purl.obolibrary.org/obo/MONDO_0017305,syndromic oculocutaneous albinism,http://purl.obolibrary.org/obo/MONDO_0018910,oculocutaneous albinism
+http://purl.obolibrary.org/obo/MONDO_0017264,syndromic recessive X-linked ichthyosis,http://purl.obolibrary.org/obo/MONDO_0010622,recessive X-linked ichthyosis
+http://purl.obolibrary.org/obo/MONDO_0019721,syndromic renal or urinary tract malformation,http://purl.obolibrary.org/obo/MONDO_0019719,congenital anomaly of kidney and urinary tract
+http://purl.obolibrary.org/obo/MONDO_0015222,syndromic respiratory or mediastinal malformation,http://purl.obolibrary.org/obo/MONDO_0020023,respiratory or mediastinal malformation
+http://purl.obolibrary.org/obo/MONDO_0020240,syndromic retinitis pigmentosa,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa
+http://purl.obolibrary.org/obo/MONDO_0015620,syndromic urogenital tract malformation,http://purl.obolibrary.org/obo/MONDO_0019356,urogenital tract malformation
+http://purl.obolibrary.org/obo/MONDO_0015846,syndromic uterovaginal malformation,http://purl.obolibrary.org/obo/MONDO_0015828,uterovaginal malformation

--- a/src/patterns/x_linked.csv
+++ b/src/patterns/x_linked.csv
@@ -1,27 +1,30 @@
 iri,iri label,disease,disease label
-MONDO:0010520,X-linked Alport syndrome,MONDO:0018965,Alport syndrome
-MONDO:0010586,X-linked Ehlers-Danlos syndrome,MONDO:0020066,Ehlers-Danlos syndrome
-MONDO:0010680,X-linked Emery-Dreifuss muscular dystrophy,MONDO:0016830,Emery-Dreifuss muscular dystrophy
-MONDO:0010222,X-linked Opitz G/BBB syndrome,MONDO:0017138,Opitz G/BBB syndrome
-MONDO:0018544,X-linked adrenoleukodystrophy,MONDO:0001070,adrenoleukodystrophy
-MONDO:0010683,X-linked centronuclear myopathy,MONDO:0018947,centronuclear myopathy
-MONDO:0016612,X-linked cerebellar ataxia,MONDO:0000437,cerebellar ataxia
-MONDO:0010556,X-linked chondrodysplasia punctata,MONDO:0019701,chondrodysplasia punctata
-MONDO:0021155,X-linked cone-rod dystrophy,MONDO:0015993,cone-rod dystrophy
-MONDO:0000425,X-linked disease,MONDO:0000001,disease
-MONDO:0018451,X-linked distal hereditary motor neuropathy,MONDO:0018894,distal hereditary motor neuropathy
-MONDO:0010420,X-linked erythropoietic protoporphyria,MONDO:0001676,erythropoietic protoporphyria
-MONDO:0000559,X-linked hereditary ataxia,MONDO:0000557,hereditary ataxia
-MONDO:0010626,X-linked hyper-IgM syndrome,MONDO:0003947,hyper-IgM syndrome
-MONDO:0010585,X-linked hypohidrotic ectodermal dysplasia,MONDO:0016535,hypohidrotic ectodermal dysplasia
-MONDO:0010619,X-linked hypophosphatemic rickets,MONDO:0000044,hypophosphatemic rickets
-MONDO:0010716,X-linked lethal multiple pterygium syndrome,MONDO:0009668,lethal multiple pterygium syndrome
-MONDO:0010627,X-linked lymphoproliferative syndrome,MONDO:0016537,lymphoproliferative syndrome
-MONDO:0010539,X-linked mandibulofacial dysostosis,MONDO:0015483,mandibulofacial dysostosis
-MONDO:0017905,X-linked mendelian susceptibility to mycobacterial diseases,MONDO:0019146,mendelian susceptibility to mycobacterial diseases
-MONDO:0019586,X-linked nonsyndromic deafness,MONDO:0019497,nonsyndromic deafness
-MONDO:0010294,X-linked severe congenital neutropenia,MONDO:0018542,severe congenital neutropenia
-MONDO:0010419,X-linked sideroblastic anemia,MONDO:0015194,sideroblastic anemia
-MONDO:0010248,X-linked spondyloepimetaphyseal dysplasia,MONDO:0000844,spondyloepimetaphyseal dysplasia
-MONDO:0020119,X-linked syndromic intellectual disability,MONDO:0000508,syndromic intellectual disability
-MONDO:0010622,recessive X-linked ichthyosis,MONDO:0019269,ichthyosis (disease)
+http://purl.obolibrary.org/obo/MONDO_0010583,"Dyggve-Melchior-Clausen syndrome, X-linked",http://purl.obolibrary.org/obo/MONDO_0009130,Dyggve-Melchior-Clausen disease
+http://purl.obolibrary.org/obo/MONDO_0010520,X-linked Alport syndrome,http://purl.obolibrary.org/obo/MONDO_0018965,Alport syndrome
+http://purl.obolibrary.org/obo/MONDO_0010586,X-linked Ehlers-Danlos syndrome,http://purl.obolibrary.org/obo/MONDO_0020066,Ehlers-Danlos syndrome
+http://purl.obolibrary.org/obo/MONDO_0010680,X-linked Emery-Dreifuss muscular dystrophy,http://purl.obolibrary.org/obo/MONDO_0016830,Emery-Dreifuss muscular dystrophy
+http://purl.obolibrary.org/obo/MONDO_0010222,X-linked Opitz G/BBB syndrome,http://purl.obolibrary.org/obo/MONDO_0017138,Opitz G/BBB syndrome
+http://purl.obolibrary.org/obo/MONDO_0010683,X-linked centronuclear myopathy,http://purl.obolibrary.org/obo/MONDO_0018947,centronuclear myopathy
+http://purl.obolibrary.org/obo/MONDO_0010556,X-linked chondrodysplasia punctata,http://purl.obolibrary.org/obo/MONDO_0019701,chondrodysplasia punctata
+http://purl.obolibrary.org/obo/MONDO_0021155,X-linked cone-rod dystrophy,http://purl.obolibrary.org/obo/MONDO_0015993,cone-rod dystrophy
+http://purl.obolibrary.org/obo/MONDO_0044749,X-linked congenital stationary night blindness,http://purl.obolibrary.org/obo/MONDO_0016293,congenital stationary night blindness
+http://purl.obolibrary.org/obo/MONDO_0000425,X-linked disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0018451,X-linked distal hereditary motor neuropathy,http://purl.obolibrary.org/obo/MONDO_0018894,distal hereditary motor neuropathy
+http://purl.obolibrary.org/obo/MONDO_0010420,X-linked erythropoietic protoporphyria,http://purl.obolibrary.org/obo/MONDO_0001676,erythropoietic protoporphyria
+http://purl.obolibrary.org/obo/MONDO_0010626,X-linked hyper-IgM syndrome,http://purl.obolibrary.org/obo/MONDO_0003947,hyper-IgM syndrome
+http://purl.obolibrary.org/obo/MONDO_0010585,X-linked hypohidrotic ectodermal dysplasia,http://purl.obolibrary.org/obo/MONDO_0016535,hypohidrotic ectodermal dysplasia
+http://purl.obolibrary.org/obo/MONDO_0010619,X-linked hypophosphatemic rickets,http://purl.obolibrary.org/obo/MONDO_0000044,hereditary hypophosphatemic rickets
+http://purl.obolibrary.org/obo/MONDO_0017269,X-linked ichthyosis syndrome,http://purl.obolibrary.org/obo/MONDO_0017263,inherited ichthyosis syndromic form
+http://purl.obolibrary.org/obo/MONDO_0010716,X-linked lethal multiple pterygium syndrome,http://purl.obolibrary.org/obo/MONDO_0009668,lethal multiple pterygium syndrome
+http://purl.obolibrary.org/obo/MONDO_0010627,X-linked lymphoproliferative syndrome,http://purl.obolibrary.org/obo/MONDO_0016537,lymphoproliferative syndrome
+http://purl.obolibrary.org/obo/MONDO_0010539,X-linked mandibulofacial dysostosis,http://purl.obolibrary.org/obo/MONDO_0015483,mandibulofacial dysostosis
+http://purl.obolibrary.org/obo/MONDO_0017905,X-linked mendelian susceptibility to mycobacterial diseases,http://purl.obolibrary.org/obo/MONDO_0019146,mendelian susceptibility to mycobacterial diseases
+http://purl.obolibrary.org/obo/MONDO_0019586,X-linked nonsyndromic deafness,http://purl.obolibrary.org/obo/MONDO_0019497,nonsyndromic genetic deafness
+http://purl.obolibrary.org/obo/MONDO_0010725,X-linked retinoschisis,http://purl.obolibrary.org/obo/MONDO_0004579,retinoschisis
+http://purl.obolibrary.org/obo/MONDO_0010294,X-linked severe congenital neutropenia,http://purl.obolibrary.org/obo/MONDO_0018542,severe congenital neutropenia
+http://purl.obolibrary.org/obo/MONDO_0010419,X-linked sideroblastic anemia,http://purl.obolibrary.org/obo/MONDO_0015194,sideroblastic anemia
+http://purl.obolibrary.org/obo/MONDO_0010248,X-linked spondyloepimetaphyseal dysplasia,http://purl.obolibrary.org/obo/MONDO_0000844,spondyloepimetaphyseal dysplasia
+http://purl.obolibrary.org/obo/MONDO_0020119,X-linked syndromic intellectual disability,http://purl.obolibrary.org/obo/MONDO_0000508,syndromic intellectual disability
+http://purl.obolibrary.org/obo/MONDO_0010584,"dyskeratosis congenita, X-linked",http://purl.obolibrary.org/obo/MONDO_0015780,dyskeratosis congenita
+http://purl.obolibrary.org/obo/MONDO_0010587,"epidermodysplasia verruciformis, X-linked",http://purl.obolibrary.org/obo/MONDO_0009176,epidermodysplasia verruciformis
+http://purl.obolibrary.org/obo/MONDO_0019181,non-syndromic X-linked intellectual disability,http://purl.obolibrary.org/obo/MONDO_0000509,non-syndromic intellectual disability

--- a/src/patterns/y_linked.csv
+++ b/src/patterns/y_linked.csv
@@ -1,3 +1,3 @@
 iri,iri label,disease,disease label
-MONDO:0000428,Y-linked disease,MONDO:0000001,disease
-MONDO:0010761,retinitis pigmentosa Y-linked,MONDO:0019200,retinitis pigmentosa
+http://purl.obolibrary.org/obo/MONDO_0000428,Y-linked disease,http://purl.obolibrary.org/obo/MONDO_0000001,disease or disorder
+http://purl.obolibrary.org/obo/MONDO_0010761,retinitis pigmentosa Y-linked,http://purl.obolibrary.org/obo/MONDO_0019200,retinitis pigmentosa

--- a/src/plq/mondo_queries.pro
+++ b/src/plq/mondo_queries.pro
@@ -15,6 +15,7 @@
 :- rdf_register_prefix('MEDGEN','http://purl.obolibrary.org/obo/MEDGEN_').
 :- rdf_register_prefix('ONCOTREE','http://purl.obolibrary.org/obo/ONCOTREE_').
 :- rdf_register_prefix('EFO','http://www.ebi.ac.uk/efo/EFO_').
+:- rdf_register_prefix('RO','http://www.ebi.ac.uk/efo/RO_').
 :- rdf_register_prefix('HGNC','http://identifiers.org/hgnc/').
 :- rdf_register_prefix('ICD10','http://purl.obolibrary.org/obo/ICD10_').
 :- rdf_register_prefix('Orphanet','http://www.orpha.net/ORDO/Orphanet_').
@@ -174,14 +175,24 @@ simj_merge_candidates(C1,C2,S,N1,N2) :-
         S > 0.8,
         C1 @< C2.
 
+obsoletion_status(C,S) :-
+        (   deprecated(C)
+        ->  S=deprecated
+        ;   \+ label(C,_)
+        ->  S=not_present
+        ;   S=live).
 
-proxy_merge(C,X1,X2,S) :-
+
+proxy_merge(C,X1,X2,S,Ob1,Ob2) :-
         owl_equivalent_class(C,X1),
         mondo(C),
         owl_equivalent_class(C,X2),
         X1 @< X2,
         uri_prefix(X1,S),
-        uri_prefix(X2,S).
+        uri_prefix(X2,S),
+        obsoletion_status(X1,Ob1),
+        obsoletion_status(X2,Ob2).
+
 
 xref_relation_inferred(C,X,R) :-
         has_dbxref(C,X),


### PR DESCRIPTION
reclassified MONDO:0019079 ‘proximal spinal muscular atrophy’ a subclass of MONDO:0001516 ‘spinal muscular atrophy’ and fixed typos in def of MONDO:0001516 ‘spinal muscular atrophy’
closes #350