### PR TITLE
Update CODE OWNERS to have Reviewers for only certain file types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Mondo code owners (Guardians of the main branch)
 
 # Removed @cmungall to stop him being added to all PRs
-*       @sabrinatoro @twhetzel
+# *       @sabrinatoro @twhetzel
 *.sparql @twhetzel
 *.py	  @twhetzel
 *.md    @sabrinatoro @twhetzel @nicolevasilevsky


### PR DESCRIPTION
Following Slack chat with @sabrinatoro about adding another person in place of me as a CODE OWNER, she suggested to not automatically assign anyone since curation PRs use the `Assignees` field instead of `Reviewers`.