### PR TITLE
OMIM and ORDO sync

### DIFF
--- a/docs/editors-guide/update-external-sources.md
+++ b/docs/editors-guide/update-external-sources.md
@@ -1,0 +1,21 @@
+# Update external sources
+
+## Update OMIM
+
+1. run ingest: https://ci.monarchinitiative.org/job/build-omim/ note: right now only a few people can actually run this and it is likely to be replaced by the new ingest being developed by Dazhi soon. For the moment, ping Nico to run this ingest. Before continuing to step 2, make sure that the run has completed by checking that the last run in the [build history](https://ci.monarchinitiative.org/job/build-omim/) is green. 
+2. In terminal: `cd src/ontology`
+3. In terminal: `sh run.sh make omim_slurp -B`
+4. If successful this command will create two files: mondo/src/ontology/tmp/ps_slurp_omim.obo and mondo/src/ontology/tmp/rest_slurp_omim.obo
+5. Add all the classes from the slurped files to mondo-edit.obo. (Use a text editor, rathe than Protege). 
+6. If ps_slurp_omim.obo is not empty, go back to step 3 and run the slurp again until the ps_slurp_omim.obo is empty
+
+## Update ORDO
+
+1. In Finder/atom, go to src/ontology/sources/orphanet/Makefile
+1. Change V=`3.2` to whatever version is the latest. To find the latest version, go to http://www.orphadata.org/, scroll down, search for Ontologies and click on section about ORDO.
+1. In terminal: `cd src/ontology`
+1. In terminal: `sh run.sh make ordo_slurp -B`
+1. If successful this command will create two files: mondo/src/ontology/tmp/ps_slurp_ordo.obo and mondo/src/ontology/tmp/rest_slurp_ordo.obo. Note: ps_slurp_ordo.obo should always be empty
+1. Add all the classes from the slurped files to mondo-edit.obo 
+
+

--- a/docs/editors-guide/update-external-sources.md
+++ b/docs/editors-guide/update-external-sources.md
@@ -18,4 +18,28 @@
 1. If successful this command will create two files: mondo/src/ontology/tmp/ps_slurp_ordo.obo and mondo/src/ontology/tmp/rest_slurp_ordo.obo. Note: ps_slurp_ordo.obo should always be empty
 1. Add all the classes from the slurped files to mondo-edit.obo 
 
+## Notes about adding new classes to mondo
+1. Add the new classes via the mondo-edit.obo text file (ie Open mondo-edit.obo in Atom and copy and paste the text into the end of the mondo-edit.obo text file.)
+1. Before copying and pasting the new terms into the text file, the terms should be reviewed and edited as described below.
 
