### PR TITLE
Adding QC to avoid definitions containing underscore

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -399,7 +399,7 @@ NEWAXTEST: mondo-edit.owl new.owl
 
 # these live in the ../sparql directory, and have suffix -violation.sparql
 # adding the name here will make the violation check live
-CORE_CHECKS =     subclass-cycle equivalent-classes trailing-whitespace owldef-self-reference xref-syntax nolabels undeclared-synonym-type undeclared-subset same-label 
+CORE_CHECKS =     subclass-cycle equivalent-classes trailing-whitespace owldef-self-reference xref-syntax nolabels undeclared-synonym-type undeclared-subset same-label definition-containing-underscore
 EDIT_CHECKS =     $(CORE_CHECKS)
 MAIN_OWL_CHECKS = $(CORE_CHECKS) no-superclass
 MAIN_OBO_CHECKS = $(CORE_CHECKS) no-superclass

--- a/src/sparql/definition-containing-underscore-violation.sparql
+++ b/src/sparql/definition-containing-underscore-violation.sparql
@@ -1,0 +1,11 @@
+# home: hp/sparql/trailing-whitespace-violation.sparql
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+
+SELECT ?term ?x WHERE 
+{
+  ?term IAO:0000115 ?x .
+  FILTER( regex(STR(?x), "_"))
+  FILTER (isIRI(?term) && regex(str(?term), "^http://purl.obolibrary.org/obo/MONDO_"))
+}


### PR DESCRIPTION
fixes #2094

Merge this first:
https://github.com/monarch-initiative/mondo/pull/2102

Right now the violation kicks in, the above has the relevant fix. 