### PR TITLE
Update GARD mappings (major)

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -741,6 +741,20 @@ migrate-%: tmp/mondo-edit-%.ttl
 
 migrate: migrate-omim
 
+GARD_MAPPINGS=https://docs.google.com/spreadsheets/d/e/2PACX-1vTsgIbFYWkhMT0EgaBNbyT6fJiNKqVjdqcZxXQLwJ3CpXpSzB24BITZGDNSMyg_3bneIvE3F2l_iHWH/pub?gid=1886610709&single=true&output=tsv
+
+.PHONY: update-gard-mappings
+update-gard-mappings:
+	grep -v '^xref: GARD:' mondo-edit.obo > TT || true
+	mv TT mondo-edit.obo
+	wget "$(GARD_MAPPINGS)" -O tmp/gard-mappings.tsv
+	$(ROBOT) template --merge-before --input $(SRC) \
+ 		--template tmp/gard-mappings.tsv convert -f obo -o $(SRC)
+	make NORM
+	mv NORM $(SRC)
+
+
+
 #######################################
 ### New Pattern merge pipeline ########
 #######################################


### PR DESCRIPTION
This PR updates the GARD mappings to the new GARD disease list provided by their development team.

Two questions for @cmungall:

I note a lot of 

<img width="643" alt="image" src="https://github.com/monarch-initiative/mondo/assets/7070631/258b21bd-a694-4401-a3c3-e2e4406902be">

The padded zeros are not provided by GARD. What to do?

Second: I abuse the `source` parameter a bit to represent the bridging concept from the chain that was used to infer the Mondo - GARD mapping.

- [ ] Needs a @cmungall review
