### PR TITLE
Fix docs GH Action workflow error

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -75,7 +75,6 @@ pattern_ontology: ../patterns/pattern.owl
 	filter --select "<http://purl.obolibrary.org/obo/mondo/patterns*>" --select "self annotations" --signature true --trim true -o ../patterns/pattern-simple.owl
 
 ../patterns/dosdp-patterns/README.md: .FORCE
-	pip install tabulate
 	python ../scripts/patterns_create_overview.py "../patterns/dosdp-patterns" "../patterns/data/matches" $@
 
 pattern_readmes: ../patterns/dosdp-patterns/README.md


### PR DESCRIPTION
This PR removes the pip install command, since the command fails and tabulate is in ODK so `sh run.sh make ../patterns/dosdp-patterns/README.md` appears to run fine without the pip command needed. 

Update: Sabrina reported in Slack that this failed as part of creating the Mondo release and this GH Action run 
https://github.com/monarch-initiative/mondo/actions/runs/12656667270