### PR TITLE
add proper mondo-base

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -24,7 +24,9 @@ SKOS=http://www.w3.org/2004/02/skos/core\#
 EFO=http://www.ebi.ac.uk/efo
 ONT=mondo
 ONTURI=$(OBO)/$(ONT)
-ONTBASE=$(ONT)-base
+ONTBASE=$(OBO)/$(ONT)
+
+
 SRC=$(ONT)-edit.obo
 #RELEASEDIR=../../target/
 ROBOT= robot
@@ -35,6 +37,8 @@ SPARQLDIR = ../sparql
 CONSTRUCTS= embedded-definition
 INCLUDES_OWL = $(patsubst %,include-%.owl,$(CONSTRUCTS))
 ISODATE:=`date +%Y-%m-%d`
+TODAY ?= $(shell date +%Y-%m-%d)
+OBODATE ?= $(shell date +'%d:%m:%Y %H:%M')
 
 FMTS = obo owl json
 
@@ -216,8 +220,15 @@ $(ONT).json: $(ONT).owl
 # Component module.
 # we remove imports and merge in additional assertions
 # note: typically component is not pre-reasoned, but this is compex for mondo.
+
+OTHER_SRC=imports/axioms.owl imports/ecto_import.owl
+
 $(ONT)-base.owl: reasoned.owl
-	$(OWLTOOLS) --use-catalog $< $(patsubst %,--remove-import-declaration $(OBO)/$(ONT)/imports/%_import.owl, $(ONTOLOGY_IMPORTS))  --merge-imports-closure $(REMOVE_DECLARATIONS) --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@
+	$(ROBOT) remove --input $< --select imports --trim false \
+		merge $(patsubst %, -i %, $(OTHER_SRC)) \
+		annotate --annotation http://purl.org/dc/elements/1.1/type http://purl.obolibrary.org/obo/IAO_8000001 \
+		--ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ \
+		--output $@.tmp.owl && mv $@.tmp.owl $@
 
 $(ONT)-base.obo: $(ONT)-base.owl
 	$(OWL2OBO)


### PR DESCRIPTION
Previously the base was missing the now ubiquitous BASE annotation, as well as having the wrong version IRI. This PR should remedy that. But there is more, read on. 

Using the normal ODK ROBOT syntax now (we should really move the Makefile back to normal ODK).

DIFF on the base artefacts:

```
17a18
>         <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/mondo/releases/2020-09-03/mondo-base.owl"/>
18a20
>         <dc:type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.obolibrary.org/obo/IAO_8000001</dc:type>
36,37d37
<         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/mondo/imports/axioms.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 11 Logical Axioms: 3]</rdfs:comment>
<         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/mondo/imports/ecto_import.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 1047 Logical Axioms: 341]</rdfs:comment>
```

However, to replicate the previous behaviour exactly, I hade to _include ECTO in the base_. This is because the ecto module is imported into Mondo, but it does not appear in the `ONTOLOGY_IMPORTS` variable in the Makefile (which was previously used to generate the base).

Now I think thats a mistake, but I wanted to check first:
1. I assume you _do not_ want ECTO in mondo-base (which it is now, check latest releases)
2. I assume that you want the ECTO import to be refreshed? Then we need to add the ECTO module back to `ONTOLOGY_IMPORTS`.
3. Or maybe there was a reason you dont want to update the ECTO import (you dont trust the current ecto version?)