### PR TITLE
Skip UMLS mappings from SKOS generation pipeline

### DIFF
--- a/src/utils/mk-skos.pl
+++ b/src/utils/mk-skos.pl
@@ -42,7 +42,7 @@ while (<>) {
         $rel = "http://www.w3.org/2004/02/skos/core#".$rel;
         my $uri;
         if ($prefix eq 'UMLS') {
-            $uri = 'http://linkedlifedata.com/resource/umls/id/';
+            next;
         }
         elsif ($prefix eq 'MESH') {
             $uri = 'http://identifiers.org/mesh/';


### PR DESCRIPTION
Rather than completely removing the `MONDO:equivalentTo` annotations on UMLS xrefs, maybe its better to skip turning those into SKOS mappings (and therefor including them into mondo.sssom.tsv)?

This PR:

- I am unsure if we should do this, rather than deleting all `MONDO:equivalentTo`
- I am unsure if my change does what I think it does (PERL)

Needs a @cmungall review, can be done in a call.
