### PR TITLE
Add NORD subset and cross-references

### DIFF
--- a/src/sparql/qc/mondo/qc-illegal-prefix-on-xref-annotation.sparql
+++ b/src/sparql/qc/mondo/qc-illegal-prefix-on-xref-annotation.sparql
@@ -61,6 +61,7 @@ WHERE
       "MESH",
       "MFOMD",
       "MONDO",
+      "NORD",
       "MONDORULE",
       "MP",
       "MPATH",

--- a/src/sparql/qc/mondo/qc-illegal-prefix-on-xref.sparql
+++ b/src/sparql/qc/mondo/qc-illegal-prefix-on-xref.sparql
@@ -49,6 +49,7 @@ WHERE
       "NCIT",
       "NDFRT",
       "NIFSTD",
+      "NORD",
       "OBI",
       "OGMS",
       "OMIM",


### PR DESCRIPTION
Supercedes #7000 

The problem was that I was using the xrefs table to generate the "nord" subset, which is a different thing altogether.

- The NORD subset is a table of all Mondo terms NORD has considered rare (>10K). 
- The NORD xrefs table is a table of about 2000K cross references to NORD. 

We need to meet with NORD to discuss exactly what we are pulling in moving forward. This PR here does not change the status quo, as it is a combination of what we previously had (the "old" nord subset) and the "approved" NORD xrefs.