### PR TITLE
Add test for OAK parsing and OBO validation of release product

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -30,11 +30,17 @@ owlaxioms_check:
 obo_validator:
 	fastobo-validator mondo-edit.obo
 
+.PHONY: obo_validator_release
+obo_validator_release: mondo.obo
+	fastobo-validator $<
+	runoak --input pronto:$< info MONDO:0000001 
+
 test: pattern_schema_checks
 test: owlaxioms_check
 test: test_reason_equivalence
 test: test_reason_equivalence_hermit
 test: obo_validator
+test: obo_validator_release
 
 test_reason_equivalence_hermit: $(ONT).obo
 	$(ROBOT) reason -i $< --equivalent-classes-allowed none -r hermit


### PR DESCRIPTION
Precludes problems like #7579 in the future.

This PR:

1. Runs a OBO validator over the _release product_ mondo.obo rather than just over the edit file (which is more important for users!)
2. Run a test parse with OAK to ensure that the primary OBO release is OAK pronto parseable,.