### PR TITLE
MAJOR: Changing mondo.owl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ src/patterns/imports/seed_sorted.txt
 src/ontology/mondo-qc.*
 src/ontology/tmp/
 src/ontology/mondo_current_release.owl
+src/ontology/mondo-with-equivalents.*
+src/ontology/mondo-edit.obo.tmp.obo
+src/ontology/reasoned-plus-equivalents.owl

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -91,7 +91,7 @@ ADDITIONAL_REPORT_FILES = reports/semantic-xref-pairs.tsv
 REPORT_FILES = $(MAIN_REPORT_FILES) $(ADDITIONAL_REPORT_FILES)
 
 
-MAIN_PRODUCTS = $(ONT) $(ONT)-base $(ONT)-with-equivalents.owl
+MAIN_PRODUCTS = $(ONT) $(ONT)-base $(ONT)-with-equivalents
 MAIN_FILES = $(foreach n,$(MAIN_PRODUCTS), $(n).owl $(n).obo $(n).json)
 ARTEFACTS = \
   $(IMPORT_FILES) \
@@ -119,7 +119,7 @@ all_artefacts: all_reports $(ARTEFACTS)
 
 #all: test all_imports all_reports all_equivalencies all_subsets imports/equivalencies.obo $(ONT).owl $(ONT).obo $(ONT).json pre/$(ONT).owl pre/$(ONT).obo pre/$(ONT).json extid/$(ONT).owl extid/$(ONT).obo extid/$(ONT).json $(ONT)-merged.owl
 
-test: sparql_test_edit roundtrip.obo debug.owl mondo-edit.owl sparql_test_main_owl sparql_test_main_obo test_nomerge
+test: sparql_test_edit roundtrip.obo debug.owl mondo-edit.owl sparql_test_main_obo test_nomerge
 
 
 # ----------------------------------------
@@ -205,10 +205,7 @@ reasoned-plus-equivalents.owl: reasoned.owl imports/equivalencies.owl
 # by default we use Elk to perform a reason-relax-reduce chain
 # after that we annotate the ontology with the release versionInfo
 $(ONT).owl: reasoned.owl
-	$(ROBOT) annotate -i $< -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
-
-$(ONT)-with-equivalents.owl: reasoned-plus-equivalents.owl
-	$(ROBOT) annotate -i $< -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
+	$(ROBOT) merge -i $< annotate -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
 
 # obo is self-contained
 $(ONT).obo: reasoned.owl
@@ -216,6 +213,10 @@ $(ONT).obo: reasoned.owl
 $(ONT).json: $(ONT).owl
 	owltools --use-catalog $< -o -f json  $(ONT).json.tmp && mv $(ONT).json.tmp $@
 #	$(ROBOT) convert -i $< -f json -o $(ONT).json.tmp && mv $(ONT).json.tmp $@
+
+$(ONT)-with-equivalents.owl: reasoned-plus-equivalents.owl
+	$(ROBOT) annotate -i $< -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
+
 
 #$(ONT)-atomic.owl: $(ONT).owl
 #	owltools --use-catalog $< --remove-imports-declarations --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@
@@ -233,14 +234,13 @@ $(ONT)-base.owl: reasoned.owl
 		--ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ \
 		--output $@.tmp.owl && mv $@.tmp.owl $@
 
-$(ONT)-base.obo: $(ONT)-base.owl
+$(ONT)-%.obo: $(ONT)-%.owl
 	$(OWL2OBO)
-$(ONT)-base.json: $(ONT)-base.owl
+$(ONT)-%.json: $(ONT)-%.owl
 	robot convert -i $< -o $@.tmp.json && mv $@.tmp.json $@
 
-
-$(ONT)-merged.owl: $(ONT).owl
-	owltools --use-catalog $< --merge-imports-closure --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@
+#$(ONT)-merged.owl: $(ONT).owl
+#	owltools --use-catalog $< --merge-imports-closure --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@
 
 #pre/$(ONT).%: $(ONT).%
 #	$(ROBOT) annotate -i $< -V $(ONTURI)/pre/$(ONT).owl -o $@

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -91,7 +91,7 @@ ADDITIONAL_REPORT_FILES = reports/semantic-xref-pairs.tsv
 REPORT_FILES = $(MAIN_REPORT_FILES) $(ADDITIONAL_REPORT_FILES)
 
 
