### PR TITLE
Mass removal of related syns where there are exact syns

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -242,10 +242,14 @@ reports/mondo_unsats.md: mondo.obo
 
 .PHONY: mondo_feature_diff
 mondo_feature_diff: reports/robot_diff.md reports/mondo_unsats.md
+
+.PHONY: mondo_feature_diff
 related_annos_to_exact:
 	$(ROBOT) query --use-graphs false -i $(SRC) --update $(SPARQLDIR)/related-exact-synonym-annotations.ru -o $(SRC)
 
+.PHONY: r2e
 r2e:
 	make related_annos_to_exact
 	make NORM
+	mv NORM mondo-edit.obo
 	


### PR DESCRIPTION
After a review by @nicolevasilevsky we decided to go ahead with clearing out the related synonyms where there are exact ones.

We are doing it in two steps. This PR:
1. Gets rid of all related synonyms where there is an exact synonym
2. Moves the annotations over (note there are some spurious other changes because I ran "NORM")

I would suggest this:
1. @nicolevasilevsky you review this with some care (I would say 20 min at least)
2. You pass on your observations to @cmungall who gives the final ok.

