### PR TITLE
Provide GH Issue URL to mass obsoletion pipeline

### DIFF
--- a/docs/editors-guide/mass-obsoletion.md
+++ b/docs/editors-guide/mass-obsoletion.md
@@ -73,23 +73,14 @@ Label for the parent	| parent class |	source |	PMID |	Curator confidence
 
 #### 2. Mass obsolete Terms
 1. Go to relevant GitHub ticket (for example, [https://github.com/monarch-initiative/mondo/issues/6739](https://github.com/monarch-initiative/mondo/issues/6739))
-2. copy and paste the table into a new tab in the spreadsheet (for example, see [here](https://docs.google.com/spreadsheets/d/1KUYvnB1VVBV7KwbKipxvgNLX9FQC0aeaPn3kaxzz92g/edit#gid=36625823))
+2. Copy and paste the table into a new tab in the spreadsheet (for example, see [here](https://docs.google.com/spreadsheets/d/1KUYvnB1VVBV7KwbKipxvgNLX9FQC0aeaPn3kaxzz92g/edit#gid=36625823))
 3. Create a new column with the CURIES (see column C)
 4. Create a new file in mondo/src/ontology/config/ named `obsolete_me.txt`
 5. Copy and paste the CURIES into `obsolete_me.txt` and save
-6. Run `sh run.sh make mass_obsolete2 -B`
-7. Run 'sh run.sh make NORM`
-8. Run `mv NORM mondo-edit.obo`
-9. (Optional) Open in Protege and make sure everything looks okay
+6. Run `sh run.sh make mass_obsolete2 -B GITHUB_ISSUE_URL=GITHUB-ISSUE-URL`, where the value of `GITHUB-ISSUE-URL` is a value like `https://github.com/monarch-initiative/mondo/issues/6739` (this value does not need to be in quotes)
 
 
-##### 2a. Add the term tracker item to the obsoleted terms
-
-1. Create a ROBOT template to add the term tracker item to the obsoleted terms (see example [here](https://docs.google.com/spreadsheets/d/1KUYvnB1VVBV7KwbKipxvgNLX9FQC0aeaPn3kaxzz92g/edit#gid=36625823))
-2. Run ROBOT command to add term tracker intermediate
-
-##### 2b. Review changes in Protege
-
+##### 2. Review changes in Protege
 1. Check the branch and review changes for obsoleted terms and orphaned terms:
     - Spot check a few terms to ensure they were properly obsoleted and have the correct Annotations
     - spot check a few terms to make sure they are assigned the correct parent (per the ROBOT template) and they have the correct source annotation(s)

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -504,7 +504,9 @@ tmp/mass_obsolete.ru: ../sparql/update/mondo-obsolete-simple.ru tmp/identify_exi
 	grep -v -w -i -f tmp/filtered_identify_existing_obsoletes.txt config/obsolete_me.txt > config/filtered_obsolete_me.txt
 
 	# Create input for query
-	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; sed "s/MONDO:0000000/$$LISTT/g" $< > $@
+	LISTT="$(shell paste -sd" " config/filtered_obsolete_me.txt)"; \
+	sed -e "s/MONDO:0000000/$$LISTT/g" -e "s|GITHUB_ISSUE_URL|$(GITHUB_ISSUE_URL)|g" $< > $@
+
 
 tmp/mass_obsolete_me.txt: tmp/mass_obsolete.sparql
 	$(ROBOT) query -i $(SRC) --use-graphs true -f tsv --query $< $@

--- a/src/sparql/update/mondo-obsolete-simple.ru
+++ b/src/sparql/update/mondo-obsolete-simple.ru
@@ -3,6 +3,7 @@ prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix MONDO: <http://purl.obolibrary.org/obo/MONDO_>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
 DELETE {
   ?entity <http://purl.obolibrary.org/obo/IAO_0006012> ?date .
@@ -23,6 +24,7 @@ DELETE {
 INSERT {
   ?xref_anno oboInOwl:source ?new_source . #adds MONDO:obsoleteEquivalent (where previously MONDO:equivalentTo) and adds MONDO:obsoleteEquivalentObsolete (where previously MONDO:equivalentObsolete)
   ?entity rdfs:label ?new_label . #this adds the new label obsolete label 
+  ?entity <http://purl.obolibrary.org/obo/IAO_0000233> ?github_issue_url .
   ?entity owl:deprecated true .
   ?entity <http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/OMO_0001000> .
   ?entity <http://purl.obolibrary.org/obo/IAO_0000115> ?obsolete_definition .
@@ -89,4 +91,5 @@ WHERE {
   	
   	BIND (REPLACE(REPLACE(?source, "MONDO:equivalentTo", "MONDO:obsoleteEquivalent"), "MONDO:equivalentObsolete", "MONDO:obsoleteEquivalentObsolete") AS ?new_source)
     BIND(CONCAT("obsolete ",str(?label)) as ?new_label)
+    BIND("GITHUB_ISSUE_URL"^^xsd:anyURI as ?github_issue_url)
 }


### PR DESCRIPTION
closes #6809 

Added functionality to take a single github_issue_url from the command line and use that in an annotation on the obsoleted class. E.g. `property_value: IAO:0000233 "https://github.com/monarch-initiative/mondo/issues/1234" xsd:anyURI`. 

The command to run the pipeline is now: 
```
sh run.sh make mass_obsolete2 -B GITHUB_ISSUE_URL=https://github.com/monarch-initiative/mondo/issues/1234
```
The documentation was updated to reflect this change.

