### PR TITLE
add new gene

### DIFF
--- a/src/ontology/imports/hgnc_terms.txt
+++ b/src/ontology/imports/hgnc_terms.txt
@@ -2076,6 +2076,7 @@ http://identifiers.org/hgnc/28727
 http://identifiers.org/hgnc/2873
 http://identifiers.org/hgnc/28741
 http://identifiers.org/hgnc/2876
+http://identifiers.org/hgnc/28762
 http://identifiers.org/hgnc/28769
 http://identifiers.org/hgnc/2877
 http://identifiers.org/hgnc/288


### PR DESCRIPTION
I tried to do another commit on this PR after I added these two files to import the new gene, and the new commit does not show up here. I reverted it in GitHub desktop but I suspect there may be errors to merge this branch now, like in https://github.com/monarch-initiative/mondo/pull/7397

It seems there is some issue with doing commits after running the import new term pipeline: https://mondo.readthedocs.io/en/latest/editors-guide/import-terms-for-logical-axioms/#preferred-instructions

which I do not understand at all

@sabrinatoro @matentzn @twhetzel 