### PR TITLE
Fixing ODK version in Mondo to 1.5.2

### DIFF
--- a/docs/developer-guide/release.md
+++ b/docs/developer-guide/release.md
@@ -50,7 +50,7 @@ _Note: While the release is running, don't shut your laptop or switch between re
 1. Do a docker pull: `docker pull obolibrary/odkfull:dev`
 1. Pull master
 1. Run command: `cd mondo/src/ontology/` (navigate to folder on your computer)
-1. `IMAGE=odkfull:dev ./run.sh make IMP=false all -B` 
+1. `./run.sh make IMP=false all -B` 
     - note, this takes 1+ hour(s)
     - note that we are using the dev image as it is always up to date with the Python dependencies.
 1. Make sure you see ‘release finished’ after the command has run

--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -12,8 +12,8 @@
 
 docker pull obolibrary/odkfull:latest
 
-IMAGE=${IMAGE:-odkfull:latest}
 MEMORY_GB=${MEMORY_GB:-8}
+IMAGE=${IMAGE:-odkfull:v1.5.2}
 MEMORY_JAVA="-Xmx${MEMORY_GB}G"
 ODK_DEBUG=${ODK_DEBUG:-no}
 

--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -10,12 +10,12 @@
 #
 # See README-editors.md for more details.
 
-docker pull obolibrary/odkfull:latest
-
 MEMORY_GB=${MEMORY_GB:-8}
 IMAGE=${IMAGE:-odkfull:v1.5.2}
 MEMORY_JAVA="-Xmx${MEMORY_GB}G"
 ODK_DEBUG=${ODK_DEBUG:-no}
+
+docker pull obolibrary/$IMAGE
 
 echo "Running ODK with ${MEMORY_GB} GB of memory, using ${IMAGE}."
 


### PR DESCRIPTION
Fixes #7981 

As per discussions in the tech call, this PR fixes the ODK version to 1.5.2. This way, we can upgrade ODK versions in tandem with mondo ingest, and avoid errors that are caused by variability in the ODK development snapshot.