### PR TITLE
mondo.sssom.config updates

### DIFF
--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -4,6 +4,9 @@ curie_map:
   NCIT: http://purl.obolibrary.org/obo/NCIT_
   DOID: http://purl.obolibrary.org/obo/DOID_
   EFO: http://www.ebi.ac.uk/efo/EFO_
+  HGNC: "https://identifiers.org/hgnc:"
+  HGNC__2: "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:"
+  HGNC_symbol: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/
   HP: http://purl.obolibrary.org/obo/HP_
   SCTID: http://identifiers.org/snomedct/
   OMIM: https://omim.org/entry/
@@ -12,7 +15,6 @@ curie_map:
   OMIM__4: http://omim.org/entry/
   MESH: http://identifiers.org/mesh/
   MEDDRA: http://identifiers.org/meddra/
-  OMIMPS: http://www.omim.org/phenotypicSeries/
   Orphanet: http://www.orpha.net/ORDO/Orphanet_
   Orphanet__2: http://purl.obolibrary.org/obo/Orphanet_
   oboInOwl: http://www.geneontology.org/formats/oboInOwl#


### PR DESCRIPTION
mondo.sssom.config updates
- OMIMPS: Deleted a deuplicate mapping. The one that I left behind assumes that the ID to be added onto the prefix will be in integer form, e.g. '100300' rather than 'PS100300'.
- HGNC: Added
- HGNC__2: Added this alternate url.
- HGNC__symbol: Added. Even though the HGNC ID is the canonical identifier, not the symbol, I figured that people may want to review this addition; maybe it's useful. I'm not sure if HGNC__symbol or HGNC_symbol is a better name, but I stuck with __, as alternate IDs appeared to use this syntax in this file.