### PR TITLE
add additional deprecation merge patterns

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1083,6 +1083,8 @@ deprecated_annotation_merging:
 	sed -i 's/source="MONDO:equivalentObsolete",\ source="MONDO:obsoleteEquivalentObsolete"/source="MONDO:obsoleteEquivalentObsolete"/g' mondo-edit.obo || true
 	sed -i 's/source="MONDO:equivalentObsolete",\ source="MONDO:equivalentTo"/source="MONDO:equivalentObsolete"/g' mondo-edit.obo || true
 	sed -i 's/\(.*\)source="MONDO:equivalentObsolete"\(.*\)source="MONDO:obsoleteEquivalentObsolete"\(.*\)/\1source="MONDO:obsoleteEquivalentObsolete"\2\3/g' mondo-edit.obo || true
+	sed -i '/source="MONDO:equivalentObsolete"/ s/, source="MONDO:equivalentTo"//g' mondo-edit.obo || true
+	sed -i 's/source="MONDO:equivalentObsolete",\ source="MONDO:obsoleteEquivalent"/source="MONDO:obsoleteEquivalentObsolete"/g' mondo-edit.obo || true
 	sed -i 's/, }/}/g' mondo-edit.obo || true
 	sed -i 's/, ,/,/g' mondo-edit.obo || true
 	echo "NOTE: There are still some broken cases that need to be manually fixed. Search for `quivalent.*quivalent` (no E) in case sensitive regex mode in Atom or Visual Studio"


### PR DESCRIPTION
closes https://github.com/monarch-initiative/mondo/issues/8509

Added additional sed commands to the `deprecated_annotation_merging` make goal  based on the issues listed [here](https://github.com/monarch-initiative/mondo/issues/8509#issuecomment-2569825604).

I tested these changes by running: `sh run.sh make update_deprecated_mappings` and comparing the diff to the changes made in the [monthly obsoletion PR](https://github.com/monarch-initiative/mondo/pull/8508). The same changes were found in both the [PR](https://github.com/monarch-initiative/mondo/pull/8508) and from running the `deprecated_annotation_merging` make goal with the additional sed commands. The run with the updated `deprecated_annotation_merging` make goal had one additional update (xref: OMIM:210550 {source="MONDO:equivalentObsolete"} for MONDO:0008868), which does match the OMIM status of this entry since it is also deprecated.