### PR TITLE
Update disease_by_gene pattern

### DIFF
--- a/src/patterns/dosdp-patterns/OMIM_disease_series_by_gene.yaml
+++ b/src/patterns/dosdp-patterns/OMIM_disease_series_by_gene.yaml
@@ -4,10 +4,10 @@ pattern_iri: http://purl.obolibrary.org/obo/mondo/patterns/disease_series_by_gen
 
 description: '
 
-  This pattern is meant to be used for OMIM Mendelian diseases (ie unitary genetic diseases, as described in
+  This pattern is meant to be used for (1) OMIM Mendelian diseases (ie unitary genetic diseases, as described in
   [PMID:33417889](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7820621/)), including children of OMIM phenotypic
-  series (OMIMPS), which are represented as grouping classes in Mondo. Notes about
-  the OMIMPS (see also OMIM_phenotypic_series.yaml):  - every instance of the OMIMPS
+  series (OMIMPS), which are represented as grouping classes in Mondo, and (2) OMIA Mendelian diseases (https://omia.org/) which are defined by a variation in a gene.
+  Notes about the OMIMPS (see also OMIM_phenotypic_series.yaml):  - every instance of the OMIMPS
   metaclass should be equivalent to (via annotated xref) to something in OMIMPS namespace
   - the OMIMPS will never have an asserted causative gene as logical axiom (and no
   single causative gene in text def) - the OMIMPS must never be equivalent to an OMIM:nnnnnn
@@ -23,6 +23,7 @@ description: '
 contributors:
 - https://orcid.org/0000-0002-6601-2165
 - https://orcid.org/0000-0001-5208-3432
+- https://orcid.org/0000-0002-4142-7153
 
 classes:
   disease: MONDO:0000001


### PR DESCRIPTION
Address #7271

The pattern [OMIM_disease_series_by_gene](https://github.com/monarch-initiative/mondo/blob/master/src/patterns/dosdp-patterns/OMIM_disease_series_by_gene.yaml) refers to the variable "disease" as "MONDO:0000001", which is the parent term of "human disease" and "non-human disease". 
Therefore, this pattern could be used for both genetic diseases for human (from OMIM) and non-human animal (from OMIA). 

I updated the existing description to reflect the above. 
Note that I did not rename the pattern because it has been used "everywhere" in the ontology. 

@matentzn @cmungall @katiermullen 

