### PR TITLE
query for number of rare diseases in Mondo

### DIFF
--- a/src/sparql/reports/paper_rarediseases.sparql
+++ b/src/sparql/reports/paper_rarediseases.sparql
@@ -1,0 +1,33 @@
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# MONDO classes with the axiom "'has modifier' some rare" AND/OR "has subset :‘gard_rare’" AND limited to the 'disease' branch (ie not including terms from the 'disease susceptibility' branch)
+
+SELECT distinct (count(distinct ?cls) as ?count)
+
+WHERE 
+{
+  {?cls a owl:Class;
+          rdfs:subClassOf+ <http://purl.obolibrary.org/obo/MONDO_0000001> .
+
+  ?cls rdfs:subClassOf+ [
+               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002573> ;
+               owl:someValuesFrom <http://purl.obolibrary.org/obo/MONDO_0021136> ] }
+ 
+ UNION 
+  { ?cls a owl:Class;
+          rdfs:subClassOf+ <http://purl.obolibrary.org/obo/MONDO_0000001> .
+
+    ?cls <http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/mondo#gard_rare>. }
+
+  
+  FILTER NOT EXISTS {
+    ?cls owl:deprecated "true"^^xsd:boolean
+  }
+ FILTER( !isBlank(?cls) && STRSTARTS(str(?cls), "http://purl.obolibrary.org/obo/MONDO_"))
+}
+  


### PR DESCRIPTION
@Nico : what this query does is explained in the comment in the query.

And for convenience:
MONDO classes with the axiom "'has modifier' some rare" AND/OR "has subset :‘gard_rare’" AND limited to the 'disease' branch (ie not including terms from the 'disease susceptibility' branch)