### PR TITLE
obsolete "rare"

### DIFF
--- a/src/ontology/imports/axioms.owl
+++ b/src/ontology/imports/axioms.owl
@@ -165,22 +165,6 @@
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0021128"/>
     </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0021136"/>
-                <owl:disjointWith rdf:nodeID="genid7"/>
-            </owl:Restriction>
-        </owl:annotatedSource>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointWith"/>
-        <owl:annotatedTarget rdf:nodeID="genid7"/>
-        <oboInOwl:created_by>cjm</oboInOwl:created_by>
-    </owl:Axiom>
-    <owl:Restriction rdf:nodeID="genid7">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
-        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0021137"/>
-    </owl:Restriction>
     <owl:Restriction>
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0021141"/>
@@ -196,14 +180,14 @@
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0700005"/>
-                <owl:disjointWith rdf:nodeID="genid12"/>
+                <owl:disjointWith rdf:nodeID="genid9"/>
             </owl:Restriction>
         </owl:annotatedSource>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointWith"/>
-        <owl:annotatedTarget rdf:nodeID="genid12"/>
+        <owl:annotatedTarget rdf:nodeID="genid9"/>
         <oboInOwl:created_by>https://orcid.org/0000-0002-4142-7153</oboInOwl:created_by>
     </owl:Axiom>
-    <owl:Restriction rdf:nodeID="genid12">
+    <owl:Restriction rdf:nodeID="genid9">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0700006"/>
     </owl:Restriction>


### PR DESCRIPTION
Closes #6448

@matentzn I obsoleted the classes "rare or common", "rare" and "not rare.

Please note that
1) only Mondo-edit.obo was changed (and not 2 files as you mentioned in the issue) 2) all the axioms were changed to use "obsolete" instead of being completely removed.

Is this because I "obsoleted" instead of "deleted" the term? How should I proceed from here?