### PR TITLE
Add report for reviewing proxy merges

### DIFF
--- a/src/sparql/reports/review-proxy-merges.sparql
+++ b/src/sparql/reports/review-proxy-merges.sparql
@@ -1,0 +1,34 @@
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+#description: No two Mondo IDs should ever point to the same external ID
+
+SELECT DISTINCT ?entity ?label ?entity2 ?label2 ?xref WHERE {
+    ?entity oboInOwl:hasDbXref ?xref .
+    ?entity rdfs:label ?label .
+    
+    ?entity2 oboInOwl:hasDbXref ?xref .
+    ?entity2 rdfs:label ?label2 .
+    
+    ?xref_anno2 a owl:Axiom ;
+           owl:annotatedSource ?entity ;
+           owl:annotatedProperty oboInOwl:hasDbXref ;
+           owl:annotatedTarget ?xref ;
+           oboInOwl:source ?source1 .
+    	
+  		?xref_anno a owl:Axiom ;
+           owl:annotatedSource ?entity2 ;
+           owl:annotatedProperty oboInOwl:hasDbXref ;
+           owl:annotatedTarget ?xref ;
+           oboInOwl:source ?source2 .
+
+  	FILTER (?entity2!=?entity)
+    FILTER ((str(?source1)="MONDO:equivalentTo") || (str(?source1)="MONDO:obsoleteEquivalent") || (str(?source1)="MONDO:equivalentObsolete") || (str(?source1)="MONDO:obsoleteEquivalentObsolete"))
+  	FILTER ((str(?source2)="MONDO:equivalentTo") || (str(?source2)="MONDO:obsoleteEquivalent") || (str(?source2)="MONDO:equivalentObsolete") || (str(?source2)="MONDO:obsoleteEquivalentObsolete"))
+    FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))
+    FILTER (isIRI(?entity2) && STRSTARTS(str(?entity2), "http://purl.obolibrary.org/obo/MONDO_"))
+    BIND(IRI(CONCAT("http://mondo.source/", ?xref)) AS ?property)
+    BIND(str(?entity2) as ?value)
+}
+ORDER BY ?entity


### PR DESCRIPTION
As per need right now, I will merge this immediately, but feel free to review anyways @twhetzel and tell me if you have thoughts.

This is so a reviewer can run

```
 sh run.sh make report-reason-query-review-proxy-merges
```

locally to review the proxy merges a bit more effectively in a table than doing so one by one

the query is, other than the labels, identical to our qc check.