-MAIN_PRODUCTS = $(ONT) $(ONT)-base
+MAIN_PRODUCTS = $(ONT) $(ONT)-base $(ONT)-with-equivalents.owl
 MAIN_FILES = $(foreach n,$(MAIN_PRODUCTS), $(n).owl $(n).obo $(n).json)
 ARTEFACTS = \
   $(IMPORT_FILES) \
@@ -195,8 +195,7 @@ reasoned.owl: filtered.owl
 	$(ROBOT) reason -T true -x true -X true -i $< -r ELK relax reduce -p false -r ELK $(ANN) -o $@
 
 # merged = reasoned + equivalencies
-# TODO: rename this -plus-equivs
-merged.owl: reasoned.owl imports/equivalencies.owl
+reasoned-plus-equivalents.owl: reasoned.owl imports/equivalencies.owl
 	owltools --use-catalog $^ --merge-support-ontologies -o $@
 
 
@@ -205,7 +204,10 @@ merged.owl: reasoned.owl imports/equivalencies.owl
 #
 # by default we use Elk to perform a reason-relax-reduce chain
 # after that we annotate the ontology with the release versionInfo
-$(ONT).owl: merged.owl
+$(ONT).owl: reasoned.owl
+	$(ROBOT) annotate -i $< -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
+
+$(ONT)-with-equivalents.owl: reasoned-plus-equivalents.owl
 	$(ROBOT) annotate -i $< -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
 
 # obo is self-contained

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -217,6 +217,10 @@ $(ONT).json: $(ONT).owl
 $(ONT)-with-equivalents.owl: reasoned-plus-equivalents.owl
 	$(ROBOT) annotate -i $< -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
 
+$(ONT)-with-equivalents.obo: $(ONT)-with-equivalents.owl
+	$(OWL2OBO)
+$(ONT)-with-equivalents.json: $(ONT)-with-equivalents.owl
+	robot convert -i $< -o $@.tmp.json && mv $@.tmp.json $@
 
 #$(ONT)-atomic.owl: $(ONT).owl
 #	owltools --use-catalog $< --remove-imports-declarations --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@
@@ -234,10 +238,15 @@ $(ONT)-base.owl: reasoned.owl
 		--ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ \
 		--output $@.tmp.owl && mv $@.tmp.owl $@
 
-$(ONT)-%.obo: $(ONT)-%.owl
+$(ONT)-base.obo: $(ONT)-base.owl
 	$(OWL2OBO)
-$(ONT)-%.json: $(ONT)-%.owl
+$(ONT)-base.json: $(ONT)-base.owl
 	robot convert -i $< -o $@.tmp.json && mv $@.tmp.json $@
+
+
+
+xx:
+	$(ROBOT) report -i mondo.owl --fail-on None -o reports/adhoc-report.tsv
 
 #$(ONT)-merged.owl: $(ONT).owl
 #	owltools --use-catalog $< --merge-imports-closure --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -244,13 +244,6 @@ $(ONT)-base.json: $(ONT)-base.owl
 	robot convert -i $< -o $@.tmp.json && mv $@.tmp.json $@
 
 
-
-xx:
-	$(ROBOT) report -i mondo.owl --fail-on None -o reports/adhoc-report.tsv
-
-#$(ONT)-merged.owl: $(ONT).owl
-#	owltools --use-catalog $< --merge-imports-closure --set-ontology-id $(OBO)/$(ONT)/$@ -o $@.tmp && mv $@.tmp $@
-
 #pre/$(ONT).%: $(ONT).%
 #	$(ROBOT) annotate -i $< -V $(ONTURI)/pre/$(ONT).owl -o $@
 #pre/$(ONT).json: $(ONT).owl


### PR DESCRIPTION
This PR:

- removes equivalencies.owl from mondo.owl
- introduces a new artefact called mondo-with-equivalents.owl (which corresponds to the old mondo.owl)
- renames merged.owl (an intermediate artefact) to reasoned-plus-equivalents.owl (as indicated by Makefile todo item)
- turns mondo.owl into a merged product, getting rid of imports altogether
- removing sparql violation tests on monarch.owl - because of the merge, all tests fail now; the tests on the edit file and monarch.obo should be sufficient, and the remaining errors will be dealt with by the new quality control workflow.