### PR TITLE
remove confidence annotation property

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -196,7 +196,7 @@ ANN = annotate -V $(ONTURI)/releases/`date +%Y-%m-%d`/$@.owl
 GITHUB_ACTION = false
 
 filtered.obo: $(SRC)
-	perl -ne 'print unless (m@^xref: (Orphanet|OMIM|OMIMPS|DOID|EFO|NCIT|SCTID|MESH|UMLS|ICD10CM):@ && !(m@(obsoleteEquivalent|equivalentObsolete|equivalentTo|relatedTo|mondoIsNarrowerThanSource|directSiblingOf|mondoIsBroaderThanSource)@i))' $< | grep -v '^property_value: confidence' | grep -v '^property_value: excluded_subClassOf' | egrep -v '^synonym: .*EXCLUDE' | egrep -v 'relationship: disease_has_basis_in_dysfunction_of (hgnc|HGNC|NCBIGene):' > $@.tmp && mv $@.tmp $@
+	perl -ne 'print unless (m@^xref: (Orphanet|OMIM|OMIMPS|DOID|EFO|NCIT|SCTID|MESH|UMLS|ICD10CM):@ && !(m@(obsoleteEquivalent|equivalentObsolete|equivalentTo|relatedTo|mondoIsNarrowerThanSource|directSiblingOf|mondoIsBroaderThanSource)@i))' $< | grep -v '^property_value: excluded_subClassOf' | egrep -v '^synonym: .*EXCLUDE' | egrep -v 'relationship: disease_has_basis_in_dysfunction_of (hgnc|HGNC|NCBIGene):' > $@.tmp && mv $@.tmp $@
 	if [ $(GITHUB_ACTION) = false ]; then $(ROBOT) query -i $@ --use-graphs false \
 		--update ../sparql/update/delete-axiom-annotations.ru \
 		--update ../sparql/update/delete-axiom-annotations-by-prefix.ru \

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -382,6 +382,9 @@ rm_related_annos_to_exact:
 rm_xref_without_source:
 	$(ROBOT) query --use-graphs false -i $(SRC) --update $(SPARQLDIR)/update/rm-xref-without-source.ru -o $(SRC)
 
+rm_confidence_annotation:
+	$(ROBOT) query --use-graphs false -i $(SRC) --update $(SPARQLDIR)/update/rm-confidence_annotation.ru -o $(SRC)
+
 report-query-%:
 	$(ROBOT) query --use-graphs true -i $(SRC) -f tsv --query $(SPARQLDIR)/reports/$*.sparql reports/report-$*.tsv
 

--- a/src/sparql/qc/general/qc-permitted-properties.sparql
+++ b/src/sparql/qc/general/qc-permitted-properties.sparql
@@ -25,7 +25,6 @@ SELECT DISTINCT ?term ?property WHERE
 		dc:conformsTo,
 		dc:creator,
 		dce:date,
-		mondo:confidence,
 		mondo:excluded_from_qc_check,
 		mondo:excluded_subClassOf,
 		mondo:excluded_synonym,

--- a/src/sparql/update/rm-confidence_annotation.ru
+++ b/src/sparql/update/rm-confidence_annotation.ru
@@ -1,0 +1,11 @@
+PREFIX mondo: <http://purl.obolibrary.org/obo/mondo#>
+
+
+# Remove the mondo:confidence annotation from all MONDO classes
+DELETE {
+    ?class mondo:confidence ?confidence .
+}
+WHERE {
+    ?class mondo:confidence ?confidence .
+    FILTER (isIRI(?class) && STRSTARTS(str(?class), "http://purl.obolibrary.org/obo/MONDO_"))
+}


### PR DESCRIPTION
closes #7575 

I added a sparql query to the mondo.Makefile to remove the `confidence` annotation property from mondo-edit.obo.