### PR TITLE
rm quick check from build

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -1296,7 +1296,12 @@ check: mondo-edit.obo
 	 ../utils/quick-check.pl $<
 
 mondo-edit.owl: mondo-edit.obo
-	../utils/quick-check.pl $< && $(ROBOT) convert -i $< -o $@
+	$(ROBOT) convert -i $< -o $@
+
+quickcheck: mondo-edit.obo
+	../utils/quick-check.pl $<
+
+test: quickcheck
 
 d2taxon-wd.tsv:
 	pq-wd -f tsv  "has_cause(D,T),doid_id(D,DX),ncbitaxon_id(T,TX)" "x(DX,TX)" > $@.tmp && perl -npe 's@\t@\tNCBITaxon:@' $@.tmp > $@


### PR DESCRIPTION
In order to build and test Mondo with externally managed content (which is sometimes broken), we need to be more permissive during the build. This moves the quick-check.pl  out of the normal release build pipeline into the qc (`test`) pipeline.