### PR TITLE
Xrefs on axioms and most annotation assertions should use oio:source

### DIFF
--- a/src/sparql/qc/general/qc-axiom-provenance-source.sparql
+++ b/src/sparql/qc/general/qc-axiom-provenance-source.sparql
@@ -1,0 +1,52 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# description: Looks for axiom annotations which use faulty provenance properties
+
+SELECT DISTINCT ?entity ?property ?value
+
+WHERE
+{
+    ?entity a owl:Class;
+    		rdfs:subClassOf+ <http://purl.obolibrary.org/obo/MONDO_0000001> ;
+       	    ?property ?v .
+
+      ?axiom owl:annotatedSource ?entity ;
+             owl:annotatedProperty ?property ;
+             owl:annotatedTarget ?v ;
+             ?provenance ?x .
+    
+    # The axiom provenance should typically use oio:source, so lets look for case where it does not
+    # (also, it should not correspond to the actual RDF-reified annotation properties)
+    FILTER(
+        ?provenance!=oio:source 
+        && ?provenance!=owl:annotatedSource 
+        && ?provenance!=owl:annotatedTarget
+        && ?provenance!=owl:annotatedProperty
+        && ?provenance!=rdf:type
+    )
+
+    # Ignore Synonym type annotations
+    FILTER(
+        ?provenance!=oio:hasSynonymType 
+        && (?property!=oio:hasExactSynonym || ?property!=oio:hasRelatedSynonym || ?property!=oio:hasBroadSynonym || ?property!=oio:hasNarrowSynonym)
+    )
+
+    # Xrefs are allowed on definitions and synonyms
+    FILTER(
+        (?provenance!=oio:hasDbXref) 
+        && (?property!=IAO:0000115 || ?property!=oio:hasExactSynonym || ?property!=oio:hasRelatedSynonym || ?property!=oio:hasBroadSynonym || ?property!=oio:hasNarrowSynonym)
+    )
+
+    BIND(CONCAT(str(?v),CONCAT(": ",str(?provenance))) as ?value)
+
+   FILTER( !isBlank(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+} ORDER BY ?entity
+


### PR DESCRIPTION
Fixes #8055 

@twhetzel and @joeflack4 have identified a few cases in #8055 where provenance was annotated inconsistently. Here I go much further and add a QC check that ensures that _all_ axiom assertions are using the correct property.

I have already fixed all these, and will wait for QC to fail as a proof the PR works