### PR TITLE
remove gard from obsoletion workflow

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -561,7 +561,7 @@ subset-metrics:
 
 SOURCE_VERSION = $(TODAY)
 # snomed
-SOURCE_IDS = doid ncit ordo omim gard
+SOURCE_IDS = doid ncit ordo omim
 SOURCE_IDS_INCL_MONDO = $(SOURCE_IDS) mondo equivalencies
 ALL_SOURCES_JSON = $(patsubst %, sources/$(SOURCE_VERSION)/%.json, $(SOURCE_IDS_INCL_MONDO))
 ALL_SOURCES_JSON_GZ = $(patsubst %, sources/$(SOURCE_VERSION)/%.json.gz, $(SOURCE_IDS_INCL_MONDO))


### PR DESCRIPTION
PR to fix https://github.com/monarch-initiative/mondo-ingest/issues/735

The Obsoletion workflow fails because the GARD file is missing since it was removed as part of a clean-up effort in mondo-ingest to remove unused files for GARD. This PR removes `gard` from being used in the Obsoletion workflow to fix the issue.

I am looking to see if/where else removal of `gard` here effects other make goals.