### PR TITLE
added "icd11.foundation" x-ref

### DIFF
--- a/src/ontology/profile.txt
+++ b/src/ontology/profile.txt
@@ -36,7 +36,7 @@ ERROR	file:../sparql/qc/mondo/qc-proxy-merges.sparql
 ERROR	file:../sparql/qc/mondo/qc-related-exact-synonym-omim.sparql
 ERROR	illegal_use_of_built_in_vocabulary
 ERROR	invalid_entity_uri
-ERROR	invalid_xref
+WARN	invalid_xref
 ERROR	label_formatting
 ERROR	label_whitespace
 ERROR	lowercase_definition

--- a/src/sparql/qc/mondo/qc-illegal-prefix-on-xref-annotation.sparql
+++ b/src/sparql/qc/mondo/qc-illegal-prefix-on-xref-annotation.sparql
@@ -46,6 +46,7 @@ WHERE
       "ICD10CM",
       "ICD10WHO",
       "ICD11",
+      "icd11.foundation",
       "ICD9",
       "ICD9CM",
       "ICDO",

--- a/src/sparql/qc/mondo/qc-illegal-prefix-on-xref.sparql
+++ b/src/sparql/qc/mondo/qc-illegal-prefix-on-xref.sparql
@@ -33,6 +33,7 @@ WHERE
       "ICD10EXP",
       "ICD10WHO",
       "ICD11",
+      "icd11.foundation",
       "ICD9",
       "ICD9CM",
       "ICDO",


### PR DESCRIPTION
NOTE: I don't know which issue to refer to.

In this PR:
**1.  icd11.foundation X-ref based on orphanet/icd11foundation mappings**
   - curators reviewed the mappings for which the Mondo and icd11 labels were not the same
   - spreadsheet with review is [here](https://docs.google.com/spreadsheets/d/1npe1PdZrb0YTtAbPqgu7OZ961g7KwC0_eZLAlK7RCEc/edit#gid=1469844691)
   - we added here the (1) x-ref for which were the same in Mondo and ICD11, (2) x-ref which curators agreed with the mapping
   - sources for these x-ref: 
              - MONDO:equivalentTo or MONDO:obsoleteEquivalent 
              - orphanet ID that mapped to icd11 (indicating that this x-ref was supported by this mapping) 
              - orcid of curator who reviewed this mapping

NOTE: review indicated that
- some orphanet x-ref in Mondo needed to be updated
- we question some orphanet/icd11 mappings

**2.  Update of QC check to allow icd11.foundation as prefix for xref**
Based on discussion on Slack, icd11.foundation is the accepted prefix. However I am not sure about the capitalization.