### PR TITLE
Add QC check for proper treatment of preferredExternal annotations

### DIFF
--- a/src/sparql/qc/general/qc-xref-without-source.sparql
+++ b/src/sparql/qc/general/qc-xref-without-source.sparql
@@ -16,7 +16,7 @@ SELECT DISTINCT ?entity ?xref WHERE {
     }
     # 20.06.2024: had to remove Orphanet and NCIT as they actually had too many errors
     # strstarts(str(?xref), "Orphanet:") || strstarts(str(?xref), "ORDO:") || strstarts(str(?xref), "NCIT:")
-    FILTER (strstarts(str(?xref), "OMIM:") || strstarts(str(?xref), "OMIMPS:") || strstarts(str(?xref), "DOID:"))
+    FILTER (strstarts(str(?xref), "OMIM:") || strstarts(str(?xref), "OMIMPS:") || strstarts(str(?xref), "DOID:") || strstarts(str(?xref), "OMIA:"))
     FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))	
 }
 ORDER BY ?entity

--- a/src/sparql/qc/mondo/qc-preferred-external-no-equivalent.sparql
+++ b/src/sparql/qc/mondo/qc-preferred-external-no-equivalent.sparql
@@ -1,0 +1,46 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX IAO: <http://purl.obolibrary.org/obo/IAO_>
+PREFIX OMO: <http://purl.obolibrary.org/obo/OMO_>
+PREFIX MONDO: <http://purl.obolibrary.org/obo/MONDO_>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# description: Ensure that preferredExternal annotations are used correctly
+
+SELECT ?entity ?property ?value WHERE {
+    VALUES ?property { oboInOwl:hasDbXref }
+    {
+        # Check for cases where there is a preferredExternal annotation
+        # but no MONDO:equivalentTo
+        [] owl:annotatedSource ?entity ;
+            owl:annotatedProperty ?property ;
+            owl:annotatedTarget ?value ;
+            oboInOwl:source "MONDO:preferredExternal" .
+        FILTER NOT EXISTS {
+            [] owl:annotatedSource ?entity ;
+            owl:annotatedProperty ?property ;
+            owl:annotatedTarget ?value ;
+            oboInOwl:source "MONDO:equivalentTo" .
+        }
+    } UNION {
+        # Check for cases where there is a preferredExternal annotation
+        # but no MONDO:equivalentTo to a different class
+        # This indicates that there is no point to saying "preferredExternal"
+        # as there is nothing this can be preferred to.
+        [] owl:annotatedSource ?entity ;
+            owl:annotatedProperty ?property ;
+            owl:annotatedTarget ?value ;
+            oboInOwl:source "MONDO:preferredExternal" .
+        FILTER NOT EXISTS {
+            [] owl:annotatedSource ?entity2 ;
+            owl:annotatedProperty ?property ;
+            owl:annotatedTarget ?value ;
+            oboInOwl:source "MONDO:equivalentTo" .
+        }
+        FILTER(?entity!=?entity2)
+        FILTER (isIRI(?entity2) && STRSTARTS(str(?entity2), "http://purl.obolibrary.org/obo/MONDO_"))
+    }
+  FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+}


### PR DESCRIPTION
Fixes #7872 

This PR adds a qc check that ensures that

1) Xrefs with preferred external must have a corresponding equivalentto on the same class (this also ensures covers the case in the #7872 which is asking for ensuring there is no "relatedTo" by being stronger: there must be an equivalent, and there cant be both).
2) Xrefs with preferred external must be related to another class which are equivalent as well