### PR TITLE
add sample code page and link to jup notebook

### DIFF
--- a/docs/editors-guide/sample-code.md
+++ b/docs/editors-guide/sample-code.md
@@ -1,0 +1,4 @@
+# Sample Code
+
+A sample Jupyter notebook that uses the [Ontology Access Kit(OAK)](https://github.com/INCATools/ontology-access-kit) to dowbload and access Mondo and extract information about classes such as the class name, parents, and children is available at: [Mondo.ipynb](https://github.com/monarch-initiative/mondo/blob/master/src/scripts/notebooks/Mondo.ipynb).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Mappings: editors-guide/mappings.md
       - Version diff report: editors-guide/version-diff-report.md
       - Using Mondo for Data curation: editors-guide/using-mondo-for-curation.md
+      - Sample code: editors-guide/sample-code.md
       - Rare disease subset: editors-guide/rare-disease-subset.md
     - Cite:
       - Cite Mondo: editors-guide/cite.md


### PR DESCRIPTION
Closes #6973 

Adding a new page in the Users Corner to document the Jupyter notebook we created. I created a new page called Sample code, please let me know if you prefer this information as a new section in an existing page and if so which page and location.

At this time, I don't know if we will be creating additional sample code but didn't see another page other than maybe Data curation that seemed like a good fit to add this.