### PR TITLE
Issue 6772 existing obsolete warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ src/ontology/subsets/mondo-rare.owl
 subsets/mondo-rare.owl
 src/ontology/imports/*_terms_combined.txt
 src/ontology/config/obsolete_me.txt
+src/ontology/config/filtered_obsolete_me.txt

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -520,7 +520,6 @@ tmp/identify_existing_obsoletes.ru: ../sparql/reports/check_obsoletes_from_list.
 	@echo "\n** Identify existing obsoletes in config/obsolete_me.txt **"
 	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
-.PHONY: identify_existing_obsoletes
 identify_existing_obsoletes: tmp/identify_existing_obsoletes.ru
 	@echo "\n** Write existing obsoletes to tmp/identify_existing_obsoletes.txt **"
 	$(ROBOT) query --format txt -i $(SRC) --queries $< --output-dir tmp/

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -520,9 +520,9 @@ tmp/identify_existing_obsoletes.ru: ../sparql/reports/check_obsoletes_from_list.
 	@echo "\n** Identify existing obsoletes in config/obsolete_me.txt **"
 	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
-identify_existing_obsoletes: tmp/identify_existing_obsoletes.ru
+tmp/identify_existing_obsoletes.txt: tmp/identify_existing_obsoletes.ru
 	@echo "\n** Write existing obsoletes to tmp/identify_existing_obsoletes.txt **"
-	$(ROBOT) query --format txt -i $(SRC) --queries $< --output-dir tmp/
+	$(ROBOT) query --format txt -i $(SRC) --query $< $@
 
 mass_obsolete2: identify_existing_obsoletes tmp/mass_obsolete.ru tmp/mass_obsolete_me.txt
 	@echo "Make sure you have updated config/obsolete_me.txt before running this script.."

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -483,16 +483,27 @@ mass_obsolete:
 	perl ../scripts/obo-obsoletify.pl --seeAlso https://github.com/monarch-initiative/mondo/issues/$(GH_ISSUE) --obsoletionReason MONDO:$(OBS_REASON)  -i ../scripts/obsolete_me.txt mondo-edit.obo > OBSOLETE && mv OBSOLETE mondo-edit.obo
 
 tmp/mass_obsolete.sparql: ../sparql/reports/mondo-obsolete-simple.sparql config/obsolete_me.txt
-	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
+	@echo "\n** Run mondo-obsolete-simple.sparql **"
+	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
 tmp/mondo-rename-effected-classes.ru: ../sparql/reports/mondo-rename-effected-classes.ru config/obsolete_me.txt
-	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
+	@echo "\n** Run mondo-rename-effected-classes.ru **"
+	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
 tmp/mass_obsolete_warning.sparql: ../sparql/reports/mondo-obsolete-warning.sparql config/obsolete_me.txt
-	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
+	@echo "\n** Run mondo-obsolete-warning.sparql **"
+	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
 tmp/mass_obsolete.ru: ../sparql/update/mondo-obsolete-simple.ru config/obsolete_me.txt
-	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
+	@echo "\n** Run mondo-obsolete-simple.ru **"
+	# Remove ^M from tmp/identify_existing_obsoletes.txt
+	sed 's/\r//g' tmp/identify_existing_obsoletes.txt > tmp/filtered_identify_existing_obsoletes.txt
+
+	# Filter out existing obsoletes
+	grep -v -w -i -f tmp/filtered_identify_existing_obsoletes.txt config/obsolete_me.txt > config/filtered_obsolete_me.txt
+
+	# Create input for query
+	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
 tmp/mass_obsolete_me.txt: tmp/mass_obsolete.sparql
 	$(ROBOT) query -i $(SRC) --use-graphs true -f tsv --query $< $@
@@ -504,8 +515,17 @@ tmp/mass_obsolete_me.txt: tmp/mass_obsolete.sparql
 mass_obsolete_warning: tmp/mass_obsolete_warning.sparql
 	$(ROBOT) verify -i $(SRC) --queries $< --output-dir reports/
 
-mass_obsolete2: tmp/mass_obsolete.ru tmp/mass_obsolete_me.txt
-	echo "Make sure you have updated config/obsolete_me.txt before running this script.."
+tmp/identify_existing_obsoletes.ru: ../sparql/reports/check_obsoletes_from_list.ru config/obsolete_me.txt
+	@echo "\n** Identify existing obsoletes in config/obsolete_me.txt **"
+	LISTT="$(shell paste -sd" " config/obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
+
+.PHONY: identify_existing_obsoletes
+identify_existing_obsoletes: tmp/identify_existing_obsoletes.ru
+	@echo "\n** Write existing obsoletes to tmp/identify_existing_obsoletes.txt **"
+	$(ROBOT) query --format txt -i $(SRC) --queries $< --output-dir tmp/
+
+mass_obsolete2: identify_existing_obsoletes tmp/mass_obsolete.ru tmp/mass_obsolete_me.txt
+	@echo "Make sure you have updated config/obsolete_me.txt before running this script.."
 	$(MAKE) tmp/mondo-obsolete-labels.obo
 	$(MAKE) mass_obsolete_warning
 	$(ROBOT) query -i $(SRC) --use-graphs true --update tmp/mass_obsolete.ru \
@@ -515,6 +535,7 @@ mass_obsolete2: tmp/mass_obsolete.ru tmp/mass_obsolete_me.txt
 	mv NORM $(SRC)
 
 tmp/mondo-obsolete-labels.obo: tmp/mondo-rename-effected-classes.ru
+	@echo "\n** Re-name obsolete class labels **"
 	$(ROBOT) merge -i $(SRC) --collapse-import-closure false query --update tmp/mondo-rename-effected-classes.ru  \
 		convert -f obo --check false -o $@
 

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -495,7 +495,7 @@ tmp/mass_obsolete_warning.sparql: ../sparql/reports/mondo-obsolete-warning.sparq
 	@echo "\n** Run mondo-obsolete-warning.sparql **"
 	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
-tmp/mass_obsolete.ru: ../sparql/update/mondo-obsolete-simple.ru config/obsolete_me.txt
+tmp/mass_obsolete.ru: ../sparql/update/mondo-obsolete-simple.ru tmp/identify_existing_obsoletes.txt config/obsolete_me.txt
 	@echo "\n** Run mondo-obsolete-simple.ru **"
 	# Remove ^M from tmp/identify_existing_obsoletes.txt
 	sed 's/\r//g' tmp/identify_existing_obsoletes.txt > tmp/filtered_identify_existing_obsoletes.txt

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -478,19 +478,20 @@ GH_ISSUE=none
 OBS_REASON=outOfScope
 
 .PRECIOUS: config/obsolete_me.txt
+.PRECIOUS: config/filtered_obsolete_me.txt
 
 mass_obsolete:
 	perl ../scripts/obo-obsoletify.pl --seeAlso https://github.com/monarch-initiative/mondo/issues/$(GH_ISSUE) --obsoletionReason MONDO:$(OBS_REASON)  -i ../scripts/obsolete_me.txt mondo-edit.obo > OBSOLETE && mv OBSOLETE mondo-edit.obo
 
-tmp/mass_obsolete.sparql: ../sparql/reports/mondo-obsolete-simple.sparql config/obsolete_me.txt
+tmp/mass_obsolete.sparql: ../sparql/reports/mondo-obsolete-simple.sparql config/filtered_obsolete_me.txt
 	@echo "\n** Run mondo-obsolete-simple.sparql **"
 	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
-tmp/mondo-rename-effected-classes.ru: ../sparql/reports/mondo-rename-effected-classes.ru config/obsolete_me.txt
+tmp/mondo-rename-effected-classes.ru: ../sparql/reports/mondo-rename-effected-classes.ru config/filtered_obsolete_me.txt
 	@echo "\n** Run mondo-rename-effected-classes.ru **"
 	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 
-tmp/mass_obsolete_warning.sparql: ../sparql/reports/mondo-obsolete-warning.sparql config/obsolete_me.txt
+tmp/mass_obsolete_warning.sparql: ../sparql/reports/mondo-obsolete-warning.sparql config/filtered_obsolete_me.txt
 	@echo "\n** Run mondo-obsolete-warning.sparql **"
 	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
 

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -524,7 +524,7 @@ tmp/identify_existing_obsoletes.txt: tmp/identify_existing_obsoletes.ru
 	@echo "\n** Write existing obsoletes to tmp/identify_existing_obsoletes.txt **"
 	$(ROBOT) query --format txt -i $(SRC) --query $< $@
 
-mass_obsolete2: identify_existing_obsoletes tmp/mass_obsolete.ru tmp/mass_obsolete_me.txt
+mass_obsolete2: tmp/identify_existing_obsoletes.ru tmp/mass_obsolete.ru tmp/mass_obsolete_me.txt
 	@echo "Make sure you have updated config/obsolete_me.txt before running this script.."
 	$(MAKE) tmp/mondo-obsolete-labels.obo
 	$(MAKE) mass_obsolete_warning

--- a/src/sparql/reports/check_obsoletes_from_list.ru
+++ b/src/sparql/reports/check_obsoletes_from_list.ru
@@ -1,0 +1,12 @@
+# Given a list of CURIEs, return only those that are not already obsolete
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX MONDO: <http://purl.obolibrary.org/obo/MONDO_>
+
+SELECT ?curie
+WHERE {
+  VALUES ?cls { MONDO:0000000 }
+  ?cls a owl:Class ;
+       owl:deprecated "true"^^xsd:boolean .
+  BIND(REPLACE(STR(?cls), "http://purl.obolibrary.org/obo/MONDO_", "MONDO:") AS ?curie) .
+}


### PR DESCRIPTION
closes #6772 

Update Mass Obsoletion pipeline to ignore classes in `obsolete_me.txt` if they are already obsolete in the ontology.

@matentzn I was not able to do the diff of terms in the LISTT assignment statement and created a new `filtered_obsolete_me.txt` file that is used in the steps. This file is added into `.gitignore` and `.PRECIOUS`. 

I've tested with this content for `obsolete_me.txt`:
```
MONDO:0020147
MONDO:0000002
MONDO:0020196
MONDO:0020256
MONDO:0000003
```