### PR TITLE
updates to have ICD11 and EFO entries in the mondo.sssom.tsv file

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -198,7 +198,7 @@ ANN = annotate -V $(ONTURI)/releases/`date +%Y-%m-%d`/$@.owl
 GITHUB_ACTION = false
 
 filtered.obo: $(SRC)
-	perl -ne 'print unless (m@^xref: (Orphanet|OMIM|OMIMPS|DOID|EFO|NCIT|SCTID|MESH|UMLS|ICD10CM):@ && !(m@(obsoleteEquivalent|equivalentObsolete|equivalentTo|relatedTo|mondoIsNarrowerThanSource|directSiblingOf|mondoIsBroaderThanSource)@i))' $< | grep -v '^property_value: excluded_subClassOf' | egrep -v '^synonym: .*EXCLUDE' | egrep -v 'relationship: disease_has_basis_in_dysfunction_of (hgnc|HGNC|NCBIGene):' > $@.tmp && mv $@.tmp $@
+	perl -ne 'print unless (m@^xref: (Orphanet|OMIM|OMIMPS|DOID|EFO|NCIT|SCTID|MESH|UMLS|ICD10CM|icd11.foundation):@ && !(m@(obsoleteEquivalent|equivalentObsolete|equivalentTo|relatedTo|mondoIsNarrowerThanSource|directSiblingOf|mondoIsBroaderThanSource)@i))' $< | grep -v '^property_value: excluded_subClassOf' | egrep -v '^synonym: .*EXCLUDE' | egrep -v 'relationship: disease_has_basis_in_dysfunction_of (hgnc|HGNC|NCBIGene):' > $@.tmp && mv $@.tmp $@
 	perl -ne 'print if !(/^xref: (Orphanet|OMIM|OMIMPS|DOID):/ && !(/(obsoleteEquivalent|equivalentObsolete|equivalentTo|obsoleteEquivalentObsolete)/i))' $@  > $@.tmp && mv $@.tmp $@
 	if [ $(GITHUB_ACTION) = false ]; then $(ROBOT) query -i $@ --use-graphs false \
 		--update ../sparql/update/delete-axiom-annotations.ru \

--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -26,6 +26,7 @@ curie_map:
   # ICD10CM__2: https://icd.codes/icd10cm/
   # ICD10WHO: https://icd.who.int/browse10/2019/en#/
   # ICD10WHO__2: http://apps.who.int/classifications/icd10/browse/2010/en#/
+  icd11.foundation: http://purl.obolibrary.org/obo/mondo/sources/icd11foundation/
   OMIMPS: https://omim.org/phenotypicSeries/PS
   MEDGEN: http://identifiers.org/medgen/
   MedDRA: http://identifiers.org/meddra/
@@ -87,6 +88,7 @@ subject_prefixes:
   - OMIMPS
   - NCIT
   - DOID
+  - icd11.foundation
 relations:
   - oboInOwl:hasDbXref
   - skos:exactMatch
@@ -139,3 +141,7 @@ source_metadata:
       object_source: http://purl.obolibrary.org/obo/doid.owl
       object_source_version: http://purl.obolibrary.org/obo/doid/releases/2018-07-05/doid.owl
       mapping_date: "2018-07-05"
+  - from: MONDO
+    to: icd11.foundation
+    metadata:
+      object_source: http://purl.obolibrary.org/obo/mondo/sources/icd11foundation.owl

--- a/src/utils/mk-skos.pl
+++ b/src/utils/mk-skos.pl
@@ -77,6 +77,12 @@ while (<>) {
         elsif ($prefix eq 'ICD10CM') {
             $uri = 'http://purl.bioontology.org/ontology/ICD10CM/';
         }
+        elsif ($prefix eq 'icd11.foundation') {
+            $uri = 'http://purl.obolibrary.org/obo/mondo/sources/icd11foundation/';
+        }
+        elsif ($prefix eq 'EFO') {
+            $uri = 'http://www.ebi.ac.uk/efo/EFO_';
+        }
 
         if ($uri) {
             my $tgt = "$uri$x";


### PR DESCRIPTION
In reviewing data for the Synonym Sync I saw that icd11.foundation was not included as a source even though Mondo now includes xrefs to this source. After further review and chat with Nico on Slack, these are the files I updated so that EFO and icd11.foundation are included in the `mondo.sssom.tsv` file. 

To confirm these changes work, I ran `sh run.sh make mappings/mondo.sssom.tsv -B` and then reviewed the `mondo.sssom.tsv` to confirm the updated content.