### PR TITLE
Update qc-xref-syntax.sparql

### DIFF
--- a/src/sparql/qc/general/qc-xref-syntax.sparql
+++ b/src/sparql/qc/general/qc-xref-syntax.sparql
@@ -1,14 +1,16 @@
-# home: hp
-prefix hasDbXref: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
-prefix owl: <http://www.w3.org/2002/07/owl#>
-prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+# # Invalid Xref
+#
+# **Problem:** A database_cross_reference is not in CURIE format.
+#
+# **Solution:** Replace the reference with a [CURIE](https://www.w3.org/TR/2010/NOTE-curie-20101216/).
 
-SELECT DISTINCT ?entity ?property ?value WHERE 
-{
-  ?entity hasDbXref: ?x .
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-  FILTER( regex(STR(?x), " ") || regex(STR(?x), ";") || STR(?x) = ""  )
-  BIND(hasDbXref: AS ?property)
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  VALUES ?property {oboInOwl:hasDbXref}
+  ?entity ?property ?value .
+  FILTER (!regex(?value, "^[A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_]:[^\\s]+$"))
+  FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity


### PR DESCRIPTION
See https://github.com/ontodev/robot/pull/1186

This replaces the old permissive xref check by the new ROBOT invalid xref which is not yet released.