### PR TITLE
Add curated content resource property

### DIFF
--- a/src/sparql/qc/general/qc-permitted-properties.sparql
+++ b/src/sparql/qc/general/qc-permitted-properties.sparql
@@ -25,7 +25,7 @@ SELECT DISTINCT ?term ?property WHERE
 		dc:conformsTo,
 		dc:creator,
 		dce:date,
-		MONDO:0700275,
+		mondo:0700275,
 		mondo:excluded_from_qc_check,
 		mondo:excluded_subClassOf,
 		mondo:excluded_synonym,

--- a/src/sparql/qc/general/qc-permitted-properties.sparql
+++ b/src/sparql/qc/general/qc-permitted-properties.sparql
@@ -25,6 +25,7 @@ SELECT DISTINCT ?term ?property WHERE
 		dc:conformsTo,
 		dc:creator,
 		dce:date,
+		MONDO:0700275,
 		mondo:excluded_from_qc_check,
 		mondo:excluded_subClassOf,
 		mondo:excluded_synonym,

--- a/src/sparql/qc/general/qc-permitted-properties.sparql
+++ b/src/sparql/qc/general/qc-permitted-properties.sparql
@@ -25,7 +25,7 @@ SELECT DISTINCT ?term ?property WHERE
 		dc:conformsTo,
 		dc:creator,
 		dce:date,
-		mondo:0700275,
+		mondo:curated_content_resource,
 		mondo:excluded_from_qc_check,
 		mondo:excluded_subClassOf,
 		mondo:excluded_synonym,

--- a/src/sparql/qc/general/qc-permitted-properties.sparql
+++ b/src/sparql/qc/general/qc-permitted-properties.sparql
@@ -42,8 +42,6 @@ SELECT DISTINCT ?term ?property WHERE
 		oboInOwl:hasRelatedSynonym,
 		oboInOwl:id,
 		oboInOwl:inSubset,
-		oboInOwl:is_metadata_tag,
-		oboInOwl:is_class_level,
 		owl:deprecated,
 		owl:disjointWith,
 		owl:equivalentClass,

--- a/src/sparql/qc/general/qc-permitted-properties.sparql
+++ b/src/sparql/qc/general/qc-permitted-properties.sparql
@@ -42,6 +42,8 @@ SELECT DISTINCT ?term ?property WHERE
 		oboInOwl:hasRelatedSynonym,
 		oboInOwl:id,
 		oboInOwl:inSubset,
+		oboInOwl:is_metadata_tag,
+		oboInOwl:is_class_level,
 		owl:deprecated,
 		owl:disjointWith,
 		owl:equivalentClass,


### PR DESCRIPTION
Right now, we cannot agree community wide on a standard way to represent linkouts, not even whether or not they should be curated in the ontology at all. This is breaking a bit more with Mondo being a pure ontology vs a bit databasey, but right now, we just need a convenient way to link to curated content for our stakeholders.

Here, we add the property so we can start using it, even if we might change the ID to an OMO id in the future.

Context:

- https://github.com/information-artifact-ontology/ontology-metadata/issues/165 
- https://github.com/monarch-initiative/mondo/issues/7071