### PR TITLE
Add Goal to generate obographviz pictures for Mondo

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -710,3 +710,8 @@ update-exclusion-reasons: python-install-dependencies
 	python3 ../scripts/exclusion_reasons_enum_updater.py \
 	--input-path-exclusion-reasons ../scripts/exclusion_reasons.csv \
 	--input-path-mondo-schema ../schema/mondo.yaml
+
+TERM=MONDO:0021055
+
+viz:
+	runoak -i prontolib:mondo-edit.obo viz $(TERM) -p i,p


### PR DESCRIPTION
Add Goal to generate obographviz pictures for Mondo. This is so that @nicolevasilevsky and others can more easily make pretty pictures for presentations.

Currently 

```
sh run.sh make viz
```

fails with 

```
Traceback (most recent call last):
  File "/usr/local/bin/runoak", line 5, in <module>
    from oaklib.cli import main
  File "/usr/local/lib/python3.10/dist-packages/oaklib/cli.py", line 107, in <module>
    from oaklib.utilities.mapping.cross_ontology_diffs import (
  File "/usr/local/lib/python3.10/dist-packages/oaklib/utilities/mapping/cross_ontology_diffs.py", line 2, in <module>
    from collections import Iterator, defaultdict
ImportError: cannot import name 'Iterator' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
make: *** [mondo.Makefile:717: viz] Error 1
```