### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 
 # Removed @cmungall to stop him being added to all PRs
 *       @sabrinatoro @twhetzel
-*.sparql @joeflack4 @twhetzel
-*.py	  @joeflack4 @twhetzel
-*.md    @sabrinatoro @twhetzel
+*.sparql @twhetzel
+*.py	  @twhetzel
+*.md    @sabrinatoro @twhetzel @nicolevasilevsky
 Makefile @matentzn @twhetzel
 mondo.Makefile @matentzn @twhetzel
 


### PR DESCRIPTION
Removing @joeflack4 as codeowner so he does not get auto-assigned to every PR (especially draft ones)

We changed branch protection settings so non-owners can also approve PRs

@joeflack4 this is only to protect you from noise - there are Draft PRs etc that you are being assigned to for no reason. Its better if @twhetzel assigns us manually if she needs our reviews IMO