### PR TITLE
Reordered all the patterns

### DIFF
--- a/src/patterns/dosdp-patterns/OMIM_disease_series_by_gene.yaml
+++ b/src/patterns/dosdp-patterns/OMIM_disease_series_by_gene.yaml
@@ -1,61 +1,64 @@
 pattern_name: OMIM_disease_series_by_gene
 
-description: >-
-    
-    This pattern is meant to be used for OMIM diseases, including children of OMIM phenotypic series (OMIMPS), which are represented as grouping classes in Mondo. Notes about the OMIMPS (see also OMIM_phenotypic_series.yaml): 
-    - every instance of the OMIMPS metaclass should be equivalent to (via annotated xref) to something in OMIMPS namespace
-    - the OMIMPS will never have an asserted causative gene as logical axiom (and no single causative gene in text def)
-    - the OMIMPS must never be equivalent to an OMIM:nnnnnn (often redundant with the above rule)
-    - the OMIMPS must have an acronym synonym, e.g. HPE
-    - the OMIMPS must have two or more subclasses (direct or indirect) that are equivalent to OMIMs and conform to this pattern
-    - the subclasses should (not must) have a logical def that uses the PS as a genus 
-    - the OMIM subclasses must have acronym synonyms that are the parent syn + number, e.g. HPE1, HPE2
-    - the primary label for the children should also be parent + {"type"} + number
-    - the first member will usually have the same number local ID as the PS
-    Examples: [holoprosencephaly 1](http://purl.obolibrary.org/obo/MONDO_0009349), [3M syndrome 1](http://purl.obolibrary.org/obo/MONDO_0010117)
-
-classes:
-    disease: MONDO:0000001
-    gene: SO:0000704
-
-relations:
-    disease has basis in dysfunction of: RO:0004020
-
-vars:
-    disease: "'disease'"
-    gene: "'gene'"
-
-name:
-    text: '%s caused by mutation in %s'
-    vars:
-      - disease
-      - gene
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%s %s'
-    vars:
-      - gene
-      - disease
-
-def:
-    text: Any %s in which the cause of the disease is a mutation in the %s gene.
-    vars:
-      - disease
-      - gene
-
-equivalentTo:
-    text: "%s and 'disease has basis in dysfunction of' some %s"
-    vars:
-      - disease
-      - gene
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/disease_series_by_gene.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: '
+
+  This pattern is meant to be used for OMIM diseases, including children of OMIM phenotypic
+  series (OMIMPS), which are represented as grouping classes in Mondo. Notes about
+  the OMIMPS (see also OMIM_phenotypic_series.yaml):  - every instance of the OMIMPS
+  metaclass should be equivalent to (via annotated xref) to something in OMIMPS namespace
+  - the OMIMPS will never have an asserted causative gene as logical axiom (and no
+  single causative gene in text def) - the OMIMPS must never be equivalent to an OMIM:nnnnnn
+  (often redundant with the above rule) - the OMIMPS must have an acronym synonym,
+  e.g. HPE - the OMIMPS must have two or more subclasses (direct or indirect) that
+  are equivalent to OMIMs and conform to this pattern - the subclasses should (not
+  must) have a logical def that uses the PS as a genus  - the OMIM subclasses must
+  have acronym synonyms that are the parent syn + number, e.g. HPE1, HPE2 - the primary
+  label for the children should also be parent + {"type"} + number - the first member
+  will usually have the same number local ID as the PS Examples: [holoprosencephaly
+  1](http://purl.obolibrary.org/obo/MONDO_0009349), [3M syndrome 1](http://purl.obolibrary.org/obo/MONDO_0010117)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  gene: SO:0000704
+
+relations:
+  disease has basis in dysfunction of: RO:0004020
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+  gene: '''gene'''
+
+name:
+  text: '%s caused by mutation in %s'
+  vars:
+  - disease
+  - gene
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%s %s'
+  vars:
+  - gene
+  - disease
+
+def:
+  text: Any %s in which the cause of the disease is a mutation in the %s gene.
+  vars:
+  - disease
+  - gene
+
+equivalentTo:
+  text: '%s and ''disease has basis in dysfunction of'' some %s'
+  vars:
+  - disease
+  - gene

--- a/src/patterns/dosdp-patterns/OMIM_phenotypic_series.yaml
+++ b/src/patterns/dosdp-patterns/OMIM_phenotypic_series.yaml
@@ -1,34 +1,36 @@
 pattern_name: OMIM_phenotypic_series
 
-description: >-
-  This pattern is meant to be used for OMIM phenotypic series (OMIMPS), which are represented as grouping classes in Mondo. Note: 
-  - every instance of this metaclass should be equivalent to (via annotated xref) to something in OMIMPS namespace
-  - it will never have an asserted causative gene as logical axiom (and no single causative gene in text def)
-  - it must never be equivalent to an OMIM:nnnnnn (often redundant with the above rule)
-  - it must have an acronym synonym, e.g. HPE
-  - it must have two or more subclasses (direct or indirect) that are equivalent to OMIMs
-  - the subclasses should (not must) have a logical def that uses the PS as a genus (see https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/disease_series_by_gene.yaml)
-  - the OMIM subclasses must have acronym synonyms that are the parent syn + number, e.g. HPE1, HPE2
-  - the primary label for the children should also be parent + {"type"} + number
-  - the first member will usually have the same number local ID as the PS
-  - the first member in OMIM usually has documentation that is pertinent to the parent PS
-  - the members may(?) generally share high semantic similarity
-
-  Examples: [holoprosencephaly](http://purl.obolibrary.org/obo/MONDO_0016296) [OMIMPS:236100](https://omim.org/phenotypicSeries/PS236100), '3-M syndrome'(http://purl.obolibrary.org/obo/MONDO_0007477) [OMIMPS:236100](https://omim.org/phenotypicSeries/PS273750). 
-
-classes:
-    disease: MONDO:0000001
-
-vars:
-    disease: "'disease'"
-
-name:
-    text: '%s'
-    vars:
-      - disease
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/OMIM_phenotypic_series.yaml
 
+description: 'This pattern is meant to be used for OMIM phenotypic series (OMIMPS),
+  which are represented as grouping classes in Mondo. Note:  - every instance of this
+  metaclass should be equivalent to (via annotated xref) to something in OMIMPS namespace
+  - it will never have an asserted causative gene as logical axiom (and no single
+  causative gene in text def) - it must never be equivalent to an OMIM:nnnnnn (often
+  redundant with the above rule) - it must have an acronym synonym, e.g. HPE - it
+  must have two or more subclasses (direct or indirect) that are equivalent to OMIMs
+  - the subclasses should (not must) have a logical def that uses the PS as a genus
+  (see https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/disease_series_by_gene.yaml)
+  - the OMIM subclasses must have acronym synonyms that are the parent syn + number,
+  e.g. HPE1, HPE2 - the primary label for the children should also be parent + {"type"}
+  + number - the first member will usually have the same number local ID as the PS
+  - the first member in OMIM usually has documentation that is pertinent to the parent
+  PS - the members may(?) generally share high semantic similarity
+
+  Examples: [holoprosencephaly](http://purl.obolibrary.org/obo/MONDO_0016296) [OMIMPS:236100](https://omim.org/phenotypicSeries/PS236100),
+  ''3-M syndrome''(http://purl.obolibrary.org/obo/MONDO_0007477) [OMIMPS:236100](https://omim.org/phenotypicSeries/PS273750). '
+
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+
+vars:
+  disease: '''disease'''
+
+name:
+  text: '%s'
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/acquired.yaml
+++ b/src/patterns/dosdp-patterns/acquired.yaml
@@ -1,46 +1,45 @@
 pattern_name: acquired
 
-description: >-
-    Pattern for extending a etiology-generic disease class to an
-    acquired form.  Here acquired means that basis for the disease
-    is acquired during the individuals lifetime. It need not exclude
-    genetic etiology, but it excludes inherited.
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/acquired.yaml
+
+description: Pattern for extending a etiology-generic disease class to an acquired
+  form.  Here acquired means that basis for the disease is acquired during the individuals
+  lifetime. It need not exclude genetic etiology, but it excludes inherited.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    acquired: MONDO:0021141
+  acquired: MONDO:0021141
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: acquired %s
-    vars:
-      - disease
+  text: acquired %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: acquired %s
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: acquired %s
+  vars:
+  - disease
 
 def:
-    text: An instance of %s that is acquired during the lifetime of the individual.
-    vars:
-      - disease
+  text: An instance of %s that is acquired during the lifetime of the individual.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'acquired'"
-    vars:
-      - disease
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/acquired.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''acquired'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/acute.yaml
+++ b/src/patterns/dosdp-patterns/acute.yaml
@@ -1,40 +1,43 @@
 pattern_name: acute
 
-classes:
-    acute: PATO:0000389
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/acute.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  acute: PATO:0000389
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: acute %s
-    vars:
-      - disease
+  text: acute %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, acute'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, acute'
+  vars:
+  - disease
 
 def:
-    text: Acute form of %s.
-    vars:
-      - disease
+  text: Acute form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'acute'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/acute.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''acute'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/adenocarcinoma.yaml
+++ b/src/patterns/dosdp-patterns/adenocarcinoma.yaml
@@ -1,57 +1,51 @@
 pattern_name: adenocarcinoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/adenocarcinoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [adenocarcinoma of cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016275),
-    [pituitary adenocarcinoma (disease)](http://purl.obolibrary.org/obo/MONDO_0017582),
-    [ureter adenocarcinoma](http://purl.obolibrary.org/obo/MONDO_0003216) (56 total)
+  Examples: [adenocarcinoma of cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016275),
+  [pituitary adenocarcinoma (disease)](http://purl.obolibrary.org/obo/MONDO_0017582),
+  [ureter adenocarcinoma](http://purl.obolibrary.org/obo/MONDO_0003216) (56 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    adenocarcinoma: MONDO:0004970
+  adenocarcinoma: MONDO:0004970
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.5714285714285714, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s adenocarcinoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.35714285714285715, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A carcinoma that arises from glandular epithelial cells of the %s
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s adenocarcinoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s adenocarcinoma'
-    vars:
-      - v0
-  - annotationProperty: related_synonym
-    # Induced p=related_synonym 
-    text: adenocarcinoma of %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s adenocarcinoma'
+  vars:
+  - v0
+- annotationProperty: related_synonym
+  text: adenocarcinoma of %s
+  vars:
+  - v0
 
+def:
+  text: A carcinoma that arises from glandular epithelial cells of the %s
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'adenocarcinoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''adenocarcinoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/adenoma.yaml
+++ b/src/patterns/dosdp-patterns/adenoma.yaml
@@ -1,57 +1,51 @@
 pattern_name: adenoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/adenoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [pituitary gland adenoma](http://purl.obolibrary.org/obo/MONDO_0006373),
-    [breast adenoma](http://purl.obolibrary.org/obo/MONDO_0002058), [Bartholin gland
-    adenoma](http://purl.obolibrary.org/obo/MONDO_0003419) (31 total)
+  Examples: [pituitary gland adenoma](http://purl.obolibrary.org/obo/MONDO_0006373),
+  [breast adenoma](http://purl.obolibrary.org/obo/MONDO_0002058), [Bartholin gland
+  adenoma](http://purl.obolibrary.org/obo/MONDO_0003419) (31 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    adenoma: MONDO:0004972
+  adenoma: MONDO:0004972
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.6129032258064516, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s adenoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.16129032258064516, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A adenoma that involves the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s adenoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s adenoma'
-    vars:
-      - v0
-  - annotationProperty: related_synonym
-    # Induced p=related_synonym 
-    text: adenoma of %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s adenoma'
+  vars:
+  - v0
+- annotationProperty: related_synonym
+  text: adenoma of %s
+  vars:
+  - v0
 
+def:
+  text: A adenoma that involves the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'adenoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''adenoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/adenosquamous_carcinoma.yaml
+++ b/src/patterns/dosdp-patterns/adenosquamous_carcinoma.yaml
@@ -1,54 +1,49 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: adenosquamous carcinoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/adenosquamous_carcinoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [adenosquamous breast carcinoma](http://purl.obolibrary.org/obo/MONDO_0003548),
-    [Bartholin's gland adenosquamous carcinoma](http://purl.obolibrary.org/obo/MONDO_0003555),
-    [gastric adenosquamous carcinoma](http://purl.obolibrary.org/obo/MONDO_0006034)
-    (16 total)
+  Examples: [adenosquamous breast carcinoma](http://purl.obolibrary.org/obo/MONDO_0003548),
+  [Bartholin''s gland adenosquamous carcinoma](http://purl.obolibrary.org/obo/MONDO_0003555),
+  [gastric adenosquamous carcinoma](http://purl.obolibrary.org/obo/MONDO_0006034)
+  (16 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    adenosquamous carcinoma: MONDO:0006074
-    multicellular anatomical structure: UBERON:0010000
-
+  adenosquamous carcinoma: MONDO:0006074
+  multicellular anatomical structure: UBERON:0010000
 
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: "'multicellular anatomical structure'"
-
-name:
-  # Induced, frequency=0.3125, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s adenosquamous carcinoma'
-    vars:
-      - v0
-
-def:
-    text: Any carcinoma that that involves the %s and is characterized by the presence
-        of glandular and squamous malignant epithelial components.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: '''multicellular anatomical structure'''
+
+name:
+  text: '%s adenosquamous carcinoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: adenosquamous %s carcinoma
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: adenosquamous %s carcinoma
+  vars:
+  - v0
 
+def:
+  text: Any carcinoma that that involves the %s and is characterized by the presence
+    of glandular and squamous malignant epithelial components.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'adenosquamous carcinoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''adenosquamous carcinoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/adult.yaml
+++ b/src/patterns/dosdp-patterns/adult.yaml
@@ -1,40 +1,43 @@
 pattern_name: adult
 
-classes:
-    adult: HP:0003581
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/adult.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  adult: HP:0003581
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: adult %s
-    vars:
-      - disease
+  text: adult %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s of adults'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s of adults'
+  vars:
+  - disease
 
 def:
-    text: A %s that occurs in an adult.
-    vars:
-      - disease
+  text: A %s that occurs in an adult.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'adult'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/adult.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''adult'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/allergic_form_of_disease.yaml
+++ b/src/patterns/dosdp-patterns/allergic_form_of_disease.yaml
@@ -1,48 +1,52 @@
 pattern_name: allergic_form_of_disease
 
-description: >4-
-
-    An etiological pattern that extends an etiology-generic disease to an allergic form (i.e. caused by pathological type I hypersensitivity reaction). The [allergy.yaml](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/allergy.yaml) pattern is to refine an existing disease by trigger.
-
-    Examples: [allergic respiratory disease](http://purl.obolibrary.org/obo/MONDO_0000771), [atopic eczema](http://purl.obolibrary.org/obo/MONDO_0004980), [allergic otitis media](http://purl.obolibrary.org/obo/MONDO_0021202)
-
-classes:
-    disease: MONDO:0000001
-    type I hypersensitivity: GO:0016068
-
-relations:
-    disease has basis in disruption of: RO:0004021
-
-vars:
-    disease: "'disease'"
-
-name:
-    text: allergic %s
-    vars:
-      - disease
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: allergic form of %s
-    vars:
-      - disease
-
-def:
-    text: A %s with a basis in a pathological type I hypersensitivity reaction.
-    vars:
-      - disease
-
-equivalentTo:
-    text: "%s and 'disease has basis in disruption of' some 'type I hypersensitivity'"
-    vars:
-      - disease
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/allergic_form_of_disease.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: '
+
+  An etiological pattern that extends an etiology-generic disease to an allergic form
+  (i.e. caused by pathological type I hypersensitivity reaction). The [allergy.yaml](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/allergy.yaml)
+  pattern is to refine an existing disease by trigger.
+
+  Examples: [allergic respiratory disease](http://purl.obolibrary.org/obo/MONDO_0000771),
+  [atopic eczema](http://purl.obolibrary.org/obo/MONDO_0004980), [allergic otitis
+  media](http://purl.obolibrary.org/obo/MONDO_0021202)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  type I hypersensitivity: GO:0016068
+
+relations:
+  disease has basis in disruption of: RO:0004021
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+
+name:
+  text: allergic %s
+  vars:
+  - disease
+
+annotations:
+- annotationProperty: exact_synonym
+  text: allergic form of %s
+  vars:
+  - disease
+
+def:
+  text: A %s with a basis in a pathological type I hypersensitivity reaction.
+  vars:
+  - disease
+
+equivalentTo:
+  text: '%s and ''disease has basis in disruption of'' some ''type I hypersensitivity'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/allergy.yaml
+++ b/src/patterns/dosdp-patterns/allergy.yaml
@@ -1,48 +1,51 @@
 pattern_name: allergy
 
-description: >4-
-
-    Allergy classified according to allergic trigger. This pattern is to refine an existing disease by trigger, the [allergic_form_of_disease.yaml](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/allergic_form_of_disease.yaml) pattern is for a generic disease.
-    
-    Examples: [egg allergy](http://purl.obolibrary.org/obo/MONDO_0005741), [peach allergy](http://purl.obolibrary.org/obo/MONDO_0000785), [gluten allergy](http://purl.obolibrary.org/obo/MONDO_0000606)
-
-classes:
-    allergic disease: MONDO:0005271
-
-    owl_thing: owl:Thing
-relations:
-    realized in response to stimulus: RO:0004028
-
-vars:
-    substance: owl_thing
-
-name:
-    text: '%s allergic disease'
-    vars:
-      - substance
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: allergy of %s
-    vars:
-      - substance
-
-def:
-    text: A allergic disease involving a %s.
-    vars:
-      - substance
-
-equivalentTo:
-    text: "'allergic disease' and 'realized in response to stimulus' some %s"
-    vars:
-      - substance
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/allergy.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: '
+
+  Allergy classified according to allergic trigger. This pattern is to refine an existing
+  disease by trigger, the [allergic_form_of_disease.yaml](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/allergic_form_of_disease.yaml)
+  pattern is for a generic disease.
+
+  Examples: [egg allergy](http://purl.obolibrary.org/obo/MONDO_0005741), [peach allergy](http://purl.obolibrary.org/obo/MONDO_0000785),
+  [gluten allergy](http://purl.obolibrary.org/obo/MONDO_0000606)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  allergic disease: MONDO:0005271
+  owl_thing: owl:Thing
+
+relations:
+  realized in response to stimulus: RO:0004028
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  substance: owl_thing
+
+name:
+  text: '%s allergic disease'
+  vars:
+  - substance
+
+annotations:
+- annotationProperty: exact_synonym
+  text: allergy of %s
+  vars:
+  - substance
+
+def:
+  text: A allergic disease involving a %s.
+  vars:
+  - substance
+
+equivalentTo:
+  text: '''allergic disease'' and ''realized in response to stimulus'' some %s'
+  vars:
+  - substance

--- a/src/patterns/dosdp-patterns/autoimmune.yaml
+++ b/src/patterns/dosdp-patterns/autoimmune.yaml
@@ -1,35 +1,37 @@
 pattern_name: autoimmune
 
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autoimmune.yaml
+
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
 classes:
-    disease: MONDO:0000001
-    autoimmunity: HP:0002960
+  disease: MONDO:0000001
+  autoimmunity: HP:0002960
 
 relations:
-    disease arises from feature: RO:0004022
+  disease arises from feature: RO:0004022
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: "'disease'"
+  disease: '''disease'''
 
 name:
-    text: autoimmune %s
-    vars:
-      - disease
+  text: autoimmune %s
+  vars:
+  - disease
 
 def:
-    text: An autoimmune form of %s.
-    vars:
-      - disease
+  text: An autoimmune form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'disease arises from feature' some 'autoimmunity'"
-    vars:
-      - disease
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autoimmune.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''disease arises from feature'' some ''autoimmunity'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/autoimmune_inflammation.yaml
+++ b/src/patterns/dosdp-patterns/autoimmune_inflammation.yaml
@@ -1,36 +1,38 @@
 pattern_name: autoimmune_inflammation
 
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autoimmune_inflammation.yaml
+
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
 classes:
-    autoimmune disease: MONDO:0007179
-    anatomical structure: UBERON:0000061
+  autoimmune disease: MONDO:0007179
+  anatomical structure: UBERON:0000061
 
 relations:
-    disease has inflammation site: RO:0004027
+  disease has inflammation site: RO:0004027
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: "'anatomical structure'"
+  location: '''anatomical structure'''
 
 name:
-    text: autoimmune %s inflammation
-    vars:
-      - location
+  text: autoimmune %s inflammation
+  vars:
+  - location
 
 def:
-    text: An autoimmune inflammatory disease involving a pathogenic inflammatory response
-        in the %s.
-    vars:
-      - location
+  text: An autoimmune inflammatory disease involving a pathogenic inflammatory response
+    in the %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'autoimmune disease' and 'disease has inflammation site' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autoimmune_inflammation.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''autoimmune disease'' and ''disease has inflammation site'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/autosomal_dominant.yaml
+++ b/src/patterns/dosdp-patterns/autosomal_dominant.yaml
@@ -1,39 +1,43 @@
 pattern_name: autosomal_dominant
 
-classes:
-    autosomal dominant inheritance: HP:0000006
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autosomal_dominant.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  autosomal dominant inheritance: HP:0000006
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
+
 name:
-    text: autosomal dominant %s
-    vars:
-      - disease
+  text: autosomal dominant %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, autosomal dominant'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, autosomal dominant'
+  vars:
+  - disease
 
 def:
-    text: Autosomal dominant form of %s.
-    vars:
-      - disease
+  text: Autosomal dominant form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'autosomal dominant inheritance'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autosomal_dominant.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''autosomal dominant inheritance'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/autosomal_recessive.yaml
+++ b/src/patterns/dosdp-patterns/autosomal_recessive.yaml
@@ -1,40 +1,43 @@
 pattern_name: autosomal_recessive
 
-classes:
-    autosomal recessive inheritance: HP:0000007
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autosomal_recessive.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  autosomal recessive inheritance: HP:0000007
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: autosomal recessive %s
-    vars:
-      - disease
+  text: autosomal recessive %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, autosomal recessive'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, autosomal recessive'
+  vars:
+  - disease
 
 def:
-    text: Autosomal recessive form of %s.
-    vars:
-      - disease
+  text: Autosomal recessive form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'autosomal recessive inheritance'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/autosomal_recessive.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''autosomal recessive inheritance'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/basis_in_disruption_of_process.yaml
+++ b/src/patterns/dosdp-patterns/basis_in_disruption_of_process.yaml
@@ -1,48 +1,48 @@
 pattern_name: basis_in_disruption_of_process
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/basis_in_disruption_of_process.yaml
 
-    A pattern for generic groupings of diseases based around the molecular basis
-    for the disease in terms of a GO molecular function or cellular process.
+description: '
 
-    For example: DNA repair or RAS signaling
+  A pattern for generic groupings of diseases based around the molecular basis for
+  the disease in terms of a GO molecular function or cellular process.
+
+  For example: DNA repair or RAS signaling'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    disease: MONDO:0000001
-    process: BFO:0000015
+  disease: MONDO:0000001
+  process: BFO:0000015
 
 relations:
-    disease has basis in disruption of: RO:0004021
+  disease has basis in disruption of: RO:0004021
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    process: "'process'"
+  process: '''process'''
 
 name:
-    text: '%s disease'
-    vars:
-      - process
+  text: '%s disease'
+  vars:
+  - process
 
 annotations:
-  - annotationProperty: related_synonym
-    text: disorder of %s
-    vars:
-      - process
+- annotationProperty: related_synonym
+  text: disorder of %s
+  vars:
+  - process
 
 def:
-    text: A disease that has its basis in the disruption of %s.
-    vars:
-      - process
+  text: A disease that has its basis in the disruption of %s.
+  vars:
+  - process
 
 equivalentTo:
-    text: "'disease' and 'disease has basis in disruption of' some %s"
-    vars:
-      - process
-
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/basis_in_disruption_of_process.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''disease'' and ''disease has basis in disruption of'' some %s'
+  vars:
+  - process

--- a/src/patterns/dosdp-patterns/benign.yaml
+++ b/src/patterns/dosdp-patterns/benign.yaml
@@ -1,48 +1,49 @@
 pattern_name: benign
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/benign.yaml
 
-    This is a design pattern for classes representing benign neoplasms, extending
-    a generic neoplasm class. For example, a benign adrenal gland pheochromocytoma,
-    defined as being the benign form of the more general adrenal gland pheochromocytoma.
+description: '
 
-    TODO: encode alternate way of representing
+  This is a design pattern for classes representing benign neoplasms, extending a
+  generic neoplasm class. For example, a benign adrenal gland pheochromocytoma, defined
+  as being the benign form of the more general adrenal gland pheochromocytoma.
+
+  TODO: encode alternate way of representing'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    neoplasm: MONDO:0005070
-    neoplastic, non-malignant: PATO:0002096
+  neoplasm: MONDO:0005070
+  neoplastic, non-malignant: PATO:0002096
 
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    neoplasm: "'neoplasm'"
+  neoplasm: '''neoplasm'''
 
 name:
-    text: benign %s
-    vars:
-      - neoplasm
+  text: benign %s
+  vars:
+  - neoplasm
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, benign'
-    vars:
-      - neoplasm
+- annotationProperty: exact_synonym
+  text: '%s, benign'
+  vars:
+  - neoplasm
 
 def:
-    text: A form of %s without malignant characteristics.
-    vars:
-      - neoplasm
+  text: A form of %s without malignant characteristics.
+  vars:
+  - neoplasm
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'neoplastic, non-malignant'"
-    vars:
-      - neoplasm
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/benign.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''neoplastic, non-malignant'''
+  vars:
+  - neoplasm

--- a/src/patterns/dosdp-patterns/benign_neoplasm.yaml
+++ b/src/patterns/dosdp-patterns/benign_neoplasm.yaml
@@ -1,66 +1,67 @@
 pattern_name: benign_neoplasm
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/benign_neoplasm.yaml
 
-    Neoplasms are benign or malignant tissue growths resulting from
-    uncontrolled cell proliferation cell types.
+description: '
 
-    This is a design pattern for classes representing *benign* neoplasms based on
-    their location.
+  Neoplasms are benign or malignant tissue growths resulting from uncontrolled cell
+  proliferation cell types.
 
-    See also: benign.yaml TODO: choose one over another
+  This is a design pattern for classes representing *benign* neoplasms based on their
+  location.
+
+  See also: benign.yaml TODO: choose one over another'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    benign neoplasm: MONDO:0005165
+  benign neoplasm: MONDO:0005165
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: benign %s neoplasm
-    vars:
-      - location
+  text: benign %s neoplasm
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s benign neoplasm'
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s benign tumor'
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: benign neoplasm of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: benign %s tumor
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s neoplasm, benign'
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: '%s benign neoplasm'
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s benign tumor'
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: benign neoplasm of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: benign %s tumor
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s neoplasm, benign'
+  vars:
+  - location
 
 def:
-    text: A benign neoplasm involving a %s.
-    vars:
-      - location
+  text: A benign neoplasm involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'benign neoplasm' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/benign_neoplasm.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''benign neoplasm'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/cancer.yaml
+++ b/src/patterns/dosdp-patterns/cancer.yaml
@@ -1,61 +1,60 @@
 pattern_name: cancer
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/cancer.yaml
 
-    Cancers are malignant neoplasms arising from a variety of different
-    cell types.
+description: '
 
-    This is a design pattern for classes representing cancers based
-    on their location. This may be the site of origin, but it can also
-    represent a secondary site for metastatized cancer.
+  Cancers are malignant neoplasms arising from a variety of different cell types.
 
-    We use the generic 'disease has location' relation, which
-    generalized over primary and secondary sites.
+  This is a design pattern for classes representing cancers based on their location.
+  This may be the site of origin, but it can also represent a secondary site for metastatized
+  cancer.
+
+  We use the generic ''disease has location'' relation, which generalized over primary
+  and secondary sites.'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    cancer: MONDO:0004992
+  cancer: MONDO:0004992
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s cancer'
-    vars:
-      - location
+  text: '%s cancer'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: malignant %s neoplasm
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: malignant neoplasm of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: cancer of %s
-    vars:
-      - location
-
+- annotationProperty: exact_synonym
+  text: malignant %s neoplasm
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: malignant neoplasm of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: cancer of %s
+  vars:
+  - location
 
 def:
-    text: A cancer involving a %s.
-    vars:
-      - location
+  text: A cancer involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'cancer' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/cancer.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''cancer'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/carcinoma.yaml
+++ b/src/patterns/dosdp-patterns/carcinoma.yaml
@@ -1,51 +1,52 @@
 pattern_name: carcinoma
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/carcinoma.yaml
 
-    Carcinomas are malignant neoplasms arising from epithelial cells.
+description: '
 
-    This is a Design pattern for classes representing carcinomas based
-    on their location. This may be the site of origin, but it can also
-    represent a secondary site for metastatized cancer.
+  Carcinomas are malignant neoplasms arising from epithelial cells.
 
-    We use the generic 'disease has location' relation, which
-    generalized over primary and secondary sites.
+  This is a Design pattern for classes representing carcinomas based on their location.
+  This may be the site of origin, but it can also represent a secondary site for metastatized
+  cancer.
+
+  We use the generic ''disease has location'' relation, which generalized over primary
+  and secondary sites.'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    carcinoma: MONDO:0004993
+  carcinoma: MONDO:0004993
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s carcinoma'
-    vars:
-      - location
+  text: '%s carcinoma'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: carcinoma of %s
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: carcinoma of %s
+  vars:
+  - location
 
 def:
-    text: A carcinoma involving a %s.
-    vars:
-      - location
+  text: A carcinoma involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'carcinoma' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/carcinoma.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''carcinoma'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/carcinoma_in_situ.yaml
+++ b/src/patterns/dosdp-patterns/carcinoma_in_situ.yaml
@@ -1,49 +1,51 @@
 pattern_name: carcinoma_in_situ
 
-classes:
-    carcinoma in situ: MONDO:0004647
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/carcinoma_in_situ.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  carcinoma in situ: MONDO:0004647
+  owl_thing: owl:Thing
+
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s carcinoma in situ'
-    vars:
-      - location
+  text: '%s carcinoma in situ'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: carcinoma in situ of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: non-invasic %s carcinoma
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: stage 0 %s carcinoma
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: carcinoma in situ of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: non-invasic %s carcinoma
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: stage 0 %s carcinoma
+  vars:
+  - location
 
 def:
-    text: A carcinoma in situ involving a %s.
-    vars:
-      - location
+  text: A carcinoma in situ involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'carcinoma in situ' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/carcinoma_in_situ.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''carcinoma in situ'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/childhood.yaml
+++ b/src/patterns/dosdp-patterns/childhood.yaml
@@ -1,44 +1,47 @@
 pattern_name: childhood
 
-classes:
-    childhood: HP:0011463
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/childhood.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  childhood: HP:0011463
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: childhood %s
-    vars:
-      - disease
+  text: childhood %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s of childhood'
-    vars:
-      - disease
-  - annotationProperty: related_synonym
-    text: pediatric %s
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s of childhood'
+  vars:
+  - disease
+- annotationProperty: related_synonym
+  text: pediatric %s
+  vars:
+  - disease
 
 def:
-    text: A %s that occurs during childhood.
-    vars:
-      - disease
+  text: A %s that occurs during childhood.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'childhood'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/childhood.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''childhood'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/chronic.yaml
+++ b/src/patterns/dosdp-patterns/chronic.yaml
@@ -1,40 +1,43 @@
 pattern_name: chronic
 
-classes:
-    chronic: PATO:0001863
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/chronic.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  chronic: PATO:0001863
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: chronic %s
-    vars:
-      - disease
+  text: chronic %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, chronic'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, chronic'
+  vars:
+  - disease
 
 def:
-    text: Chronic form of %s.
-    vars:
-      - disease
+  text: Chronic form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'chronic'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/chronic.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''chronic'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/congenital.yaml
+++ b/src/patterns/dosdp-patterns/congenital.yaml
@@ -1,40 +1,43 @@
 pattern_name: congenital
 
-classes:
-    congenital: MONDO:0021140
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/congenital.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  congenital: MONDO:0021140
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: congenital %s
-    vars:
-      - disease
+  text: congenital %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: congenital %s
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: congenital %s
+  vars:
+  - disease
 
 def:
-    text: An instance of %s that is present from birth.
-    vars:
-      - disease
+  text: An instance of %s that is present from birth.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'congenital'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/congenital.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''congenital'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/consequence_of_infectious_disease.yaml
+++ b/src/patterns/dosdp-patterns/consequence_of_infectious_disease.yaml
@@ -1,42 +1,41 @@
 pattern_name: consequence_of_infectious_disease
 
-classes:
-    disease: MONDO:0000001
-    infectious disease: MONDO:0005550
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/consequence_of_infectious_disease.yaml
 
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  disease: MONDO:0000001
+  infectious disease: MONDO:0005550
 
 relations:
-    disease arises from feature: RO:0004022
+  disease arises from feature: RO:0004022
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    parent: disease
-    cause: "'infectious disease'"
+  parent: disease
+  cause: '''infectious disease'''
 
 name:
-    text: '%s %s'
-    vars:
-      - cause
-      - parent
-
+  text: '%s %s'
+  vars:
+  - cause
+  - parent
 
 def:
-    text: A %s that arises as a consequence of %s.
-    vars:
-      - parent
-      - cause
+  text: A %s that arises as a consequence of %s.
+  vars:
+  - parent
+  - cause
 
 equivalentTo:
-    text: "%s and 'disease arises from feature' some %s"
-    vars:
-      - parent
-      - cause
-
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/consequence_of_infectious_disease.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''disease arises from feature'' some %s'
+  vars:
+  - parent
+  - cause

--- a/src/patterns/dosdp-patterns/disease_by_dysfunctional_structure.yaml
+++ b/src/patterns/dosdp-patterns/disease_by_dysfunctional_structure.yaml
@@ -1,46 +1,47 @@
 pattern_name: disease_by_dysfunctional_structure
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/disease_by_dysfunctional_structure.yaml
 
-    Diseases classified by a perturbation in an anatomical structure
-    (such as a subcellular component, or an organ)
+description: '
+
+  Diseases classified by a perturbation in an anatomical structure (such as a subcellular
+  component, or an organ)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    disease: MONDO:0000001
-    anatomical structure: UBERON:0000061
+  disease: MONDO:0000001
+  anatomical structure: UBERON:0000061
 
 relations:
-    disease has basis in dysfunction of: RO:0004020
+  disease has basis in dysfunction of: RO:0004020
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    structure: "'anatomical structure'"
+  structure: '''anatomical structure'''
 
 name:
-    text: '%s disease'
-    vars:
-      - structure
+  text: '%s disease'
+  vars:
+  - structure
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: disease of %s
-    vars:
-      - structure
+- annotationProperty: exact_synonym
+  text: disease of %s
+  vars:
+  - structure
 
 def:
-    text: Any disease in which the causes of the disease is a perturbation of the
-        %s leading to its dysfunction.
-    vars:
-      - structure
+  text: Any disease in which the causes of the disease is a perturbation of the %s
+    leading to its dysfunction.
+  vars:
+  - structure
 
 equivalentTo:
-    text: "'disease' and 'disease has basis in dysfunction of' some %s"
-    vars:
-      - structure
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/disease_by_dysfunctional_structure.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''disease'' and ''disease has basis in dysfunction of'' some %s'
+  vars:
+  - structure

--- a/src/patterns/dosdp-patterns/disease_series_by_gene.yaml
+++ b/src/patterns/dosdp-patterns/disease_series_by_gene.yaml
@@ -1,57 +1,59 @@
 pattern_name: disease_series_by_gene
 
-description: >-
-  This pattern is for diseases that are caused by a single mutation in a single gene, that have gene-based names, such as new disease terms that are requested by ClinGen, like MED12-related intellectual disability syndrome. 
-  Examples: [MED12-related intellectual disability syndrome](http://purl.obolibrary.org/obo/MONDO_0100000), [TTN-related myopathy](http://purl.obolibrary.org/obo/MONDO_0100175), [MYPN-related myopathy](http://purl.obolibrary.org/obo/MONDO_0015023)
-
-classes:
-    disease: MONDO:0000001
-    gene: SO:0001217
-
-relations:
-    disease has basis in dysfunction of: RO:0004020
-
-vars:
-    disease: "'disease'"
-    gene: "'gene'"
-
-name:
-    text: '%s caused by mutation in %s'
-    vars:
-      - disease
-      - gene
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%s %s'
-    vars:
-      - gene
-      - disease
-  - annotationProperty: exact_synonym
-    text: '%s related %s'
-    vars:
-      - gene
-      - disease
-      
-def:
-    text: Any %s in which the cause of the disease is a mutation in the %s gene.
-    vars:
-      - disease
-      - gene
-
-
-equivalentTo:
-    text: "%s and 'disease has basis in dysfunction of' some %s"
-    vars:
-      - disease
-      - gene
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/disease_series_by_gene.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: 'This pattern is for diseases that are caused by a single mutation in
+  a single gene, that have gene-based names, such as new disease terms that are requested
+  by ClinGen, like MED12-related intellectual disability syndrome.  Examples: [MED12-related
+  intellectual disability syndrome](http://purl.obolibrary.org/obo/MONDO_0100000),
+  [TTN-related myopathy](http://purl.obolibrary.org/obo/MONDO_0100175), [MYPN-related
+  myopathy](http://purl.obolibrary.org/obo/MONDO_0015023)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  gene: SO:0001217
+
+relations:
+  disease has basis in dysfunction of: RO:0004020
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+  gene: '''gene'''
+
+name:
+  text: '%s caused by mutation in %s'
+  vars:
+  - disease
+  - gene
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%s %s'
+  vars:
+  - gene
+  - disease
+- annotationProperty: exact_synonym
+  text: '%s related %s'
+  vars:
+  - gene
+  - disease
+
+def:
+  text: Any %s in which the cause of the disease is a mutation in the %s gene.
+  vars:
+  - disease
+  - gene
+
+equivalentTo:
+  text: '%s and ''disease has basis in dysfunction of'' some %s'
+  vars:
+  - disease
+  - gene

--- a/src/patterns/dosdp-patterns/disrupts_process.yaml
+++ b/src/patterns/dosdp-patterns/disrupts_process.yaml
@@ -1,53 +1,48 @@
 pattern_name: disease or disorder disease caused by disruption of X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/disrupts_process.yaml
 
-description: >-
-    A disease that disrupts a process, like immune system function, or early development.
+description: 'A disease that disrupts a process, like immune system function, or early
+  development.
 
-    Examples: [type III hypersensitivity disease](http://purl.obolibrary.org/obo/MONDO_0007004),
-    [type IV hypersensitivity disease](http://purl.obolibrary.org/obo/MONDO_0002459),
-    [neural tube closure defect](http://purl.obolibrary.org/obo/MONDO_0017059) (55
-    total)
+  Examples: [type III hypersensitivity disease](http://purl.obolibrary.org/obo/MONDO_0007004),
+  [type IV hypersensitivity disease](http://purl.obolibrary.org/obo/MONDO_0002459),
+  [neural tube closure defect](http://purl.obolibrary.org/obo/MONDO_0017059) (55 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    disease or disorder: MONDO:0000001
+  disease or disorder: MONDO:0000001
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease caused by disruption of: RO:0004021
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.38181818181818183, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s disease'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.38181818181818183, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A disease that has its basis in the disruption of %s.
-    vars:
-      - v0
+  disease caused by disruption of: RO:0004021
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s disease'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: disorder of %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: disorder of %s
+  vars:
+  - v0
 
+def:
+  text: A disease that has its basis in the disruption of %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'disease or disorder' and ('disease caused by disruption of' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''disease or disorder'' and (''disease caused by disruption of'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/environmental_stimulus.yaml
+++ b/src/patterns/dosdp-patterns/environmental_stimulus.yaml
@@ -1,51 +1,52 @@
 pattern_name: environmental_stimulus
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/environmental_stimulus.yaml
 
-description: >-
-    A disease that is caused by exposure to an environmental stimulus, like the sun or pesticides. 
-    Examples: [carbon monoxide-induced parkinsonism](http://purl.obolibrary.org/obo/MONDO_0017639), [cocaine intoxication](http://purl.obolibrary.org/obo/MONDO_0019544), [Colorado tick fever](http://purl.obolibrary.org/obo/MONDO_0005708)
-
-classes:
-    disease: MONDO:0000001
-    material entity: BFO:0000040
-
-relations:
-    realized in response to stimulus: RO:0004028
-
-vars:
-    disease: "'disease'"
-    stimulus: "'material entity'"
-
-name:
-    text: '%s from %s'
-    vars:
-      - disease
-      - stimulus
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%s %s'
-    vars:
-      - stimulus
-      - disease
-
-def:
-    text: A %s that is caused by exposure to %s.
-    vars:
-      - disease
-      - stimulus
-
-equivalentTo:
-    text: "%s and 'realized in response to stimulus' some %s"
-    vars:
-      - disease
-      - stimulus
-
-
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+description: 'A disease that is caused by exposure to an environmental stimulus, like
+  the sun or pesticides.  Examples: [carbon monoxide-induced parkinsonism](http://purl.obolibrary.org/obo/MONDO_0017639),
+  [cocaine intoxication](http://purl.obolibrary.org/obo/MONDO_0019544), [Colorado
+  tick fever](http://purl.obolibrary.org/obo/MONDO_0005708)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  material entity: BFO:0000040
+
+relations:
+  realized in response to stimulus: RO:0004028
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+  stimulus: '''material entity'''
+
+name:
+  text: '%s from %s'
+  vars:
+  - disease
+  - stimulus
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%s %s'
+  vars:
+  - stimulus
+  - disease
+
+def:
+  text: A %s that is caused by exposure to %s.
+  vars:
+  - disease
+  - stimulus
+
+equivalentTo:
+  text: '%s and ''realized in response to stimulus'' some %s'
+  vars:
+  - disease
+  - stimulus

--- a/src/patterns/dosdp-patterns/hemangioma.yaml
+++ b/src/patterns/dosdp-patterns/hemangioma.yaml
@@ -1,59 +1,54 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: hemangioma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/hemangioma.yaml
 
-description: >-
-    A hemangioma (a benign vascular lesion characterized by the formation of capillary-sized or cavernous vascular channels) that is located in a specific anatomical site.
+description: 'A hemangioma (a benign vascular lesion characterized by the formation
+  of capillary-sized or cavernous vascular channels) that is located in a specific
+  anatomical site.
 
-    Examples: [skin hemangioma](http://purl.obolibrary.org/obo/MONDO_0003110), [breast
-    hemangioma](http://purl.obolibrary.org/obo/MONDO_0003126), [gastric hemangioma](http://purl.obolibrary.org/obo/MONDO_0002414)
-    (20 total)
+  Examples: [skin hemangioma](http://purl.obolibrary.org/obo/MONDO_0003110), [breast
+  hemangioma](http://purl.obolibrary.org/obo/MONDO_0003126), [gastric hemangioma](http://purl.obolibrary.org/obo/MONDO_0002414)
+  (20 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    hemangioma: MONDO:0006500
-    anatomical entity: UBERON:0001062
-
+  hemangioma: MONDO:0006500
+  anatomical entity: UBERON:0001062
 
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: "'anatomical entity'"
-
-name:
-  # Induced, frequency=0.3, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: hemangioma of %s
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.25, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A hemangioma that involves the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: '''anatomical entity'''
+
+name:
+  text: hemangioma of %s
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s hemangioma'
-    vars:
-      - v0
-  - annotationProperty: related_synonym
-    # Induced p=related_synonym 
-    text: angioma of %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s hemangioma'
+  vars:
+  - v0
+- annotationProperty: related_synonym
+  text: angioma of %s
+  vars:
+  - v0
 
+def:
+  text: A hemangioma that involves the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'hemangioma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '''hemangioma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/inborn_metabolic.yaml
+++ b/src/patterns/dosdp-patterns/inborn_metabolic.yaml
@@ -1,51 +1,48 @@
 pattern_name: inborn_metabolic
 
-description: >-
-    An acquired metabolic disease that causes disruption of a process.
-
-classes:
-    ieom: MONDO:0019052
-    process: BFO:0000015
-
-relations:
-    disease has basis in disruption of: RO:0004021
-
-vars:
-    process: "'process'"
-
-name:
-    text: inborn %s disorder
-    vars:
-      - process
-
-annotations:
-  - annotationProperty: related_synonym
-    text: rare inborn error of %s
-    vars:
-      - process
-  - annotationProperty: exact_synonym
-    text: inborn error of %s
-    vars:
-      - process
-
-def:
-    text: An acquired metabolic disease that is has its basis in the disruption of
-        %s.
-    vars:
-      - process
-
-equivalentTo:
-    text: "'ieom' and 'disease has basis in disruption of' some %s"
-    vars:
-      - process
-
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/inborn_metabolic.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: An acquired metabolic disease that causes disruption of a process.
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  ieom: MONDO:0019052
+  process: BFO:0000015
+
+relations:
+  disease has basis in disruption of: RO:0004021
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  process: '''process'''
+
+name:
+  text: inborn %s disorder
+  vars:
+  - process
+
+annotations:
+- annotationProperty: related_synonym
+  text: rare inborn error of %s
+  vars:
+  - process
+- annotationProperty: exact_synonym
+  text: inborn error of %s
+  vars:
+  - process
+
+def:
+  text: An acquired metabolic disease that is has its basis in the disruption of %s.
+  vars:
+  - process
+
+equivalentTo:
+  text: '''ieom'' and ''disease has basis in disruption of'' some %s'
+  vars:
+  - process

--- a/src/patterns/dosdp-patterns/inborn_metabolic_disrupts.yaml
+++ b/src/patterns/dosdp-patterns/inborn_metabolic_disrupts.yaml
@@ -1,62 +1,54 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: inborn errors of metabolism disease caused by disruption of X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/inborn_metabolic_disrupts.yaml
 
-description: >-
-    This pattern is used for inborn errors of metabolism that cause disruption of a specific biological process, such as enzyme activity or ion transport. 
+description: "This pattern is used for inborn errors of metabolism that cause disruption\
+  \ of a specific biological process, such as enzyme activity or ion transport. \n\
+  Examples: ['5-oxoprolinase deficiency (disease)'](http://purl.obolibrary.org/obo/MONDO_0009825),\
+  \ [inborn disorder of methionine cycle and sulfur amino acid metabolism](http://purl.obolibrary.org/obo/MONDO_0019222),\
+  \ [inborn aminoacylase deficiency](http://purl.obolibrary.org/obo/MONDO_0017686)\
+  \ (51 total)"
 
-    Examples: ['5-oxoprolinase deficiency (disease)'](http://purl.obolibrary.org/obo/MONDO_0009825),
-    [inborn disorder of methionine cycle and sulfur amino acid metabolism](http://purl.obolibrary.org/obo/MONDO_0019222),
-    [inborn aminoacylase deficiency](http://purl.obolibrary.org/obo/MONDO_0017686)
-    (51 total)
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    inborn errors of metabolism: MONDO:0019052
-    owl:Thing: owl:Thing
-
+  inborn errors of metabolism: MONDO:0019052
+  owl:Thing: owl:Thing
 
 relations:
-    disease caused by disruption of: RO:0004021
-
-
-vars:
-    v0: "'owl:Thing'"
-
-name:
-  # Induced, frequency=0.23529411764705882, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: inborn disorder of %s
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.5098039215686274, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: An acquired metabolic disease that is has its basis in the disruption of
-        %s.
-    vars:
-      - v0
+  disease caused by disruption of: RO:0004021
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: '''owl:Thing'''
+
+name:
+  text: inborn disorder of %s
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: inborn error of %s
-    vars:
-      - v0
-  - annotationProperty: related_synonym
-    # Induced p=related_synonym 
-    text: rare inborn error of %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: inborn error of %s
+  vars:
+  - v0
+- annotationProperty: related_synonym
+  text: rare inborn error of %s
+  vars:
+  - v0
 
+def:
+  text: An acquired metabolic disease that is has its basis in the disruption of %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'inborn errors of metabolism' and ('disease caused by disruption of' some\
-        \ %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '''inborn errors of metabolism'' and (''disease caused by disruption of''
+    some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/infantile.yaml
+++ b/src/patterns/dosdp-patterns/infantile.yaml
@@ -1,51 +1,52 @@
 pattern_name: infantile
 
-description: >-
-    An instance of a disease that has an onset of signs or symptoms of disease within the first 12 months of life (infantile onset).
-  
-    Examples: [infant botulism](http://purl.obolibrary.org/obo/MONDO_0015804), [infantile glycine encephalopathy](http://purl.obolibrary.org/obo/MONDO_0017354)
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/infantile.yaml
 
+description: 'An instance of a disease that has an onset of signs or symptoms of disease
+  within the first 12 months of life (infantile onset).
+
+  Examples: [infant botulism](http://purl.obolibrary.org/obo/MONDO_0015804), [infantile
+  glycine encephalopathy](http://purl.obolibrary.org/obo/MONDO_0017354)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    infantile: HP:0003593
+  infantile: HP:0003593
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: infantile %s
-    vars:
-      - disease
+  text: infantile %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: infantile onset %s
-    vars:
-      - disease
-  - annotationProperty: exact_synonym
-    text: '%s of infancy'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: infantile onset %s
+  vars:
+  - disease
+- annotationProperty: exact_synonym
+  text: '%s of infancy'
+  vars:
+  - disease
 
 def:
-    text: A %s that occurs between 28 days to one year of life..
-    vars:
-      - disease
+  text: A %s that occurs between 28 days to one year of life..
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'infantile'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/infantile.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-    
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '%s and ''has modifier'' some ''infantile'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/infectious_disease_by_agent.yaml
+++ b/src/patterns/dosdp-patterns/infectious_disease_by_agent.yaml
@@ -1,55 +1,52 @@
 pattern_name: infectious_disease_by_agent
 
-description: >-
-    Infectious diseases can be classified by the infectioos agent, such as bacteria, coronavirus, etc, that causes the disease.
-
-    Examples: [COVID-19](http://purl.obolibrary.org/obo/MONDO_0100096), [cholera](http://purl.obolibrary.org/obo/MONDO_0015766)
-
-classes:
-    disease: MONDO:0000001
-    organism: NCBITaxon:1
-    infectious disease: MONDO:0005550
-
-
-# NOTE: this may change in future
-relations:
-    disease has infectious agent: RO:0014001
-
-vars:
-    agent: "'organism'"
-
-name:
-    text: '%s infectious disease'
-    vars:
-      - agent
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: infection due to %s
-    vars:
-      - agent
-  - annotationProperty: exact_synonym
-    text: '%s infection'
-    vars:
-      - agent
-
-
-def:
-    text: A disease caused by infection with %s.
-    vars:
-      - agent
-
-equivalentTo:
-    text: "'infectious disease' and 'disease has infectious agent' some %s"
-    vars:
-      - agent
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/infectious_disease_by_agent.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: 'Infectious diseases can be classified by the infectioos agent, such
+  as bacteria, coronavirus, etc, that causes the disease.
+
+  Examples: [COVID-19](http://purl.obolibrary.org/obo/MONDO_0100096), [cholera](http://purl.obolibrary.org/obo/MONDO_0015766)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  organism: NCBITaxon:1
+  infectious disease: MONDO:0005550
+
+relations:
+  disease has infectious agent: RO:0014001
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  agent: '''organism'''
+
+name:
+  text: '%s infectious disease'
+  vars:
+  - agent
+
+annotations:
+- annotationProperty: exact_synonym
+  text: infection due to %s
+  vars:
+  - agent
+- annotationProperty: exact_synonym
+  text: '%s infection'
+  vars:
+  - agent
+
+def:
+  text: A disease caused by infection with %s.
+  vars:
+  - agent
+
+equivalentTo:
+  text: '''infectious disease'' and ''disease has infectious agent'' some %s'
+  vars:
+  - agent

--- a/src/patterns/dosdp-patterns/infectious_inflammation.yaml
+++ b/src/patterns/dosdp-patterns/infectious_inflammation.yaml
@@ -1,57 +1,61 @@
 pattern_name: infectious_inflammation
 
-description: >-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/infectious_inflammation.yaml
 
-    This combines the [infectious disease by agent pattern](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/infectious_disease_by_agent.yaml) and the [inflammatory disease by site](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/inflammatory_disease_by_site.yaml) pattern.
-    
-    Examples: [bacterial endocarditis (disease)](http://purl.obolibrary.org/obo/MONDO_0006669), [fungal gastritis](http://purl.obolibrary.org/obo/MONDO_0002843)
+description: '
+
+  This combines the [infectious disease by agent pattern](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/infectious_disease_by_agent.yaml)
+  and the [inflammatory disease by site](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/inflammatory_disease_by_site.yaml)
+  pattern.
+
+  Examples: [bacterial endocarditis (disease)](http://purl.obolibrary.org/obo/MONDO_0006669),
+  [fungal gastritis](http://purl.obolibrary.org/obo/MONDO_0002843)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    disease: MONDO:0000001
-    organism: NCBITaxon:1
-    anatomical structure: UBERON:0000061
-    infectious disease: MONDO:0005550
+  disease: MONDO:0000001
+  organism: NCBITaxon:1
+  anatomical structure: UBERON:0000061
+  infectious disease: MONDO:0005550
 
 relations:
-    disease has inflammation site: RO:0004027
-    realized in response to stimulus: RO:0004028
+  disease has inflammation site: RO:0004027
+  realized in response to stimulus: RO:0004028
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: "'anatomical structure'"
-    agent: "'organism'"
+  location: '''anatomical structure'''
+  agent: '''organism'''
 
 name:
-    text: inflammation of %s due to %s
-    vars:
-      - location
-      - agent
+  text: inflammation of %s due to %s
+  vars:
+  - location
+  - agent
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s %s inflammation'
-    vars:
-      - location
-      - agent
+- annotationProperty: exact_synonym
+  text: '%s %s inflammation'
+  vars:
+  - location
+  - agent
 
 def:
-    text: An inflammatory disease involving a pathogenic inflammatory response in
-        the %s caused by infection with %s.
-    vars:
-      - location
-      - agent
+  text: An inflammatory disease involving a pathogenic inflammatory response in the
+    %s caused by infection with %s.
+  vars:
+  - location
+  - agent
 
 equivalentTo:
-    text: "'infectious disease' and 'disease has inflammation site' some %s and 'realized\
-        \ in response to stimulus' some %s"
-    vars:
-      - location
-      - agent
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/infectious_inflammation.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '''infectious disease'' and ''disease has inflammation site'' some %s and
+    ''realized in response to stimulus'' some %s'
+  vars:
+  - location
+  - agent

--- a/src/patterns/dosdp-patterns/inflammatory_disease_by_site.yaml
+++ b/src/patterns/dosdp-patterns/inflammatory_disease_by_site.yaml
@@ -1,55 +1,57 @@
 pattern_name: inflammatory_disease_by_site
 
-description: >-
-
-    Inflammatory diseases can be classified by the location in which the pathological inflammatory process occurs.
-
-    For inflammatory diseases caused by infection, this may be the site of infection.
-    
-    Examples: ['Achilles bursitis'](http://purl.obolibrary.org/obo/MONDO_0001594), [blepharitis](http://purl.obolibrary.org/obo/MONDO_0004785), [epiglottitis](http://purl.obolibrary.org/obo/MONDO_0005753)
-
-classes:
-    disease: MONDO:0000001
-    anatomical structure: UBERON:0000061
-
-relations:
-    disease has inflammation site: RO:0004027
-
-vars:
-    location: "'anatomical structure'"
-
-name:
-    text: inflammation of %s
-    vars:
-      - location
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%sitis'
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s inflammation'
-    vars:
-      - location
-
-def:
-    text: An inflammatory disease involving a pathogenic inflammatory response in
-        the %s.
-    vars:
-      - location
-
-equivalentTo:
-    text: "'disease' and 'disease has inflammation site' some %s"
-    vars:
-      - location
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/inflammatory_disease_by_site.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: '
+
+  Inflammatory diseases can be classified by the location in which the pathological
+  inflammatory process occurs.
+
+  For inflammatory diseases caused by infection, this may be the site of infection.
+
+  Examples: [''Achilles bursitis''](http://purl.obolibrary.org/obo/MONDO_0001594),
+  [blepharitis](http://purl.obolibrary.org/obo/MONDO_0004785), [epiglottitis](http://purl.obolibrary.org/obo/MONDO_0005753)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  anatomical structure: UBERON:0000061
+
+relations:
+  disease has inflammation site: RO:0004027
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  location: '''anatomical structure'''
+
+name:
+  text: inflammation of %s
+  vars:
+  - location
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%sitis'
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s inflammation'
+  vars:
+  - location
+
+def:
+  text: An inflammatory disease involving a pathogenic inflammatory response in the
+    %s.
+  vars:
+  - location
+
+equivalentTo:
+  text: '''disease'' and ''disease has inflammation site'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/inherited_susceptibility.yaml
+++ b/src/patterns/dosdp-patterns/inherited_susceptibility.yaml
@@ -1,51 +1,58 @@
 pattern_name: inherited_susceptibility
 
-description: >-
-    This pattern should be used for children of MONDO_0020573'inherited disease susceptibility', including OMIM phenotypic series (OMIMPS) for which the subclasses are susceptibilities. Note, this pattern should not have an asserted causative gene as logical axiom (and no single causative gene in text definition), in those cases, the susceptibility_by_gene pattern should be used instead. The children should have asserted causative genes in the text definitions and in the logical axioms. This pattern is a superclass of the susceptibility_by_gene pattern.
-    
-    Examples: ['microvascular complications of diabetes, susceptibility'](http://purl.obolibrary.org/obo/MONDO_0000065), ['epilepsy, idiopathic generalized'](http://purl.obolibrary.org/obo/MONDO_0005579), ['aspergillosis, susceptibility to'](http://purl.obolibrary.org/obo/MONDO_0013562).
-
-classes:
-    disease or disorder: MONDO:0000001
-    inherited disease susceptibility: MONDO:0020573
-
-relations:
-    predisposes towards: http://purl.obolibrary.org/obo/mondo#predisposes_towards
-    
-vars:
-    disease: "'disease or disorder'"
-
-name:
-    text: '%s susceptibility'
-    vars:
-      - disease
-
-def:
-    text: An inherited susceptibility or predisposition to developing %s.
-    vars:
-      - disease
-
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-    
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, susceptibility'
-    vars:
-      - disease
-  - annotationProperty: exact_synonym
-    text: '%s, susceptibility to'
-    vars:
-      - disease
-
-equivalentTo:
-    text: ('inherited disease susceptibility' and ('predisposes towards' some %s))
-    vars:
-      - disease
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/inherited_susceptibility.yaml
 
+description: 'This pattern should be used for children of MONDO_0020573''inherited
+  disease susceptibility'', including OMIM phenotypic series (OMIMPS) for which the
+  subclasses are susceptibilities. Note, this pattern should not have an asserted
+  causative gene as logical axiom (and no single causative gene in text definition),
+  in those cases, the susceptibility_by_gene pattern should be used instead. The children
+  should have asserted causative genes in the text definitions and in the logical
+  axioms. This pattern is a superclass of the susceptibility_by_gene pattern.
+
+  Examples: [''microvascular complications of diabetes, susceptibility''](http://purl.obolibrary.org/obo/MONDO_0000065),
+  [''epilepsy, idiopathic generalized''](http://purl.obolibrary.org/obo/MONDO_0005579),
+  [''aspergillosis, susceptibility to''](http://purl.obolibrary.org/obo/MONDO_0013562).'
+
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease or disorder: MONDO:0000001
+  inherited disease susceptibility: MONDO:0020573
+
+relations:
+  predisposes towards: http://purl.obolibrary.org/obo/mondo#predisposes_towards
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease or disorder'''
+
+name:
+  text: '%s susceptibility'
+  vars:
+  - disease
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%s, susceptibility'
+  vars:
+  - disease
+- annotationProperty: exact_synonym
+  text: '%s, susceptibility to'
+  vars:
+  - disease
+
+def:
+  text: An inherited susceptibility or predisposition to developing %s.
+  vars:
+  - disease
+
+equivalentTo:
+  text: ('inherited disease susceptibility' and ('predisposes towards' some %s))
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/isolated.yaml
+++ b/src/patterns/dosdp-patterns/isolated.yaml
@@ -1,49 +1,57 @@
 pattern_name: isolated
 
-description: >-
-    Some diseases exist in both isolated and syndromic forms. For example, aniridia ([MONDO_0019172 aniridia](http://purl.obolibrary.org/obo/MONDO_0019172), [MONDO_0020148'syndromic aniridia'](http://purl.obolibrary.org/obo/MONDO_0020148) and [MONDO_0007119 'isolated aniridia'](http://purl.obolibrary.org/obo/MONDO_0007119). Use this pattern to define the isolated form of a disease when a term exists for the isolated/syndromic-neutral version.
-    In general, this pattern should be used in parallel with syndromic. E.g. if you make a term 'syndromic disease, you should also have 'isolated disease' [see pattern here(https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/syndromic.yaml). 
-    Note that the isolated and syndromic forms will be inferred to be disjoint due to the GCI pattern.
-
-    Examples: ['isolated aniridia'](http://purl.obolibrary.org/obo/MONDO_0007119), ['isolated dystonia'](http://purl.obolibrary.org/obo/MONDO_0015494), ['isolated focal palmoplantar keratoderma'](http://purl.obolibrary.org/obo/MONDO_0017673)
-    
-classes:
-    isolated: MONDO:0021128
-    disease: MONDO:0000001
-
-relations:
-    has modifier: RO:0002573
-
-vars:
-    disease: "'disease'"
-
-name:
-    text: isolated %s
-    vars:
-      - disease
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: nonsyndromic %s
-    vars:
-      - disease
-
-def:
-    text: A %s that is not part of a larger syndrome.
-    vars:
-      - disease
-
-equivalentTo:
-    text: "%s and 'has modifier' some 'isolated'"
-    vars:
-      - disease
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/isolated.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: 'Some diseases exist in both isolated and syndromic forms. For example,
+  aniridia ([MONDO_0019172 aniridia](http://purl.obolibrary.org/obo/MONDO_0019172),
+  [MONDO_0020148''syndromic aniridia''](http://purl.obolibrary.org/obo/MONDO_0020148)
+  and [MONDO_0007119 ''isolated aniridia''](http://purl.obolibrary.org/obo/MONDO_0007119).
+  Use this pattern to define the isolated form of a disease when a term exists for
+  the isolated/syndromic-neutral version. In general, this pattern should be used
+  in parallel with syndromic. E.g. if you make a term ''syndromic disease, you should
+  also have ''isolated disease'' [see pattern here(https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/syndromic.yaml).  Note
+  that the isolated and syndromic forms will be inferred to be disjoint due to the
+  GCI pattern.
+
+  Examples: [''isolated aniridia''](http://purl.obolibrary.org/obo/MONDO_0007119),
+  [''isolated dystonia''](http://purl.obolibrary.org/obo/MONDO_0015494), [''isolated
+  focal palmoplantar keratoderma''](http://purl.obolibrary.org/obo/MONDO_0017673)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  isolated: MONDO:0021128
+  disease: MONDO:0000001
+
+relations:
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+
+name:
+  text: isolated %s
+  vars:
+  - disease
+
+annotations:
+- annotationProperty: exact_synonym
+  text: nonsyndromic %s
+  vars:
+  - disease
+
+def:
+  text: A %s that is not part of a larger syndrome.
+  vars:
+  - disease
+
+equivalentTo:
+  text: '%s and ''has modifier'' some ''isolated'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/juvenile.yaml
+++ b/src/patterns/dosdp-patterns/juvenile.yaml
@@ -1,46 +1,48 @@
 pattern_name: juvenile
 
-description: >-
-    An instance of a disease that has an onset of signs or symptoms of disease between the age of 5 and 15 years (juvenile onset).
-
-    Examples: [juvenile-onset Parkinson disease](http://purl.obolibrary.org/obo/MONDO_0000828), ['juvenile idiopathic scoliosis'](http://purl.obolibrary.org/obo/MONDO_0100076)
-
-classes:
-    juvenile: HP:0003621
-
-    owl_thing: owl:Thing
-relations:
-    has modifier: RO:0002573
-
-vars:
-    disease: owl_thing
-
-name:
-    text: juvenile %s
-    vars:
-      - disease
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: juvenile %s
-    vars:
-      - disease
-
-def:
-    text: An instance of %s that has a juvenile onset.
-    vars:
-      - disease
-
-equivalentTo:
-    text: "%s and 'has modifier' some 'juvenile'"
-    vars:
-      - disease
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/juvenile.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: 'An instance of a disease that has an onset of signs or symptoms of disease
+  between the age of 5 and 15 years (juvenile onset).
+
+  Examples: [juvenile-onset Parkinson disease](http://purl.obolibrary.org/obo/MONDO_0000828),
+  [''juvenile idiopathic scoliosis''](http://purl.obolibrary.org/obo/MONDO_0100076)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  juvenile: HP:0003621
+  owl_thing: owl:Thing
+
+relations:
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: owl_thing
+
+name:
+  text: juvenile %s
+  vars:
+  - disease
+
+annotations:
+- annotationProperty: exact_synonym
+  text: juvenile %s
+  vars:
+  - disease
+
+def:
+  text: An instance of %s that has a juvenile onset.
+  vars:
+  - disease
+
+equivalentTo:
+  text: '%s and ''has modifier'' some ''juvenile'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/leiomyoma.yaml
+++ b/src/patterns/dosdp-patterns/leiomyoma.yaml
@@ -1,56 +1,52 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: leiomyoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/leiomyoma.yaml
 
-description: >-
-    A leiomyoma (a well-circumscribed benign smooth muscle neoplasm characterized by the presence of spindle cells with cigar-shaped nuclei, interlacing fascicles, and a whorled pattern) that is located in a specific anatomical entity.
+description: 'A leiomyoma (a well-circumscribed benign smooth muscle neoplasm characterized
+  by the presence of spindle cells with cigar-shaped nuclei, interlacing fascicles,
+  and a whorled pattern) that is located in a specific anatomical entity.
 
-    Examples: [leiomyoma cutis](http://purl.obolibrary.org/obo/MONDO_0003291), [ureter
-    leiomyoma](http://purl.obolibrary.org/obo/MONDO_0001399), [urethra leiomyoma](http://purl.obolibrary.org/obo/MONDO_0002222)
-    (30 total)
+  Examples: [leiomyoma cutis](http://purl.obolibrary.org/obo/MONDO_0003291), [ureter
+  leiomyoma](http://purl.obolibrary.org/obo/MONDO_0001399), [urethra leiomyoma](http://purl.obolibrary.org/obo/MONDO_0002222)
+  (30 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    leiomyoma: MONDO:0001572
-    anatomical entity: UBERON:0001062
-
+  leiomyoma: MONDO:0001572
+  anatomical entity: UBERON:0001062
 
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: "'anatomical entity'"
-
-name:
-  # Induced, frequency=0.7, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s leiomyoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.43333333333333335, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A benign smooth muscle neoplasm arising from the %s. It is characterized
-        by the presence of spindle cells with cigar-shaped nuclei, interlacing fascicles,
-        and a whorled pattern.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: '''anatomical entity'''
+
+name:
+  text: '%s leiomyoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s leiomyoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s leiomyoma'
+  vars:
+  - v0
 
+def:
+  text: A benign smooth muscle neoplasm arising from the %s. It is characterized by
+    the presence of spindle cells with cigar-shaped nuclei, interlacing fascicles,
+    and a whorled pattern.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'leiomyoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '''leiomyoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/leiomyosarcoma.yaml
+++ b/src/patterns/dosdp-patterns/leiomyosarcoma.yaml
@@ -1,53 +1,50 @@
 pattern_name: leiomyosarcoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/leiomyosarcoma.yaml
 
-description: >-
-    An uncommon, aggressive malignant smooth muscle neoplasm, usually occurring in post-menopausal women that is characterized by a proliferation of neoplastic spindle cells that is located in a specific anatomical location.
+description: 'An uncommon, aggressive malignant smooth muscle neoplasm, usually occurring
+  in post-menopausal women that is characterized by a proliferation of neoplastic
+  spindle cells that is located in a specific anatomical location.
 
-    Examples: [leiomyosarcoma of the cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016283),
-    [cutaneous leiomyosarcoma (disease)](http://purl.obolibrary.org/obo/MONDO_0003362),
-    [breast leiomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0003371) (29 total)
+  Examples: [leiomyosarcoma of the cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016283),
+  [cutaneous leiomyosarcoma (disease)](http://purl.obolibrary.org/obo/MONDO_0003362),
+  [breast leiomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0003371) (29 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    leiomyosarcoma: MONDO:0005058
+  leiomyosarcoma: MONDO:0005058
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.7586206896551724, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s leiomyosarcoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.7931034482758621, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: An aggressive malignant smooth muscle neoplasm, arising from the %s. It
-        is characterized by a proliferation of neoplastic spindle cells.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s leiomyosarcoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s leiomyosarcoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s leiomyosarcoma'
+  vars:
+  - v0
 
+def:
+  text: An aggressive malignant smooth muscle neoplasm, arising from the %s. It is
+    characterized by a proliferation of neoplastic spindle cells.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'leiomyosarcoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''leiomyosarcoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/lipoma.yaml
+++ b/src/patterns/dosdp-patterns/lipoma.yaml
@@ -1,53 +1,49 @@
 pattern_name: lipoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/lipoma.yaml
 
-description: >-
-    A benign, usually painless, well-circumscribed lipomatous tumor composed of adipose tissue that is located in a specific anatomical location.
+description: 'A benign, usually painless, well-circumscribed lipomatous tumor composed
+  of adipose tissue that is located in a specific anatomical location.
 
-    Examples: [skin lipoma](http://purl.obolibrary.org/obo/MONDO_0000964), [colorectal
-    lipoma](http://purl.obolibrary.org/obo/MONDO_0003885), [tendon sheath lipoma](http://purl.obolibrary.org/obo/MONDO_0004076)
-    (28 total)
+  Examples: [skin lipoma](http://purl.obolibrary.org/obo/MONDO_0000964), [colorectal
+  lipoma](http://purl.obolibrary.org/obo/MONDO_0003885), [tendon sheath lipoma](http://purl.obolibrary.org/obo/MONDO_0004076)
+  (28 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    lipoma: MONDO:0005106
+  lipoma: MONDO:0005106
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.6071428571428571, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s lipoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.14285714285714285, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A benign adipose tissue neoplasm of the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s lipoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s lipoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s lipoma'
+  vars:
+  - v0
 
+def:
+  text: A benign adipose tissue neoplasm of the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'lipoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '''lipoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/location.yaml
+++ b/src/patterns/dosdp-patterns/location.yaml
@@ -1,53 +1,54 @@
 pattern_name: location
 
-description: >-
-    A disease that is located in a specific anatomical site.
-
-    Examples: ['abdominal cystic lymphangioma'](http://purl.obolibrary.org/obo/MONDO_0021726), ['articular cartilage disease'](http://purl.obolibrary.org/obo/MONDO_0003816), ['urethral disease'](http://purl.obolibrary.org/obo/MONDO_0004184)
-    
-classes:
-    disease: MONDO:0000001
-    anatomical entity: UBERON:0001062
-    cell: CL:0000000
-
-relations:
-    disease has location: RO:0004026
-
-vars:
-    disease: "'disease'"
-    location: "'anatomical entity' or 'cell'"
-
-name:
-    text: '%s of %s'
-    vars:
-      - disease
-      - location
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%s %s'
-    vars:
-      - location
-      - disease
-
-def:
-    text: A %s that involves the %s.
-    vars:
-      - disease
-      - location
-
-equivalentTo:
-    text: "%s and 'disease has location' some %s"
-    vars:
-      - disease
-      - location
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/location.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: 'A disease that is located in a specific anatomical site.
+
+  Examples: [''abdominal cystic lymphangioma''](http://purl.obolibrary.org/obo/MONDO_0021726),
+  [''articular cartilage disease''](http://purl.obolibrary.org/obo/MONDO_0003816),
+  [''urethral disease''](http://purl.obolibrary.org/obo/MONDO_0004184)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  anatomical entity: UBERON:0001062
+  cell: CL:0000000
+
+relations:
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+  location: '''anatomical entity'' or ''cell'''
+
+name:
+  text: '%s of %s'
+  vars:
+  - disease
+  - location
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%s %s'
+  vars:
+  - location
+  - disease
+
+def:
+  text: A %s that involves the %s.
+  vars:
+  - disease
+  - location
+
+equivalentTo:
+  text: '%s and ''disease has location'' some %s'
+  vars:
+  - disease
+  - location

--- a/src/patterns/dosdp-patterns/location_top.yaml
+++ b/src/patterns/dosdp-patterns/location_top.yaml
@@ -1,45 +1,47 @@
 pattern_name: location_top
 
-classes:
-    disease: MONDO:0000001
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/location_top.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  disease: MONDO:0000001
+  owl_thing: owl:Thing
+
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s disease'
-    vars:
-      - location
+  text: '%s disease'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: related_synonym
-    text: disorder of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: disease of %s
-    vars:
-      - location
+- annotationProperty: related_synonym
+  text: disorder of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: disease of %s
+  vars:
+  - location
 
 def:
-    text: A disease involving the %s.
-    vars:
-      - location
+  text: A disease involving the %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'disease' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/location_top.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''disease'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/lymphoma.yaml
+++ b/src/patterns/dosdp-patterns/lymphoma.yaml
@@ -1,53 +1,50 @@
 pattern_name: lymphoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/lymphoma.yaml
 
-description: >-
-    A malignant (clonal) proliferation of B- lymphocytes or T- lymphocytes which involves the lymph nodes, bone marrow and/or extranodal sites. This category includes Non-Hodgkin lymphomas and Hodgkin lymphomas.
+description: 'A malignant (clonal) proliferation of B- lymphocytes or T- lymphocytes
+  which involves the lymph nodes, bone marrow and/or extranodal sites. This category
+  includes Non-Hodgkin lymphomas and Hodgkin lymphomas.
 
-    Examples: [marginal zone lymphoma](http://purl.obolibrary.org/obo/MONDO_0017604),
-    [ureteral lymphoma](http://purl.obolibrary.org/obo/MONDO_0001977), [colorectal
-    lymphoma](http://purl.obolibrary.org/obo/MONDO_0024656) (37 total)
+  Examples: [marginal zone lymphoma](http://purl.obolibrary.org/obo/MONDO_0017604),
+  [ureteral lymphoma](http://purl.obolibrary.org/obo/MONDO_0001977), [colorectal lymphoma](http://purl.obolibrary.org/obo/MONDO_0024656)
+  (37 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
 
 classes:
-    lymphoma: MONDO:0005062
+  lymphoma: MONDO:0005062
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.7027027027027027, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s lymphoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.13513513513513514, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A lymphoma that involves the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s lymphoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s lymphoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s lymphoma'
+  vars:
+  - v0
 
+def:
+  text: A lymphoma that involves the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'lymphoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+  text: '''lymphoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/malignant.yaml
+++ b/src/patterns/dosdp-patterns/malignant.yaml
@@ -1,42 +1,44 @@
 pattern_name: malignant
 
-classes:
-    neoplasm: MONDO:0005070
-    malignant: PATO:0002097
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/malignant.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  neoplasm: MONDO:0005070
+  malignant: PATO:0002097
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    neoplasm: owl_thing
+  neoplasm: owl_thing
 
 name:
-    text: malignant %s
-    vars:
-      - neoplasm
+  text: malignant %s
+  vars:
+  - neoplasm
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, malignant'
-    vars:
-      - neoplasm
+- annotationProperty: exact_synonym
+  text: '%s, malignant'
+  vars:
+  - neoplasm
 
 def:
-    text: A malignant form of %s.
-    vars:
-      - neoplasm
+  text: A malignant form of %s.
+  vars:
+  - neoplasm
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'malignant'"
-    vars:
-      - neoplasm
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/malignant.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''malignant'''
+  vars:
+  - neoplasm

--- a/src/patterns/dosdp-patterns/melanoma.yaml
+++ b/src/patterns/dosdp-patterns/melanoma.yaml
@@ -1,52 +1,47 @@
 pattern_name: melanoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/melanoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [cutaneous melanoma](http://purl.obolibrary.org/obo/MONDO_0005012),
-    [malignant breast melanoma](http://purl.obolibrary.org/obo/MONDO_0002975), [malignant
-    melanoma of the mucosa](http://purl.obolibrary.org/obo/MONDO_0015694) (22 total)
+  Examples: [cutaneous melanoma](http://purl.obolibrary.org/obo/MONDO_0005012), [malignant
+  breast melanoma](http://purl.obolibrary.org/obo/MONDO_0002975), [malignant melanoma
+  of the mucosa](http://purl.obolibrary.org/obo/MONDO_0015694) (22 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    melanoma: MONDO:0005105
+  melanoma: MONDO:0005105
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.22727272727272727, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s melanoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.18181818181818182, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A melanoma that involves the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s melanoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s melanoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s melanoma'
+  vars:
+  - v0
 
+def:
+  text: A melanoma that involves the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'melanoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''melanoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/meningioma.yaml
+++ b/src/patterns/dosdp-patterns/meningioma.yaml
@@ -1,53 +1,47 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: meningioma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/meningioma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [skin meningioma](http://purl.obolibrary.org/obo/MONDO_0004429), [brain
-    meningioma](http://purl.obolibrary.org/obo/MONDO_0000642), [choroid plexus meningioma](http://purl.obolibrary.org/obo/MONDO_0003053)
-    (26 total)
+  Examples: [skin meningioma](http://purl.obolibrary.org/obo/MONDO_0004429), [brain
+  meningioma](http://purl.obolibrary.org/obo/MONDO_0000642), [choroid plexus meningioma](http://purl.obolibrary.org/obo/MONDO_0003053)
+  (26 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    meningioma: MONDO:0016642
-    anatomical entity: UBERON:0001062
-
+  meningioma: MONDO:0016642
+  anatomical entity: UBERON:0001062
 
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: "'anatomical entity'"
-
-name:
-  # Induced, frequency=0.8076923076923077, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s meningioma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.6153846153846154, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A meningioma that affects the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: '''anatomical entity'''
+
+name:
+  text: '%s meningioma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s meningioma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s meningioma'
+  vars:
+  - v0
 
+def:
+  text: A meningioma that affects the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'meningioma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''meningioma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/mitochondrial_subtype.yaml
+++ b/src/patterns/dosdp-patterns/mitochondrial_subtype.yaml
@@ -1,36 +1,39 @@
 pattern_name: mitochondriaal_subtype
-description: A disease that is classified as a mitochondrial subtype, due to a defect
-    in a mitochondrial gene, such as MONDO:0100134 'mitochondrial complex I deficiency,
-    mitochondrial type'.
-
-classes:
-    mt_gene: SO:0000088
-    disease: MONDO:0000001
-
-relations:
-    disease has basis in dysfunction of: RO:0004020
-
-vars:
-    disease: "'disease'"
-
-name:
-    text: '%s, mitochondrial type'
-    vars:
-      - disease
-
-def:
-    text: A %s that has a defect in a mitochondrial gene.
-    vars:
-      - disease
-
-equivalentTo:
-    text: "%s and 'disease has basis in dysfunction of' some 'mt_gene'"
-    vars:
-      - disease
 
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/mitochondrial_subtype.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: A disease that is classified as a mitochondrial subtype, due to a defect
+  in a mitochondrial gene, such as MONDO:0100134 'mitochondrial complex I deficiency,
+  mitochondrial type'.
+
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  mt_gene: SO:0000088
+  disease: MONDO:0000001
+
+relations:
+  disease has basis in dysfunction of: RO:0004020
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+
+name:
+  text: '%s, mitochondrial type'
+  vars:
+  - disease
+
+def:
+  text: A %s that has a defect in a mitochondrial gene.
+  vars:
+  - disease
+
+equivalentTo:
+  text: '%s and ''disease has basis in dysfunction of'' some ''mt_gene'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/mucoepidermoid_carcinoma.yaml
+++ b/src/patterns/dosdp-patterns/mucoepidermoid_carcinoma.yaml
@@ -1,54 +1,48 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: mucoepidermoid carcinoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/mucoepidermoid_carcinoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [cutaneous mucoepidermoid carcinoma](http://purl.obolibrary.org/obo/MONDO_0003091),
-    [oral cavity mucoepidermoid carcinoma](http://purl.obolibrary.org/obo/MONDO_0044964),
-    [mucoepidermoid breast carcinoma](http://purl.obolibrary.org/obo/MONDO_0003087)
-    (18 total)
+  Examples: [cutaneous mucoepidermoid carcinoma](http://purl.obolibrary.org/obo/MONDO_0003091),
+  [oral cavity mucoepidermoid carcinoma](http://purl.obolibrary.org/obo/MONDO_0044964),
+  [mucoepidermoid breast carcinoma](http://purl.obolibrary.org/obo/MONDO_0003087)
+  (18 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    mucoepidermoid carcinoma: MONDO:0003036
-    anatomical entity: UBERON:0001062
-
+  mucoepidermoid carcinoma: MONDO:0003036
+  anatomical entity: UBERON:0001062
 
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: "'anatomical entity'"
-
-name:
-  # Induced, frequency=0.5555555555555556, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s mucoepidermoid carcinoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.2777777777777778, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A mucoepidermoid carcinoma that involves the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: '''anatomical entity'''
+
+name:
+  text: '%s mucoepidermoid carcinoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s mucoepidermoid carcinoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s mucoepidermoid carcinoma'
+  vars:
+  - v0
 
+def:
+  text: A mucoepidermoid carcinoma that involves the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'mucoepidermoid carcinoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''mucoepidermoid carcinoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/neoplasm.yaml
+++ b/src/patterns/dosdp-patterns/neoplasm.yaml
@@ -1,68 +1,66 @@
 pattern_name: neoplasm
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neoplasm.yaml
 
-    Neoplasms are benign or malignant tissue growths resulting from
-    uncontrolled cell proliferation cell types.
+description: '
 
-    This is a design pattern for classes representing neoplasms based on
-    their location. This may be the site of origin, but it can also
-    represent a secondary site for malignant neoplasms that have
-    metastasized.
+  Neoplasms are benign or malignant tissue growths resulting from uncontrolled cell
+  proliferation cell types.
 
-    We use the generic 'disease has location' relation, which
-    generalized over primary and secondary sites.
+  This is a design pattern for classes representing neoplasms based on their location.
+  This may be the site of origin, but it can also represent a secondary site for malignant
+  neoplasms that have metastasized.
 
-    Note that tumor is typically a synonym for neoplasm, although this
-    can be context dependent. For NETs, NCIT uses the nomenclature 'tumor'
-    to indicate 'well differentiated, low or intermediate grade tumor'.
-    This can also be called carcinoid, see
-    https://www.cancer.org/cancer/gastrointestinal-carcinoid-tumor/about/what-is-gastrointestinal-carcinoid.html
-    We attempt to spell this out in our labels.
+  We use the generic ''disease has location'' relation, which generalized over primary
+  and secondary sites.
+
+  Note that tumor is typically a synonym for neoplasm, although this can be context
+  dependent. For NETs, NCIT uses the nomenclature ''tumor'' to indicate ''well differentiated,
+  low or intermediate grade tumor''. This can also be called carcinoid, see https://www.cancer.org/cancer/gastrointestinal-carcinoid-tumor/about/what-is-gastrointestinal-carcinoid.html
+  We attempt to spell this out in our labels.'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    neoplasm: MONDO:0005070
+  neoplasm: MONDO:0005070
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s neoplasm'
-    vars:
-      - location
+  text: '%s neoplasm'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: neoplasm of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s tumor'
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: tumor of %s
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: neoplasm of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s tumor'
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: tumor of %s
+  vars:
+  - location
 
 def:
-    text: A neoplasm involving a %s.
-    vars:
-      - location
+  text: A neoplasm involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'neoplasm' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neoplasm.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''neoplasm'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/neoplasm_by_origin.yaml
+++ b/src/patterns/dosdp-patterns/neoplasm_by_origin.yaml
@@ -1,45 +1,47 @@
 pattern_name: neoplasm
 
-classes:
-    neoplasm: MONDO:0005070
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neoplasm_by_origin.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  neoplasm: MONDO:0005070
+  owl_thing: owl:Thing
+
 relations:
-    disease arises from structure: RO:0004022
+  disease arises from structure: RO:0004022
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    structure: owl_thing
+  structure: owl_thing
 
 name:
-    text: '%s neoplasm'
-    vars:
-      - structure
+  text: '%s neoplasm'
+  vars:
+  - structure
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: malignant %s neoplasm
-    vars:
-      - structure
-  - annotationProperty: exact_synonym
-    text: neoplasm of %s
-    vars:
-      - structure
+- annotationProperty: exact_synonym
+  text: malignant %s neoplasm
+  vars:
+  - structure
+- annotationProperty: exact_synonym
+  text: neoplasm of %s
+  vars:
+  - structure
 
 def:
-    text: A neoplasm involving a %s.
-    vars:
-      - structure
+  text: A neoplasm involving a %s.
+  vars:
+  - structure
 
 equivalentTo:
-    text: "'neoplasm' and 'disease arises from structure' some %s"
-    vars:
-      - structure
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neoplasm_by_origin.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''neoplasm'' and ''disease arises from structure'' some %s'
+  vars:
+  - structure

--- a/src/patterns/dosdp-patterns/neuroendocrine_neoplasm.yaml
+++ b/src/patterns/dosdp-patterns/neuroendocrine_neoplasm.yaml
@@ -1,58 +1,65 @@
 pattern_name: neoendocrine_neoplasm
 
-description: >-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neuroendocrine_neoplasm.yaml
 
-    Note that tumor is typically a synonym for neoplasm, although this can be context dependent. For neuroendocrine tumors (NETs), NCIT uses the nomenclature 'tumor' to indicate 'well differentiated, low or intermediate grade tumor'. This can also be called carcinoid, see [https://www.cancer.org/cancer/gastrointestinal-carcinoid-tumor/about/what-is-gastrointestinal-carcinoid.html](https://www.cancer.org/cancer/gastrointestinal-carcinoid-tumor/about/what-is-gastrointestinal-carcinoid.html). We attempt to spell this out in our labels.
-    
-    Examples: [breast neuroendocrine neoplasm](http://purl.obolibrary.org/obo/MONDO_0002485), [digestive system neuroendocrine neoplasm](http://purl.obolibrary.org/obo/MONDO_0024503), [ovarian neuroendocrine neoplasm](http://purl.obolibrary.org/obo/MONDO_0002481)
+description: '
+
+  Note that tumor is typically a synonym for neoplasm, although this can be context
+  dependent. For neuroendocrine tumors (NETs), NCIT uses the nomenclature ''tumor''
+  to indicate ''well differentiated, low or intermediate grade tumor''. This can also
+  be called carcinoid, see [https://www.cancer.org/cancer/gastrointestinal-carcinoid-tumor/about/what-is-gastrointestinal-carcinoid.html](https://www.cancer.org/cancer/gastrointestinal-carcinoid-tumor/about/what-is-gastrointestinal-carcinoid.html).
+  We attempt to spell this out in our labels.
+
+  Examples: [breast neuroendocrine neoplasm](http://purl.obolibrary.org/obo/MONDO_0002485),
+  [digestive system neuroendocrine neoplasm](http://purl.obolibrary.org/obo/MONDO_0024503),
+  [ovarian neuroendocrine neoplasm](http://purl.obolibrary.org/obo/MONDO_0002481)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    neuroendocrine neoplasm: MONDO:0019496
+  neuroendocrine neoplasm: MONDO:0019496
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s neuroendocrine neoplasm'
-    vars:
-      - location
+  text: '%s neuroendocrine neoplasm'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: neuroendocrine neoplasm of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s neuroendocrine tumor, well differentiated, low or intermediate grade'
-    vars:
-      - location
-  - annotationProperty: related_synonym
-    text: '%s neuroendocrine tumor'
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s NET'
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: neuroendocrine neoplasm of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s neuroendocrine tumor, well differentiated, low or intermediate grade'
+  vars:
+  - location
+- annotationProperty: related_synonym
+  text: '%s neuroendocrine tumor'
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s NET'
+  vars:
+  - location
 
 def:
-    text: A neuroendocrine neoplasm involving a %s.
-    vars:
-      - location
+  text: A neuroendocrine neoplasm involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'neuroendocrine neoplasm' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neuroendocrine_neoplasm.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''neuroendocrine neoplasm'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/neuroendocrine_neoplasm_grade1.yaml
+++ b/src/patterns/dosdp-patterns/neuroendocrine_neoplasm_grade1.yaml
@@ -1,57 +1,59 @@
 pattern_name: neoendocrine_neoplasm_grade1
 
-description: >-
-    we follow NCIT in making carcinoid a syn for G1 NET
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neuroendocrine_neoplasm_grade1.yaml
+
+description: we follow NCIT in making carcinoid a syn for G1 NET
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    neuroendocrine neoplasm: MONDO:0019496
-    grade 1: MONDO:0024491
+  neuroendocrine neoplasm: MONDO:0019496
+  grade 1: MONDO:0024491
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-    has modifier: RO:0002573
+  disease has location: RO:0004026
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s neuroendocrine neoplasm G1'
-    vars:
-      - location
+  text: '%s neuroendocrine neoplasm G1'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: grade 1 neuroendocrine neoplasm of %s
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s neuroendocrine tumor, well differentiated, low grade'
-    vars:
-      - location
-  - annotationProperty: exact_synonym
-    text: '%s NET G1'
-    vars:
-      - location
-  - annotationProperty: related_synonym
-    text: '%s carcinoid tumor'
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: grade 1 neuroendocrine neoplasm of %s
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s neuroendocrine tumor, well differentiated, low grade'
+  vars:
+  - location
+- annotationProperty: exact_synonym
+  text: '%s NET G1'
+  vars:
+  - location
+- annotationProperty: related_synonym
+  text: '%s carcinoid tumor'
+  vars:
+  - location
 
 def:
-    text: A well differentiated, low grade tumor with neuroendocrine differentiation
-        that arises from the %s.
-    vars:
-      - location
+  text: A well differentiated, low grade tumor with neuroendocrine differentiation
+    that arises from the %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'neuroendocrine neoplasm' and 'disease has location' some %s and 'has modifier'\
-        \ some 'grade 1'"
-    vars:
-      - location
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/neuroendocrine_neoplasm_grade1.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''neuroendocrine neoplasm'' and ''disease has location'' some %s and ''has
+    modifier'' some ''grade 1'''
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/nuclear_subtype.yaml
+++ b/src/patterns/dosdp-patterns/nuclear_subtype.yaml
@@ -1,35 +1,39 @@
 pattern_name: nuclear_subtype
+
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/nuclear_subtype.yaml
+
 description: A disease that is classified as a nuclear subtype, due to a defect in
-    a nuclear gene, such as MONDO:0009640 'mitochondrial complex I deficiency, nuclear
-    type'.
+  a nuclear gene, such as MONDO:0009640 'mitochondrial complex I deficiency, nuclear
+  type'.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    nuclear_gene: SO:0000087
-    disease: MONDO:0000001
+  nuclear_gene: SO:0000087
+  disease: MONDO:0000001
 
 relations:
-    disease has basis in dysfunction of: RO:0004020
+  disease has basis in dysfunction of: RO:0004020
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: "'disease'"
+  disease: '''disease'''
 
 name:
-    text: '%s, nuclear type'
-    vars:
-      - disease
+  text: '%s, nuclear type'
+  vars:
+  - disease
 
 def:
-    text: A %s that has a defect in a nuclear gene.
-    vars:
-      - disease
+  text: A %s that has a defect in a nuclear gene.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'disease has basis in dysfunction of' some 'nuclear_gene'"
-    vars:
-      - disease
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/nuclear_subtype.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''disease has basis in dysfunction of'' some ''nuclear_gene'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/postinfectious_disease.yaml
+++ b/src/patterns/dosdp-patterns/postinfectious_disease.yaml
@@ -1,63 +1,60 @@
 pattern_name: postinfectious_disease
 
-description: >-
-    A design pattern for conditions such as post-herpetic neuralgia or postinfectious
-    encephalitis,
-    where the disease is secondary to the initial infection.
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/postinfectious_disease.yaml
 
-    TODO: write better guidelines on what constitutes a secondary disease vs primary.
-    * We do not use this pattern for AIDS-HIV for example, instead representing this
-    is using SubClassOf.
-    * We draw a distinction between infectious and postinfectious encepahlitis.
-    * we do not use this pattern for chickenpox, but we do for shingles 
+description: 'A design pattern for conditions such as post-herpetic neuralgia or postinfectious
+  encephalitis, where the disease is secondary to the initial infection.
+
+  TODO: write better guidelines on what constitutes a secondary disease vs primary.
+  * We do not use this pattern for AIDS-HIV for example, instead representing this
+  is using SubClassOf. * We draw a distinction between infectious and postinfectious
+  encepahlitis. * we do not use this pattern for chickenpox, but we do for shingles '
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
 classes:
-    disease: MONDO:0000001
-    infectious disease: MONDO:0005550
-    organism: NCBITaxon:1
+  disease: MONDO:0000001
+  infectious disease: MONDO:0005550
+  organism: NCBITaxon:1
 
-# NOTE: this may change in future
 relations:
-    disease arises from feature: RO:0004022
+  disease arises from feature: RO:0004022
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: "'organism'"
-    feature: "'infectious disease'"
+  disease: '''organism'''
+  feature: '''infectious disease'''
 
 name:
-    text: postinfectious %s arising from %s
-    vars:
-      - disease
-      - feature
+  text: postinfectious %s arising from %s
+  vars:
+  - disease
+  - feature
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: post-%s %s
-    vars:
-      - feature
-      - disease
-  - annotationProperty: related_synonym
-    text: '%s secondary to %s'
-    vars:
-      - disease
-      - feature
+- annotationProperty: exact_synonym
+  text: post-%s %s
+  vars:
+  - feature
+  - disease
+- annotationProperty: related_synonym
+  text: '%s secondary to %s'
+  vars:
+  - disease
+  - feature
 
 def:
-    text: A post-infectious form of %s that arises as a result on an initial %s.
-    vars:
-      - disease
-      - feature
+  text: A post-infectious form of %s that arises as a result on an initial %s.
+  vars:
+  - disease
+  - feature
 
 equivalentTo:
-    text: "%s and 'disease arises from feature' some %s"
-    vars:
-      - disease
-      - feature
-
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/postinfectious_disease.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''disease arises from feature'' some %s'
+  vars:
+  - disease
+  - feature

--- a/src/patterns/dosdp-patterns/primary_infectious.yaml
+++ b/src/patterns/dosdp-patterns/primary_infectious.yaml
@@ -1,40 +1,41 @@
 pattern_name: primary infectious
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/primary_infectious.yaml
 
-    Pattern for extending a disease class to a primary infectious form, a characteristic
-    of an infectious disease in which the disease affects an immunologically normal
-    host. Example: MONDO_0000308 'primary systemic mycosis'.
+description: '
+
+  Pattern for extending a disease class to a primary infectious form, a characteristic
+  of an infectious disease in which the disease affects an immunologically normal
+  host. Example: MONDO_0000308 ''primary systemic mycosis''.'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    primary infectious: MONDO:0045036
+  primary infectious: MONDO:0045036
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: primary %s
-    vars:
-      - disease
+  text: primary %s
+  vars:
+  - disease
 
 def:
-    text: A %s that arises from infection in an immunologically normal host.
-    vars:
-      - disease
+  text: A %s that arises from infection in an immunologically normal host.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'primary infectious'"
-    vars:
-      - disease
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/primary_infectious.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''primary infectious'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/rare.yaml
+++ b/src/patterns/dosdp-patterns/rare.yaml
@@ -1,41 +1,43 @@
 pattern_name: rare
 
-classes:
-    rare: MONDO:0021136
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/rare.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  rare: MONDO:0021136
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: rare %s
-    vars:
-      - disease
+  text: rare %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: rare %s
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: rare %s
+  vars:
+  - disease
 
 def:
-    text: Any of the forms of %s that have a rare incidence.
-    vars:
-      - disease
+  text: Any of the forms of %s that have a rare incidence.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'rare'"
-    vars:
-      - disease
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/rare.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''rare'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/rare_genetic.yaml
+++ b/src/patterns/dosdp-patterns/rare_genetic.yaml
@@ -1,48 +1,48 @@
 pattern_name: rare_genetic
 
-classes:
-    genetic: MONDO:0021150
-    rare: MONDO:0021136
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/rare_genetic.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  genetic: MONDO:0021150
+  rare: MONDO:0021136
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: rare genetic %s
-    vars:
-      - disease
+  text: rare genetic %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: rare inborn %s
-    vars:
-      - disease
-
-  - annotationProperty: exact_synonym
-    text: rare constitutional %s
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: rare inborn %s
+  vars:
+  - disease
+- annotationProperty: exact_synonym
+  text: rare constitutional %s
+  vars:
+  - disease
 
 def:
-    text: A form of %s that is both rare and genetic.
-    vars:
-      - disease
+  text: A form of %s that is both rare and genetic.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'genetic' and 'has modifier' some 'rare'"
-    vars:
-      - disease
-
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/rare_genetic.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''genetic'' and ''has modifier'' some ''rare'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/realized_in_response_to_environmental_exposure.yaml
+++ b/src/patterns/dosdp-patterns/realized_in_response_to_environmental_exposure.yaml
@@ -1,51 +1,47 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: disease realized in response to environmental exposure
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/realized_in_response_to_evironmental_exposure.yaml
 
-description: >-
-    This pattern is used for a disease, where the cause of the disease is an exposure to an environmental stimulus (using ECTO exposure terms).
+description: 'This pattern is used for a disease, where the cause of the disease is
+  an exposure to an environmental stimulus (using ECTO exposure terms).
 
-    Examples: [chemically-induced disorder](http://purl.obolibrary.org/obo/MONDO_0029001),
-    [alcohol amnestic disorder](http://purl.obolibrary.org/obo/MONDO_0021702), [alcoholic
-    polyneuropathy](http://purl.obolibrary.org/obo/MONDO_0006645) (26 total)
-
-classes:
-    disease: MONDO:0000001
-    exposure event: ExO:0000002
-   
-relations:
-    realized in response to: RO:0009501
-
-vars:
-    disease: "'disease'"
-    exposure: "'exposure event'"
-
-name:
-    text: '%s realized in response to %s'
-    vars:
-      - disease
-      - exposure
-
-def:
-  # Could not induce def, using default
-    text: Any %s that is realized in response to a %s
-    vars:
-      - disease
-      - exposure
-
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-
-# could not infer annotations
-
-
-equivalentTo:
-    text: "%s and ('realized in response to' some %s)"
-    vars:
-      - disease
-      - exposure
+  Examples: [chemically-induced disorder](http://purl.obolibrary.org/obo/MONDO_0029001),
+  [alcohol amnestic disorder](http://purl.obolibrary.org/obo/MONDO_0021702), [alcoholic
+  polyneuropathy](http://purl.obolibrary.org/obo/MONDO_0006645) (26 total)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease: MONDO:0000001
+  exposure event: ExO:0000002
+
+relations:
+  realized in response to: RO:0009501
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease'''
+  exposure: '''exposure event'''
+
+name:
+  text: '%s realized in response to %s'
+  vars:
+  - disease
+  - exposure
+
+def:
+  text: Any %s that is realized in response to a %s
+  vars:
+  - disease
+  - exposure
+
+equivalentTo:
+  text: '%s and (''realized in response to'' some %s)'
+  vars:
+  - disease
+  - exposure

--- a/src/patterns/dosdp-patterns/refractory.yaml
+++ b/src/patterns/dosdp-patterns/refractory.yaml
@@ -1,40 +1,43 @@
 pattern_name: refractory
 
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/refractory.yaml
+
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
 classes:
-    refractory: HP:0031375
-    disease: MONDO:0000001
+  refractory: HP:0031375
+  disease: MONDO:0000001
 
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: disease
+  disease: disease
 
 name:
-    text: refractory %s
-    vars:
-      - disease
+  text: refractory %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, refractory'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, refractory'
+  vars:
+  - disease
 
 def:
-    text: A %s that is difficult to treat or cure.
-    vars:
-      - disease
+  text: A %s that is difficult to treat or cure.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'refractory'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/refractory.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''refractory'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/rhabdomyosarcoma.yaml
+++ b/src/patterns/dosdp-patterns/rhabdomyosarcoma.yaml
@@ -1,58 +1,52 @@
 pattern_name: rhabdomyosarcoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/rhabdomyosarcoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [rhabdomyosarcoma of the cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016282),
-    [breast rhabdomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0002859), [testis
-    rhabdomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0002860) (15 total)
+  Examples: [rhabdomyosarcoma of the cervix uteri](http://purl.obolibrary.org/obo/MONDO_0016282),
+  [breast rhabdomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0002859), [testis
+  rhabdomyosarcoma](http://purl.obolibrary.org/obo/MONDO_0002860) (15 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    rhabdomyosarcoma: MONDO:0005212
+  rhabdomyosarcoma: MONDO:0005212
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.8, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s rhabdomyosarcoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.4666666666666667, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A malignant mesenchymal tumor with skeletal muscle differentiation affecting
-        the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s rhabdomyosarcoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s rhabdomyosarcoma'
-    vars:
-      - v0
-  - annotationProperty: related_synonym
-    # Induced p=related_synonym 
-    text: rhabdomyosarcoma of the %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s rhabdomyosarcoma'
+  vars:
+  - v0
+- annotationProperty: related_synonym
+  text: rhabdomyosarcoma of the %s
+  vars:
+  - v0
 
+def:
+  text: A malignant mesenchymal tumor with skeletal muscle differentiation affecting
+    the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'rhabdomyosarcoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''rhabdomyosarcoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/sarcoma.yaml
+++ b/src/patterns/dosdp-patterns/sarcoma.yaml
@@ -1,51 +1,52 @@
 pattern_name: sarcoma
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/sarcoma.yaml
 
-    Sarcomas are malignant neoplasms arising from soft tissue or bone.
+description: '
 
-    This is a design pattern for classes representing sarcomas based
-    on their location. This may be the site of origin, but it can also
-    represent a secondary site for metastatized sarcma.
+  Sarcomas are malignant neoplasms arising from soft tissue or bone.
 
-    We use the generic 'disease has location' relation, which
-    generalized over primary and secondary sites.
+  This is a design pattern for classes representing sarcomas based on their location.
+  This may be the site of origin, but it can also represent a secondary site for metastatized
+  sarcma.
+
+  We use the generic ''disease has location'' relation, which generalized over primary
+  and secondary sites.'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    sarcoma: MONDO:0005089
+  sarcoma: MONDO:0005089
+  owl_thing: owl:Thing
 
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
+  disease has location: RO:0004026
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    location: owl_thing
+  location: owl_thing
 
 name:
-    text: '%s sarcoma'
-    vars:
-      - location
+  text: '%s sarcoma'
+  vars:
+  - location
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: sarcoma of %s
-    vars:
-      - location
+- annotationProperty: exact_synonym
+  text: sarcoma of %s
+  vars:
+  - location
 
 def:
-    text: A sarcoma involving a %s.
-    vars:
-      - location
+  text: A sarcoma involving a %s.
+  vars:
+  - location
 
 equivalentTo:
-    text: "'sarcoma' and 'disease has location' some %s"
-    vars:
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/sarcoma.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''sarcoma'' and ''disease has location'' some %s'
+  vars:
+  - location

--- a/src/patterns/dosdp-patterns/small_cell_carcinoma.yaml
+++ b/src/patterns/dosdp-patterns/small_cell_carcinoma.yaml
@@ -1,60 +1,54 @@
 pattern_name: small cell carcinoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/small_cell_carcinoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [cervical small cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0006142),
-    [pancreatic small cell neuroendocrine carcinoma](http://purl.obolibrary.org/obo/MONDO_0006348),
-    [ureter small cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0006482) (16
-    total)
+  Examples: [cervical small cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0006142),
+  [pancreatic small cell neuroendocrine carcinoma](http://purl.obolibrary.org/obo/MONDO_0006348),
+  [ureter small cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0006482) (16
+  total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    small cell carcinoma: MONDO:0000402
+  small cell carcinoma: MONDO:0000402
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.3125, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s small cell carcinoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.1875, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: An aggressive, high-grade and poorly differentiated carcinoma with neuroendocrine
-        differentiation that arises from the %s. It is characterized by the presence
-        of malignant small cells.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s small cell carcinoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s small cell carcinoma'
-    vars:
-      - v0
-  - annotationProperty: related_synonym
-    # Induced p=related_synonym 
-    text: small cell cancer of the %s
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s small cell carcinoma'
+  vars:
+  - v0
+- annotationProperty: related_synonym
+  text: small cell cancer of the %s
+  vars:
+  - v0
 
+def:
+  text: An aggressive, high-grade and poorly differentiated carcinoma with neuroendocrine
+    differentiation that arises from the %s. It is characterized by the presence of
+    malignant small cells.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'small cell carcinoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''small cell carcinoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/specific_disease_by_dysfunctional_structure.yaml
+++ b/src/patterns/dosdp-patterns/specific_disease_by_dysfunctional_structure.yaml
@@ -1,52 +1,45 @@
-# options: [min(15),dir(tmp),trim(true),max_and_cardinality(4),base('http://purl.obolibrary.org/obo/mondo'),exclude_prefixes(['UBERON']),load_import_closure(false),annotations([ann(exact_synonym,oio:hasExactSynonym,0.05),ann(related_synonym,oio:hasRelatedSynonym,0.05)])]
 pattern_name: X disease has basis in dysfunction of X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_disease_by_dysfunctional_structure.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [collagenopathy type 2 alpha 1](http://purl.obolibrary.org/obo/MONDO_0022800),
-    [hemoglobinopathy](http://purl.obolibrary.org/obo/MONDO_0044348), [blood platelet
-    disease](http://purl.obolibrary.org/obo/MONDO_0002245) (2195 total)
+  Examples: [collagenopathy type 2 alpha 1](http://purl.obolibrary.org/obo/MONDO_0022800),
+  [hemoglobinopathy](http://purl.obolibrary.org/obo/MONDO_0044348), [blood platelet
+  disease](http://purl.obolibrary.org/obo/MONDO_0002245) (2195 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    owl:Thing: owl:Thing
-
+  owl:Thing: owl:Thing
 
 relations:
-    disease has basis in dysfunction of: RO:0004020
-
-
-vars:
-    v0: "'owl:Thing'"
-    v1: "'owl:Thing'"
-
-name:
-  # Induced, frequency=0.001366742596810934, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s %s'
-    vars:
-      - v1
-      - v0
-
-def:
-  # Induced, frequency=0.001366742596810934, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: Any %s in which the causes of the disease is a perturbation of the %s leading
-        to its dysfunction.
-    vars:
-      - v0
-      - v1
+  disease has basis in dysfunction of: RO:0004020
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
-# could not infer annotations
+vars:
+  v0: '''owl:Thing'''
+  v1: '''owl:Thing'''
 
+name:
+  text: '%s %s'
+  vars:
+  - v1
+  - v0
+
+def:
+  text: Any %s in which the causes of the disease is a perturbation of the %s leading
+    to its dysfunction.
+  vars:
+  - v0
+  - v1
 
 equivalentTo:
-    text: "%s and ('disease has basis in dysfunction of' some %s)"
-    vars:
-      - v0
-      - v1
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and (''disease has basis in dysfunction of'' some %s)'
+  vars:
+  - v0
+  - v1

--- a/src/patterns/dosdp-patterns/specific_infectious_disease_by_agent.yaml
+++ b/src/patterns/dosdp-patterns/specific_infectious_disease_by_agent.yaml
@@ -1,49 +1,50 @@
 pattern_name: specific_inflammatory_disease_by_site
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_infectious_disease_by_agent.yaml
 
-    as for inflammatory_disease_by_site, but refining a specific disease
+description: '
+
+  as for inflammatory_disease_by_site, but refining a specific disease'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    disease: MONDO:0000001
-    organism: NCBITaxon:1
+  disease: MONDO:0000001
+  organism: NCBITaxon:1
 
 relations:
-    realized in response to stimulus: RO:0004028
+  realized in response to stimulus: RO:0004028
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: "'disease'"
-    agent: "'organism'"
+  disease: '''disease'''
+  agent: '''organism'''
 
 name:
-    text: '%s %s'
-    vars:
-      - agent
-      - disease
+  text: '%s %s'
+  vars:
+  - agent
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s caused %s'
-    vars:
-      - agent
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s caused %s'
+  vars:
+  - agent
+  - disease
 
 def:
-    text: An %s caused by infection with %s.
-    vars:
-      - disease
-      - agent
+  text: An %s caused by infection with %s.
+  vars:
+  - disease
+  - agent
 
 equivalentTo:
-    text: "%s and 'realized in response to stimulus' some %s"
-    vars:
-      - disease
-      - agent
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_infectious_disease_by_agent.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''realized in response to stimulus'' some %s'
+  vars:
+  - disease
+  - agent

--- a/src/patterns/dosdp-patterns/specific_infectious_disease_by_location.yaml
+++ b/src/patterns/dosdp-patterns/specific_infectious_disease_by_location.yaml
@@ -1,42 +1,43 @@
 pattern_name: specific_infectious_disease_by_location
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_infectious_disease_by_location.yaml
 
-    TODO
+description: '
+
+  TODO'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    disease: MONDO:0000001
-    anatomical structure: UBERON:0000061
+  disease: MONDO:0000001
+  anatomical structure: UBERON:0000061
 
 relations:
-    disease has inflammation site: RO:0004027
+  disease has inflammation site: RO:0004027
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: "'disease'"
-    location: "'anatomical structure'"
+  disease: '''disease'''
+  location: '''anatomical structure'''
 
 name:
-    text: '%s %s'
-    vars:
-      - location
-      - disease
+  text: '%s %s'
+  vars:
+  - location
+  - disease
 
 def:
-    text: An %s involving a pathogenic inflammatory response in the %s.
-    vars:
-      - disease
-      - location
+  text: An %s involving a pathogenic inflammatory response in the %s.
+  vars:
+  - disease
+  - location
 
 equivalentTo:
-    text: "%s and 'disease has inflammation site' some %s"
-    vars:
-      - disease
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_infectious_disease_by_location.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''disease has inflammation site'' some %s'
+  vars:
+  - disease
+  - location

--- a/src/patterns/dosdp-patterns/specific_inflammatory_disease_by_site.yaml
+++ b/src/patterns/dosdp-patterns/specific_inflammatory_disease_by_site.yaml
@@ -1,49 +1,50 @@
 pattern_name: specific_inflammatory_disease_by_site
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_inflammatory_disease_by_site.yaml
 
-    as for inflammatory_disease_by_site, but refining a specific disease
+description: '
+
+  as for inflammatory_disease_by_site, but refining a specific disease'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    disease: MONDO:0000001
-    anatomical structure: UBERON:0000061
+  disease: MONDO:0000001
+  anatomical structure: UBERON:0000061
 
 relations:
-    disease has inflammation site: RO:0004027
+  disease has inflammation site: RO:0004027
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: "'disease'"
-    location: "'anatomical structure'"
+  disease: '''disease'''
+  location: '''anatomical structure'''
 
 name:
-    text: '%s %s'
-    vars:
-      - location
-      - disease
+  text: '%s %s'
+  vars:
+  - location
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s %sitis'
-    vars:
-      - disease
-      - location
+- annotationProperty: exact_synonym
+  text: '%s %sitis'
+  vars:
+  - disease
+  - location
 
 def:
-    text: An %s involving a pathogenic inflammatory response in the %s.
-    vars:
-      - disease
-      - location
+  text: An %s involving a pathogenic inflammatory response in the %s.
+  vars:
+  - disease
+  - location
 
 equivalentTo:
-    text: "%s and 'disease has inflammation site' some %s"
-    vars:
-      - disease
-      - location
-
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/specific_inflammatory_disease_by_site.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''disease has inflammation site'' some %s'
+  vars:
+  - disease
+  - location

--- a/src/patterns/dosdp-patterns/squamous_cell_carcinoma.yaml
+++ b/src/patterns/dosdp-patterns/squamous_cell_carcinoma.yaml
@@ -1,53 +1,47 @@
 pattern_name: squamous cell carcinoma disease has location X
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/squamous_cell_carcinoma.yaml
 
-description: >-
-    This is auto-generated. Add your description here
+description: 'This is auto-generated. Add your description here
 
-    Examples: [cervical squamous cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0006143),
-    [skin squamous cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0002529),
-    [ureter squamous cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0003502)
-    (63 total)
+  Examples: [cervical squamous cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0006143),
+  [skin squamous cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0002529), [ureter
+  squamous cell carcinoma](http://purl.obolibrary.org/obo/MONDO_0003502) (63 total)'
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    squamous cell carcinoma: MONDO:0005096
+  squamous cell carcinoma: MONDO:0005096
+  owl_thing: owl:Thing
 
-
-    owl_thing: owl:Thing
 relations:
-    disease has location: RO:0004026
-
-
-vars:
-    v0: owl_thing
-
-name:
-  # Induced, frequency=0.5714285714285714, p=http://www.w3.org/2000/01/rdf-schema#label 
-    text: '%s squamous cell carcinoma'
-    vars:
-      - v0
-
-def:
-  # Induced, frequency=0.19047619047619047, p=http://purl.obolibrary.org/obo/IAO_0000115 
-    text: A squamous cell carcinoma that involves the %s.
-    vars:
-      - v0
+  disease has location: RO:0004026
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  v0: owl_thing
+
+name:
+  text: '%s squamous cell carcinoma'
+  vars:
+  - v0
 
 annotations:
-  - annotationProperty: exact_synonym
-    # Induced p=exact_synonym 
-    text: '%s squamous cell carcinoma'
-    vars:
-      - v0
+- annotationProperty: exact_synonym
+  text: '%s squamous cell carcinoma'
+  vars:
+  - v0
 
+def:
+  text: A squamous cell carcinoma that involves the %s.
+  vars:
+  - v0
 
 equivalentTo:
-    text: "'squamous cell carcinoma' and ('disease has location' some %s)"
-    vars:
-      - v0
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '''squamous cell carcinoma'' and (''disease has location'' some %s)'
+  vars:
+  - v0

--- a/src/patterns/dosdp-patterns/susceptibility_by_gene.yaml
+++ b/src/patterns/dosdp-patterns/susceptibility_by_gene.yaml
@@ -1,59 +1,57 @@
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/susceptibility_by_gene.yaml
 pattern_name: susceptibility_by_gene
 
-description: >4-
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/susceptibility_by_gene.yaml
 
-    Examples - [autism, susceptibility to, X-linked 5](http://purl.obolibrary.org/obo/MONDO_0010449),
-    [bulimia nervosa, susceptibility to, 2](http://purl.obolibrary.org/obo/MONDO_0012461),
-    [nephrolithiasis susceptibility caused by SLC26A1](http://purl.obolibrary.org/obo/MONDO_0020722)
+description: '
 
-classes:
-    disease or disorder: MONDO:0000001
-    inherited disease susceptibility: MONDO:0020573
-    gene: SO:0000704
-
-
-relations:
-    disease has basis in dysfunction of: RO:0004020
-    predisposes towards: http://purl.obolibrary.org/obo/mondo#predisposes_towards
-
-
-vars:
-    gene: "'gene'"
-    disease: "'disease or disorder'"
-
-name:
-  # Could not induce name, using default
-    text: '%s susceptibility, %s form'
-    vars:
-      - disease
-      - gene
-
-def:
-    text: A susceptibility or predisposition to %s in which the cause of the disease is a mutation in the %s gene.
-    vars:
-      - disease
-      - gene
-
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym    
-    related_synonym: oio:hasRelatedSynonym
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: '%s susceptibility caused by %s'
-    vars:
-      - disease
-      - gene
-
-equivalentTo:
-    text: ('inherited disease susceptibility' and ('disease has basis in dysfunction
-        of' some %s) and ('predisposes towards' some %s))
-    vars:
-      - gene
-      - disease
-
+  Examples - [autism, susceptibility to, X-linked 5](http://purl.obolibrary.org/obo/MONDO_0010449),
+  [bulimia nervosa, susceptibility to, 2](http://purl.obolibrary.org/obo/MONDO_0012461),
+  [nephrolithiasis susceptibility caused by SLC26A1](http://purl.obolibrary.org/obo/MONDO_0020722)'
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  disease or disorder: MONDO:0000001
+  inherited disease susceptibility: MONDO:0020573
+  gene: SO:0000704
+
+relations:
+  disease has basis in dysfunction of: RO:0004020
+  predisposes towards: http://purl.obolibrary.org/obo/mondo#predisposes_towards
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  gene: '''gene'''
+  disease: '''disease or disorder'''
+
+name:
+  text: '%s susceptibility, %s form'
+  vars:
+  - disease
+  - gene
+
+annotations:
+- annotationProperty: exact_synonym
+  text: '%s susceptibility caused by %s'
+  vars:
+  - disease
+  - gene
+
+def:
+  text: A susceptibility or predisposition to %s in which the cause of the disease
+    is a mutation in the %s gene.
+  vars:
+  - disease
+  - gene
+
+equivalentTo:
+  text: ('inherited disease susceptibility' and ('disease has basis in dysfunction
+    of' some %s) and ('predisposes towards' some %s))
+  vars:
+  - gene
+  - disease

--- a/src/patterns/dosdp-patterns/syndromic.yaml
+++ b/src/patterns/dosdp-patterns/syndromic.yaml
@@ -1,53 +1,57 @@
 pattern_name: syndromic
 
-description: >-
-    Some diseases exist in both isolated and syndromic forms. For example, aniridia ([MONDO_0019172 aniridia](http://purl.obolibrary.org/obo/MONDO_0019172), [MONDO_0020148'syndromic aniridia'](http://purl.obolibrary.org/obo/MONDO_0020148) and [MONDO_0007119 'isolated aniridia'](http://purl.obolibrary.org/obo/MONDO_0007119). Use this pattern to define the syndromic form of a disease when a term exists for the isolated/syndromic-neutral version.
-    In general, this pattern should be used in parallel with isolated. E.g. if you make a term 'syndromic disease, you should also have 'isolated disease' [see pattern here(https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/isolated.yaml). 
-    
-    Note that the isolated and syndromic forms will be inferred to be disjoint due to the GCI pattern.
-
-classes:
-    syndromic: MONDO:0021127
-    disease or disorder: "MONDO:0000001"
-
-relations:
-    has modifier: RO:0002573
-
-vars:
-    disease: "'disease or disorder'"
-
-name:
-    text: syndromic %s
-    vars:
-      - disease
-
-annotations:
-  - annotationProperty: exact_synonym
-    text: syndromic %s
-    vars:
-      - disease
-      
-  - annotationProperty: related_synonym
-    text: syndrome associated with %s
-    vars:
-      - disease
-
-def:
-    text: A %s that is part of a larger syndrome.
-    vars:
-      - disease
-
-equivalentTo:
-    text: "%s and 'has modifier' some 'syndromic'"
-    vars:
-      - disease
-
-
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/syndromic.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
+
+description: "Some diseases exist in both isolated and syndromic forms. For example,\
+  \ aniridia ([MONDO_0019172 aniridia](http://purl.obolibrary.org/obo/MONDO_0019172),\
+  \ [MONDO_0020148'syndromic aniridia'](http://purl.obolibrary.org/obo/MONDO_0020148)\
+  \ and [MONDO_0007119 'isolated aniridia'](http://purl.obolibrary.org/obo/MONDO_0007119).\
+  \ Use this pattern to define the syndromic form of a disease when a term exists\
+  \ for the isolated/syndromic-neutral version. In general, this pattern should be\
+  \ used in parallel with isolated. E.g. if you make a term 'syndromic disease, you\
+  \ should also have 'isolated disease' [see pattern here(https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/isolated.yaml).\
+  \ \nNote that the isolated and syndromic forms will be inferred to be disjoint due\
+  \ to the GCI pattern."
 
 contributors:
-  - https://orcid.org/0000-0002-6601-2165
-  - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-6601-2165
+- https://orcid.org/0000-0001-5208-3432
+
+classes:
+  syndromic: MONDO:0021127
+  disease or disorder: MONDO:0000001
+
+relations:
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  disease: '''disease or disorder'''
+
+name:
+  text: syndromic %s
+  vars:
+  - disease
+
+annotations:
+- annotationProperty: exact_synonym
+  text: syndromic %s
+  vars:
+  - disease
+- annotationProperty: related_synonym
+  text: syndrome associated with %s
+  vars:
+  - disease
+
+def:
+  text: A %s that is part of a larger syndrome.
+  vars:
+  - disease
+
+equivalentTo:
+  text: '%s and ''has modifier'' some ''syndromic'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/vectorBorneDisease.yaml
+++ b/src/patterns/dosdp-patterns/vectorBorneDisease.yaml
@@ -1,43 +1,43 @@
 pattern_name: vectorBorneDisease
+
 pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/vectorBorneDisease.yaml
 
-description: "An infectious disease where a pathogen is carried and transmitted by\
-    \ another organism that acts as disease vector. Examples: MONDO_0020601 'mosquito-borne\
-    \ viral encephalitis', MONDO_0017572 'tick-borne encephalitis'"
+description: 'An infectious disease where a pathogen is carried and transmitted by
+  another organism that acts as disease vector. Examples: MONDO_0020601 ''mosquito-borne
+  viral encephalitis'', MONDO_0017572 ''tick-borne encephalitis'''
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
 
 classes:
-    infectious disease: MONDO:0005550
-    organism: OBI:0100026
+  infectious disease: MONDO:0005550
+  organism: OBI:0100026
 
 relations:
-    transmitted by: RO:0002451
-
-vars:
-    infectious_disease: "'infectious disease'"
-    vector: "'organism'"
-
-name:
-    text: '%s transmitted by %s'
-    vars:
-      - infectious_disease
-      - vector
-
-def:
-    text: '%s-borne %s.'
-    vars:
-      - vector
-      - infectious_disease
-
-
-
-equivalentTo:
-    text: (%s and ('transmitted by' some %s))
-    vars:
-      - infectious_disease
-      - vector
+  transmitted by: RO:0002451
 
 annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
+
+vars:
+  infectious_disease: '''infectious disease'''
+  vector: '''organism'''
+
+name:
+  text: '%s transmitted by %s'
+  vars:
+  - infectious_disease
+  - vector
+
+def:
+  text: '%s-borne %s.'
+  vars:
+  - vector
+  - infectious_disease
+
+equivalentTo:
+  text: (%s and ('transmitted by' some %s))
+  vars:
+  - infectious_disease
+  - vector

--- a/src/patterns/dosdp-patterns/x_linked.yaml
+++ b/src/patterns/dosdp-patterns/x_linked.yaml
@@ -1,40 +1,43 @@
 pattern_name: x_linked
 
-classes:
-    x_linked_inheritance: HP:0001417
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/x_linked.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  x_linked_inheritance: HP:0001417
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: X-linked %s
-    vars:
-      - disease
+  text: X-linked %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, X-linked'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, X-linked'
+  vars:
+  - disease
 
 def:
-    text: X-linked form of %s.
-    vars:
-      - disease
+  text: X-linked form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'x_linked_inheritance'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/x_linked.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''x_linked_inheritance'''
+  vars:
+  - disease

--- a/src/patterns/dosdp-patterns/y_linked.yaml
+++ b/src/patterns/dosdp-patterns/y_linked.yaml
@@ -1,40 +1,43 @@
 pattern_name: y_linked
 
-classes:
-    y_linked_inheritance: HP:0001450
+pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/y_linked.yaml
 
-    owl_thing: owl:Thing
+description: TBD.
+
+contributors:
+- https://orcid.org/0000-0002-6601-2165
+
+classes:
+  y_linked_inheritance: HP:0001450
+  owl_thing: owl:Thing
+
 relations:
-    has modifier: RO:0002573
+  has modifier: RO:0002573
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+  related_synonym: oio:hasRelatedSynonym
 
 vars:
-    disease: owl_thing
+  disease: owl_thing
 
 name:
-    text: Y-linked %s
-    vars:
-      - disease
+  text: Y-linked %s
+  vars:
+  - disease
 
 annotations:
-  - annotationProperty: exact_synonym
-    text: '%s, Y-linked'
-    vars:
-      - disease
+- annotationProperty: exact_synonym
+  text: '%s, Y-linked'
+  vars:
+  - disease
 
 def:
-    text: Y-linked form of %s.
-    vars:
-      - disease
+  text: Y-linked form of %s.
+  vars:
+  - disease
 
 equivalentTo:
-    text: "%s and 'has modifier' some 'y_linked_inheritance'"
-    vars:
-      - disease
-
-pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/y_linked.yaml
-annotationProperties:
-    exact_synonym: oio:hasExactSynonym
-    related_synonym: oio:hasRelatedSynonym
-description: TBD.
-contributors:
-  - https://orcid.org/0000-0002-6601-2165
+  text: '%s and ''has modifier'' some ''y_linked_inheritance'''
+  vars:
+  - disease


### PR DESCRIPTION
Used this simple script to reorder all the patterns to a single standard:

```

import os
import yaml

pattern_dir = "/Users/matentzn/ws/mondo/src/patterns/dosdp-patterns"

ordered = ["pattern_name", "pattern_iri", "description", "contributors", "classes", "relations", "annotationProperties", "vars", "name", "annotations", "def", "equivalentTo"]
files = os.listdir(pattern_dir)
files.sort()
class MyDumper(yaml.SafeDumper):
    # HACK: insert blank lines between top-level objects
    # inspired by https://stackoverflow.com/a/44284819/3786245
    def write_line_break(self, data=None):
        super().write_line_break(data)

        if len(self.indents) == 1:
            super().write_line_break()

for filename in files:
    if filename.endswith(".yaml"):
        f_path = os.path.join(pattern_dir,filename)
        f = open(f_path)
        try:
            y = yaml.load(f, Loader=yaml.FullLoader)
            yn = {}

            for k in ordered:
                if k in y:
                    yn[k]=y[k]
                else:
                    if k=="contributors":
                        yn[k]=["https://orcid.org/0000-0002-6601-2165", "https://orcid.org/0000-0001-5208-3432"]
            for key in y:
                if key not in ordered:
                    print(f"WARNING: {key} not considered in order")
                    yn[key]=y[key]

            with open(f_path, 'w') as file:
                yaml.dump(yn, file, Dumper=MyDumper, sort_keys=False)
        except yaml.YAMLError as exc:
            print(exc)

```