### PR TITLE
Create qc-doublewhite.sparql

### DIFF
--- a/src/sparql/qc/general/qc-doublewhite.sparql
+++ b/src/sparql/qc/general/qc-doublewhite.sparql
@@ -1,0 +1,25 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+SELECT ?entity ?property ?value
+WHERE {
+  VALUES ?property { 
+      rdfs:comment
+      rdfs:label
+      oio:hasExactSynonym
+      oio:hasNarrowSynonym
+      oio:hasBroadSynonym
+      oio:hasCloseSynonym
+      oio:hasRelatedSynonym
+    }
+    ?entity rdf:type owl:Class ;
+            ?property ?value .
+  filter( regex(str(?value), "  " ) || regex(str(?value), "\t" ))
+  FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+
+}


### PR DESCRIPTION
This check prevents double whitespaces and tabs to make it into any of the Mondo annotations