### PR TITLE
Reinstate ClinGen labels

### DIFF
--- a/src/ontology/config/remove-annotations-before-release.txt
+++ b/src/ontology/config/remove-annotations-before-release.txt
@@ -1,4 +1,2 @@
-http://purl.obolibrary.org/obo/mondo#CLINGEN_PREFERRED
-http://purl.obolibrary.org/obo/mondo#clingen_preferred
 http://purl.obolibrary.org/obo/mondo#excluded_from_qc_check
 http://purl.obolibrary.org/obo/mondo#confidence

--- a/src/sparql/update/delete-axiom-annotations-by-prefix.ru
+++ b/src/sparql/update/delete-axiom-annotations-by-prefix.ru
@@ -3,8 +3,6 @@ prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix mondoPatterns: <http://purl.obolibrary.org/obo/mondo/patterns/>
-prefix rm1: <http://purl.obolibrary.org/obo/mondo#CLINGEN_PREFERRED>
-prefix rm2: <http://purl.obolibrary.org/obo/mondo#clingen_preferred>
 prefix synonym_type: <http://www.geneontology.org/formats/oboInOwl#hasSynonymType>
 prefix source: <http://www.geneontology.org/formats/oboInOwl#source>
 

--- a/src/sparql/update/delete-axiom-annotations.ru
+++ b/src/sparql/update/delete-axiom-annotations.ru
@@ -3,8 +3,6 @@ prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix mondoPatterns: <http://purl.obolibrary.org/obo/mondo/patterns/>
-prefix rm1: <http://purl.obolibrary.org/obo/mondo#CLINGEN_PREFERRED>
-prefix rm2: <http://purl.obolibrary.org/obo/mondo#clingen_preferred>
 prefix synonym_type: <http://www.geneontology.org/formats/oboInOwl#hasSynonymType>
 prefix source: <http://www.geneontology.org/formats/oboInOwl#source>
 
@@ -12,7 +10,7 @@ DELETE {
   ?anno ?property ?value .
 }
 WHERE {
-  VALUES ?value { "MONDO:preferredExternal" rm1: rm2: } 
+  VALUES ?value { "MONDO:preferredExternal" } 
   VALUES ?property { synonym_type: source: }
   ?anno a owl:Axiom ;
          owl:annotatedSource ?s ;


### PR DESCRIPTION
This PR:

- undoes the process of stripping away Clingen labels and reinstates them
- renames CLINGEN_PREFERRED to CLINGEN_LABEL

Partially addresses #7028 