### PR TITLE
Fixing Travis build failure, closes #742

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ services:
   - docker
 
 before_install:
-  - sudo apt install jq
-  - env | sort
   # The following triggers the Jenkis build. Shahim is managing this.
   - > 
     export CMTMSG="$(jq -nc --arg str "${TRAVIS_COMMIT_MESSAGE}" '$str')";
@@ -39,9 +37,6 @@ script:
 branches:
   only:
     - master
-    - test-travis
-    - jenkins-setup
-
 ### UNCOMMENT THIS AND ADD YOUR DETAILS:
 #notifications:
 #  email:


### PR DESCRIPTION
Apparently something changed in the build environment that startd
to cause "apt install jq" to fail. I also noticed that jq is already
included in the bionic image so no need to install it anyway.