+### Review new OMIM terms 
+1. Check Mondo to ensure the term does not already exist (ie the term was already added from another source).
+1. If the term already exists in Mondo, add the OMIM ID as a dbxref, and add MONDO:equivalentTo.
+1. Add any synonyms from OMIM (if they don't already exist), or add OMIM as a dbxref to any existing synonyms, as applicable.
+1. Terms in the OMIM slurp include RELATED synonyms in the format TERM IN ALL CAPS; ABBREVIATION, for example: `synonym: "MEGACYSTIS-MICROCOLON-INTESTINAL HYPOPERISTALSIS SYNDROME 2; MMIHS2" RELATED  [OMIM:619351]`. 
+1. For these cases, we do not want to duplicate the label in the synonym, so delete the duplicate label.
+1. In almost all cases, the synonym should be EXACT.
+1. Mark the abbreviation with ABBREVIATION 
+For example: `synonym: "MMIHS2" RELATED ABBREVIATION [OMIM:619351]`
+
+### Review new Orphanet terms 
+1. Check Mondo to ensure the term does not already exist (ie the term was already added from another source like OMIM or NCIT).
+1. If the term already exists in Mondo, add the Orphanet ID as a dbxref, and add MONDO:equivalentTo.
+1. Add any synonyms from Orphanet (if they don't already exist), or add Orphanet as a dbxref to any existing synonyms, as applicable.
+1. Check the capitalization of the synonyms and revise accordingly. All synonyms should lowercase unless they are proper names or abbreviations.
+1. Add abbreviation tags to synonyms where applicable.
+1. Fix annotations to 'narrow to broad term' or 'broad to narrow term'. The format should be changed as shown in the example below:
+- **Original:**
+xref: `ICD10:D21.9 {source="Orphanet:595133"} {source="NTBT (ORPHA code's Narrower Term maps to a Broader Term)"}` 
+- **Fixed:**
+xref: `ICD10:D21.9 {source="Orphanet:595133", source="Orphanet:595133/ntbt"}`

--- a/src/ontology/sources/orphanet/Makefile
+++ b/src/ontology/sources/orphanet/Makefile
@@ -31,7 +31,7 @@ EFO2OBO_OPTS = --rename-entity $(EFO)/definition $(OBO)/IAO_0000115 \
            --rename-entity $(OBO)/ECO_0000218 "$(OIO)source"
 
 
-V=3.1
+V=3.2
 
 # STEP 0: DOWNLOAD
 #ordo_orphanet.owl.zip:


### PR DESCRIPTION
- reclassify 'COVID-19–associated multisystem inflammatory syndrome in adults' and 'COVID-19–associated multisystem inflammatory syndrome in children' as child of 'multisystem inflammatory syndrome in children and adults'
- write up documentation about how to do OMIM and ORDO slurp

**Notes:**
- I checked OMIM for new genetic diseases from Orphanet to see if a class already existed in OMIM and if it didn't, I added the new Orphanet class to Mondo, otherwise I just added Orphanet xrefs to existing Mondo classes. For example:
  - there is not a class in [OMIM](https://omim.org/phenotypicSeries/PS266600) that is a TRIM22-related inflammatory bowel disease
  - there is not a class in [OMIM](https://omim.org/phenotypicSeries/PS266600) that is a ALPI-related inflammatory bowel disease

**Questions:**

- [x] there is this term (see below) in Orphanet, which might be equivalent to MONDO_0035364 'oculocutaneous albinism type 8' (https://omim.org/entry/619165), but Orphanet doesn't have much info about this term, so I can't be sure. Should I add the Orphanet ID as an equiv xref on MONDO_0035364?

[Term]
id: MONDO:0035364
name: oculocutaneous albinism type 8
subset: ordo_disease
synonym: "OCA8" EXACT  [Orphanet:597733]
is_a: MONDO:0000001 {source="Orphanet:597733"} ! disease or disorder
is_a: MONDO:0018910 {source="Orphanet:597733"} ! oculocutaneous albinism
xref: Orphanet:597733 {source="MONDO:equivalentTo"} ! oculocutaneous albinism type 8

- [x] I think the term below is equivalent to this [OMIM term](https://omim.org/entry/618367) (MONDO_0032705 Neurodevelopmental disorder with microcephaly, epilepsy, and hypomyelination), but there is not a mapping b/w these two terms in OMIM or Orphanet

[Term]
id: MONDO:0035369
name: mthfs-related developmental delay-microcephaly-short stature-epilepsy syndrome
subset: ordo_disease
is_a: MONDO:0015162 {source="Orphanet:597874"} ! obsolete rare syndromic intellectual disability
is_a: MONDO:0015983 {source="Orphanet:597874"} ! obsolete rare genetic syndromic intellectual disability
is_a: MONDO:0016406 {source="Orphanet:597874"} ! obsolete other metabolic disease with epilepsy
is_a: MONDO:0017313 {source="Orphanet:597874"} ! disorder of folate metabolism and transport
is_a: MONDO:0000001 {source="Orphanet:597874"} ! disease or disorder
is_a: MONDO:0019046 {source="Orphanet:597874"} ! leukodystrophy
is_a: MONDO:0019058 {source="Orphanet:597874"} ! neurometabolic disease
xref: Orphanet:597874 {source="MONDO:equivalentTo"} ! mthfs-related developmental delay-microcephaly-short stature-epilepsy syndrome