### PR TITLE
added obsoletion protection

### DIFF
--- a/src/sparql/qc/mondo/qc-obsoletionprotected.sparql
+++ b/src/sparql/qc/mondo/qc-obsoletionprotected.sparql
@@ -8,15 +8,17 @@ prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 #this query reports when an obsoletion-candidate tag is added to a protected term
 
-SELECT ?mondo_id ?label
+SELECT ?entity ?property ?value
 WHERE 
   { 
-?mondo_id a owl:Class; 
-  		rdfs:label ?label .
-  
-?mondo_id <http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/mondo#obsoletion_candidate>.
-  
-?mondo_id <http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/mondo#obsoletion_protected>.
 
-  FILTER( !isBlank(?mondo_id) && regex(str(?mondo_id), "^http://purl.obolibrary.org/obo/MONDO_"))
+VALUES ?property { <http://purl.obolibrary.org/obo/mondo#obsoletion_candidate> }
+?entity <http://www.geneontology.org/formats/oboInOwl#inSubset> ?property.
+
+?entity a owl:Class; 
+  		rdfs:label ?value .
+
+?entity <http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/mondo#obsoletion_protected>.
+
+  FILTER( !isBlank(?entity) && regex(str(?entity), "^http://purl.obolibrary.org/obo/MONDO_"))
 }

--- a/src/sparql/qc/mondo/qc-obsoletionprotected.sparql
+++ b/src/sparql/qc/mondo/qc-obsoletionprotected.sparql
@@ -1,0 +1,22 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX replaced_by: <http://purl.obolibrary.org/obo/IAO_0100001>
+PREFIX MONDO: <http://purl.obolibrary.org/obo/MONDO_>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+#this query reports when an obsoletion-candidate tag is added to a protected term
+
+SELECT ?mondo_id ?label
+WHERE 
+  { 
+?mondo_id a owl:Class; 
+  		rdfs:label ?label .
+  
+?mondo_id <http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/mondo#obsoletion_candidate>.
+  
+?mondo_id <http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/mondo#obsoletion_protected>.
+
+  FILTER( !isBlank(?mondo_id) && regex(str(?mondo_id), "^http://purl.obolibrary.org/obo/MONDO_"))
+}


### PR DESCRIPTION
I have received a few requests to remove some terms from the obsoletion list. I am still reviewing these requests. In the meantime, I went ahead and set up the basis to deal with "protection for obsoletion". 
In this PR, I 
- created a new AP: "obsoletion_protected"
- used this AP for a "in subset" annotation on the term to protect from obsoletion
- I removed all the "obsoletion candidate" information
- Request to protect the term from obsoletion is in the GH issue already on the term. 


@twhetzel @matentzn @nicolevasilevsky 
Please take a look and give your ok with this new subtype. 
We can set up a QC check at a later time. 