### PR TITLE
Add check for omim gene entries used as xrefs

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -600,6 +600,28 @@ mappings_fast:
 	$(MAKE) clean_mappings -B
 	$(MAKE) mappings IMP=false MIR=false PAT=false -B
 
+###### OMIM Genes #########
+
+tmp/omim.owl:
+	$(ROBOT) merge -I "https://github.com/monarch-initiative/omim/releases/latest/download/omim.owl" convert -o $@
+
+tmp/omim-genes.tsv: tmp/omim.owl
+	$(ROBOT) query --use-graphs true -i tmp/omim.owl -f tsv --tdb true --query $(SPARQLDIR)/reports/omim-genes.sparql $@
+	sed -i 's/[?]//g' $@
+	sed -i 's/[<]https[:][/][/]omim[.]org[/]entry[/]/OMIM:/g' $@
+	sed -i 's/>//g' $@
+	tail -n +2 $@ > output_file && mv output_file $@
+
+# Check for occurrences of OMIM genes in MONDO,
+# Then narrow down to only xrefs
+tmp/omim-gene-matches.txt: tmp/omim-genes.tsv
+	grep -Ff $< mondo-edit.obo | grep '^xref' > $@ || true
+	if [ -s $@ ]; then \
+		echo "FAIL: OMIM gene entry used in xref (matches found in $@)"; \
+		exit 1; \
+	fi
+
+test: tmp/omim-gene-matches.txt
 
 ##### RELEASE Report ######
 

--- a/src/sparql/reports/omim-genes.sparql
+++ b/src/sparql/reports/omim-genes.sparql
@@ -1,0 +1,5 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?gene WHERE {
+  ?gene rdfs:subClassOf+ <http://purl.obolibrary.org/obo/SO_0000704> .
+}


### PR DESCRIPTION
Replaces https://github.com/monarch-initiative/mondo/pull/7984 since too many changes in `master` at this point.

See https://github.com/monarch-initiative/mondo/issues/7983 for context. Should also pass now since https://github.com/monarch-initiative/mondo/pull/8011.

