### PR TITLE
Adding a check for APs used on axiom annotations

### DIFF
--- a/src/sparql/qc/general/qc-deprecated-class-reference.sparql
+++ b/src/sparql/qc/general/qc-deprecated-class-reference.sparql
@@ -1,0 +1,67 @@
+# # Deprecated Class Reference
+#
+# **Problem:** A deprecated class is used in a logical axiom. A deprecated class can be the child of another class (e.g. ObsoleteClass), but it cannot have children or be used in blank nodes or equivalent class statements. Additionally, a deprecated class should not have any equivalent classes or anonymous parents.
+#
+# **Solution:** Replace deprecated class.
+
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  {
+   VALUES ?property {
+     rdfs:subClassOf
+   }
+   ?entity a owl:Class;
+           owl:deprecated true ;
+           ?property ?value .
+   FILTER ( ?value NOT IN (oboInOwl:ObsoleteClass, owl:Thing) )
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:equivalentClass
+     owl:disjointWith
+   }
+   ?entity a owl:Class;
+           owl:deprecated true ;
+           ?property ?value .
+  }
+  UNION
+  {
+     VALUES ?property {
+       rdfs:subClassOf
+       owl:equivalentClass
+       owl:disjointWith
+     }
+     ?entity a owl:Class;
+             owl:deprecated true .  
+     ?value ?property ?entity .
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:ObjectProperty
+     owl:DataProperty
+   }
+   ?entity a owl:Class ;
+           owl:deprecated true ;
+           ?property ?value .
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:someValuesFrom   
+     owl:allValuesFrom
+   }
+   ?value a owl:Class ;
+          owl:deprecated true .
+   ?rest a owl:Restriction ;
+         ?property ?value .
+   BIND("anonymous expression" as ?entity)
+  }
+}
+ORDER BY ?entity

--- a/src/sparql/qc/general/qc-illegal-axiom-annotation.sparql
+++ b/src/sparql/qc/general/qc-illegal-axiom-annotation.sparql
@@ -1,0 +1,23 @@
+PREFIX IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+# Checks wether Axiom annotation are one of oboInOwl:source, oboInOwl:hasDbXref or oboInOwl:hasSynonymType .
+
+SELECT distinct ?entity ?property ?value
+WHERE 
+{ 
+      [
+         a owl:Axiom ;
+           owl:annotatedSource ?entity ;
+           owl:annotatedProperty ?property ;
+           owl:annotatedTarget ?x ;
+           ?value ?y 
+      ] .
+    FILTER(?property!=rdfs:subClassOf && ?value!=rdfs:comment)
+  	FILTER(?y!=?x && ?y!=?property && ?y!=?entity && ?y!=owl:Axiom)
+  	FILTER ((?value != oboInOwl:source) && (?value != oboInOwl:hasDbXref) && (?value != oboInOwl:hasSynonymType)) .
+    FILTER (isIRI(?entity) && regex(str(?entity), "^http://purl.obolibrary.org/obo/MONDO_"))
+
+}


### PR DESCRIPTION
Add sparql check that checks wether Axiom annotation are one of oboInOwl:source, oboInOwl:hasDbXref or oboInOwl:hasSynonymType  (or comments in the case of subclass of axioms).

also fixing all current violations

fixes https://github.com/monarch-initiative/mondo/issues/3444