### PR TITLE
Replace myself as PR creator by `GitHub-actions` when ontobot creates a PR

### DIFF
--- a/.github/workflows/ontobot.yaml
+++ b/.github/workflows/ontobot.yaml
@@ -62,9 +62,11 @@ jobs:
         if: ${{ env.PR_TITLE}}
         with:
           branch-suffix: short-commit-hash
-          labels: Automated
+          # labels: Automated
+          author: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
+          committer: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
           body: ${{ env.PR_BODY }}
           title: ${{ env.PR_TITLE }}
           base: ${{ github.head_ref }}
           branch: ${{ env.branch-name }}
-          token: ${{ secrets.GH_TOKEN }}
+          # token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ontobot.yaml
+++ b/.github/workflows/ontobot.yaml
@@ -62,7 +62,7 @@ jobs:
         if: ${{ env.PR_TITLE}}
         with:
           branch-suffix: short-commit-hash
-          # labels: Automated
+          labels: Automated
           author: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
           committer: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
           body: ${{ env.PR_BODY }}


### PR DESCRIPTION
Added
- `author` 
- `committer`
Which will be the person who creates the issue.

Removed:
- `token`

NOTE: `token` was generated from my account and hence all PRs generated by `ontobot` seemed to have been requested by me. This will put an end to it but the presence of `token` triggered QC GitHub Actions which will not happen henceforth (once this PR is merged). with this change the PR requester will be `github-actions` user.