### PR TITLE
Update monarch rdf file location

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -721,7 +721,7 @@ mirror/medgen-disease-extract.owl: mirror/medgen-disease-extract.obo
 	owltools $< -o $@.tmp && perl -npe $(FIX_URI_EXPR) $@.tmp > $@
 
 mirror/dipper-%.ttl:
-	wget --no-check-certificate https://archive.monarchinitiative.org/latest/rdf/$*.ttl -O $@.tmp && perl -npe 's@https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:@http://identifiers.org/hgnc/@g' $@.tmp > $@
+	wget --no-check-certificate https://data.monarchinitiative.org/monarch/latest/$*.ttl -O $@.tmp && perl -npe 's@https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:@http://identifiers.org/hgnc/@g' $@.tmp > $@
 
 mirror/dipper-%.obo: mirror/dipper-%.ttl
 	$(ROBOT) convert -i $< -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@


### PR DESCRIPTION
Updated with a data.monarchinitiative.org url that points to the latest ttl files. 

(This may change again as we settle into a merged archive + data filesystem, but most importantly it's served from the new infrastructure)