### PR TITLE
Adding new Feature: version diff report

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -458,11 +458,24 @@ reports/mondo_base_current_%.tsv: mondo-base.owl
 reports/mondo_base_last_%.tsv: tmp/mondo-lastbase.owl
 	$(ROBOT) query --use-graphs true -i tmp/mondo-lastbase.owl -f tsv --tdb true --query $(SPARQLDIR)/reports/$*.sparql $@
 
-reports/mondo_release_diff.md reports/mondo_release_diff_changed_terms.tsv reports/mondo_release_diff_new_terms.tsv: reports/mondo_base_last_release-report.tsv reports/mondo_base_current_release-report.tsv reports/mondo_release_diff_changed_terms.tsv reports/mondo_release_diff_new_terms.tsv
+tmp/mondo-versioned-base.owl:
+	$(ROBOT) convert -I http://purl.obolibrary.org/obo/mondo/releases/$(COMPARE_VERSION)/mondo-base.owl -f owl -o $@
+
+reports/mondo_base_version_%.tsv: #tmp/mondo-versioned-base.owl
+	$(ROBOT) query --use-graphs true -i tmp/mondo-versioned-base.owl -f tsv --tdb true --query $(SPARQLDIR)/reports/$*.sparql $@
+
+reports/mondo_release_diff.md reports/mondo_release_diff_changed_terms.tsv reports/mondo_release_diff_new_terms.tsv: reports/mondo_base_last_release-report.tsv reports/mondo_base_current_release-report.tsv reports/mondo_obsoletioncandidates.tsv
 	python ../scripts/merge_release_diff.py reports/mondo_base_last_release-report.tsv reports/mondo_base_current_release-report.tsv reports/mondo_obsoletioncandidates.tsv reports/mondo_release_diff_changed_terms.tsv reports/mondo_release_diff_new_terms.tsv > reports/mondo_release_diff.md
 	sed -i 's/  */ /g' reports/mondo_release_diff.md
 	sed -i 's/----*/---/g' reports/mondo_release_diff.md
 	sed -i 's/----*/---/g' reports/mondo_release_diff.md
+
+version_diff: reports/mondo_base_version_release-report.tsv reports/mondo_base_current_release-report.tsv reports/mondo_obsoletioncandidates.tsv
+	python ../scripts/merge_release_diff.py reports/mondo_base_last_release-report.tsv reports/mondo_base_current_release-report.tsv reports/mondo_obsoletioncandidates.tsv reports/mondo_release_diff_changed_terms_version.tsv reports/mondo_release_diff_new_terms_version.tsv > reports/mondo_release_diff_version.md
+	sed -i 's/  */ /g' reports/mondo_release_diff_version.md
+	sed -i 's/----*/---/g' reports/mondo_release_diff_version.md
+	sed -i 's/----*/---/g' reports/mondo_release_diff_version.md
+
 
 reports/mondo_obsoletioncandidates.tsv: report-base-query-obsoletioncandidates-withcomment
 	cp reports/report-base-obsoletioncandidates-withcomment.tsv $@

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -461,7 +461,7 @@ reports/mondo_base_last_%.tsv: tmp/mondo-lastbase.owl
 tmp/mondo-versioned-base.owl:
 	$(ROBOT) convert -I http://purl.obolibrary.org/obo/mondo/releases/$(COMPARE_VERSION)/mondo-base.owl -f owl -o $@
 
-reports/mondo_base_version_%.tsv: #tmp/mondo-versioned-base.owl
+reports/mondo_base_version_%.tsv: tmp/mondo-versioned-base.owl
 	$(ROBOT) query --use-graphs true -i tmp/mondo-versioned-base.owl -f tsv --tdb true --query $(SPARQLDIR)/reports/$*.sparql $@
 
 reports/mondo_release_diff.md reports/mondo_release_diff_changed_terms.tsv reports/mondo_release_diff_new_terms.tsv: reports/mondo_base_last_release-report.tsv reports/mondo_base_current_release-report.tsv reports/mondo_obsoletioncandidates.tsv


### PR DESCRIPTION
- [ ] Add to docs:

To generate a diff report (like the release report) between two distinct versions (like for an RPPR report)

```
sh run.sh make version_diff IMP=false MIR=false COMPARE_VERSION=2021-09-01
```

The report is created as `reports/mondo_release_diff_version.md`