### PR TITLE
Bugfix: `%_slurp` failing because no `src/ontology/tmp/` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,8 @@ src/patterns/imports/seed.txt
 src/patterns/imports/seed.txt
 src/patterns/imports/seed_sorted.txt
 src/ontology/mondo-qc.*
-src/ontology/tmp/
+src/ontology/tmp/*
+!src/ontology/tmp/.keep
 src/ontology/mondo_current_release.owl
 src/ontology/sources/*.json
 src/ontology/sources/*/*.owl


### PR DESCRIPTION
Updates
- `src/ontology/Makefile`: `%_slurp`: Was failing because there was no `src/ontology/tmp/` dir. Fixed this by adding the dir and a blank `.keep` file, and updating the `.gitignore` so that only this directory and only this file in this directory will be preserved.