### PR TITLE
Add qc check excluded subclass of provenance

### DIFF
--- a/src/sparql/qc/general/qc-excluded-subclass.sparql
+++ b/src/sparql/qc/general/qc-excluded-subclass.sparql
@@ -1,0 +1,19 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+
+# Tests if an animal disease made it into the rare disease subset
+
+SELECT DISTINCT ?entity ?property ?value WHERE
+{
+  VALUES ?property { <http://purl.obolibrary.org/obo/mondo#excluded_subClassOf> }
+  ?entity ?property ?value .
+  FILTER(!isIRI(?value) || !STRSTARTS(STR(?value),"http://purl.obolibrary.org/obo/MONDO_"))
+  FILTER( !isBlank(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+}

--- a/src/sparql/qc/general/qc-provenance-missing.sparql
+++ b/src/sparql/qc/general/qc-provenance-missing.sparql
@@ -1,0 +1,25 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+
+# Tests if an animal disease made it into the rare disease subset
+
+SELECT DISTINCT ?entity ?property ?value WHERE
+{
+  VALUES ?property { <http://purl.obolibrary.org/obo/mondo#excluded_subClassOf> }
+  ?entity ?property ?value .
+  FILTER NOT EXISTS {
+  [] owl:annotatedSource ?entity ;
+         owl:annotatedProperty ?property ;
+         owl:annotatedTarget ?value ;
+         oboInOwl:source ?orcid .
+        FILTER(STRSTARTS(STR(?orcid),"https://orcid.org/"))
+  }
+ FILTER( !isBlank(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+}

--- a/src/sparql/update/update-provenance-missing.ru
+++ b/src/sparql/update/update-provenance-missing.ru
@@ -1,0 +1,34 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+
+# Tests if an animal disease made it into the rare disease subset
+
+INSERT
+{
+  [] rdf:type owl:Axiom ;
+  owl:annotatedSource ?entity ;
+         owl:annotatedProperty ?property ;
+         owl:annotatedTarget ?value ;
+         oboInOwl:source <https://orcid.org/0000-0001-5208-3432> .
+}
+
+WHERE
+{
+  VALUES ?property { <http://purl.obolibrary.org/obo/mondo#excluded_subClassOf> }
+  ?entity ?property ?value .
+  FILTER NOT EXISTS {
+  [] owl:annotatedSource ?entity ;
+         owl:annotatedProperty ?property ;
+         owl:annotatedTarget ?value ;
+         oboInOwl:source ?orcid .
+        FILTER(STRSTARTS(STR(?orcid),"https://orcid.org/"))
+  }
+ FILTER( !isBlank(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+}


### PR DESCRIPTION
This PR:

- adds a QC check that ensures that all "excluded_SubClassOf" axioms have provenance
- adds a QC check that ensures that the range of all excluded subclass axioms is always an ontology IRI (see #7414)
- adds an update query to add @nicolevasilevsky orcid to 300 excluded subclass of axioms that currently do not have provenance