### PR TITLE
Fix subclass of sync

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1264,9 +1264,8 @@ all: config/exclusion_reasons.tsv
 $(TMPDIR)/subclass-confirmed.robot.tsv:
 	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/main/src/ontology/reports/sync-subClassOf.confirmed.tsv" -O $@
 
-# TODO WARNING THE URL POINTS TO A BRANCH!
 $(TMPDIR)/synonyms-confirmed.robot.tsv:
-	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/refs/heads/sync1-synonyms/src/ontology/reports/sync-synonym/sync-synonyms.confirmed.robot.tsv" -O $@
+	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/refs/heads/main/src/ontology/reports/sync-synonym/sync-synonyms.confirmed.robot.tsv" -O $@
 
 $(TMPDIR)/new-exact-matches-%.tsv:
 	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/main/src/ontology/lexmatch/unmapped_$*_lex_exact.tsv" -O $@


### PR DESCRIPTION
Previously the syncing was wrong as the method was deleting _all_ subclass of axioms, regardless of whether they were existential restrictions or subclass between names. It took a while to find this solution, but I think it should work:

1. delete _all_ subclass of axioms after
2. backing up all subclass of axioms with existentials
3. backing uo all subclass of axioms without existentials, and then removing evidence from all the mondo ingest primary sources from it.

I accidentally merged the synonym sync commit with the URL change but this will disappear since #8430 is merged.

- [ ] Depends on https://github.com/monarch-initiative/mondo-ingest/issues/708 (and subsequent dataload) to ensure no other issues are caused by this PR