### PR TITLE
Add Jenkins status icon and add plain branch name parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     --user "essaids:${ShahimAPIToken}" 
     --form json='{
     "parameter": [
+       {"name":"MONDO_BRANCH", "value":"'"${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}"'"},
        {"name":"TRAVIS_BRANCH", "value":"'"${TRAVIS_BRANCH}"'"},
        {"name":"TRAVIS_COMMIT", "value":"'"${TRAVIS_COMMIT}"'"},
        {"name":"TRAVIS_COMMIT_MESSAGE", "value":'"${CMTMSG}"'},

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/monarch-initiative/mondo.svg?branch=master)](https://travis-ci.org/monarch-initiative/mondo)
+[![testing](https://monarch-jenkins.cgrb.oregonstate.edu/buildStatus/icon?subject=Jenkins%20master%20status&job=test-mondo&build=last:${params.MONDO_BRANCH=master})](https://monarch-jenkins.cgrb.oregonstate.edu/job/test-mondo/)
 
 <img src="https://github.com/jmcmurry/closed-illustrations/blob/master/logos/mondo-logos/mondo_logo_black-banner.png"/>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![testing](https://monarch-jenkins.cgrb.oregonstate.edu/buildStatus/icon?subject=Jenkins%20master%20status&job=test-mondo&build=last:${params.MONDO_BRANCH=master})](https://monarch-jenkins.cgrb.oregonstate.edu/job/test-mondo/)
+[![Jenkins master status](https://monarch-jenkins.cgrb.oregonstate.edu/buildStatus/icon?subject=Jenkins%20master%20status&job=test-mondo&build=last:${params.MONDO_BRANCH=master})](https://monarch-jenkins.cgrb.oregonstate.edu/job/test-mondo/)
 
 <img src="https://github.com/jmcmurry/closed-illustrations/blob/master/logos/mondo-logos/mondo_logo_black-banner.png"/>
 


### PR DESCRIPTION
Removed the previous Travis status icon since it is no longer meaningful and
replaced it with an icond that shows the build status for master. The status
will always be for the master branch even if the README.md file is viewed on
GitHub on a different branch.

I also added another Jenkins build parameter that captures just the branch
name that is being built. Travis didn't have such an environment variable to
use.