### PR TITLE
Add goal to create a branch diff and see unsats

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -640,9 +640,17 @@ tmp/mondo-lastbase.owl:
 reports/mondo_diff.md: mondo-base.owl tmp/mondo-lastbase.owl
 	$(ROBOT) diff --left tmp/mondo-lastbase.owl --right $< -f markdown -o $@
 
-reports/mondo_unsats.md: mondo.obo
-	$(ROBOT) explain -i $< --reasoner ELK -M unsatisfiability --unsatisfiable all --explanation $@ \
-		annotate --ontology-iri "http://purl.obolibrary.org/obo/$@" -o $@.owl
+tmp/mondo-main-edit.owl:
+	wget "https://raw.githubusercontent.com/monarch-initiative/mondo/refs/heads/master/src/ontology/mondo-edit.obo" -O $@
+
+reports/mondo_branch_edit_diff.md: mondo-edit.obo tmp/mondo-main-edit.owl
+	$(ROBOT) diff --left tmp/mondo-main-edit.owl --right $< -f markdown -o $@
+
+reports/mondo_unsats.md: mondo-edit.obo
+	$(ROBOT) explain -i $< -M unsatisfiability --unsatisfiable random:10 --explanation $@
+
+.PHONY: mondo_branch_diff
+mondo_branch_diff: reports/mondo_branch_edit_diff.md reports/mondo_unsats.md
 
 .PHONY: mondo_feature_diff
 mondo_feature_diff: reports/robot_diff.md reports/mondo_unsats.md

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -649,8 +649,9 @@ reports/mondo_branch_edit_diff.md: mondo-edit.obo tmp/mondo-main-edit.owl
 reports/mondo_unsats.md: mondo-edit.obo
 	$(ROBOT) explain -i $< -M unsatisfiability --unsatisfiable random:10 --explanation $@
 
-.PHONY: mondo_branch_diff
+.PHONY: mondo_branch_diff reports/mondo_branch_edit_diff.md reports/mondo_unsats.md tmp/mondo-main-edit.owl
 mondo_branch_diff: reports/mondo_branch_edit_diff.md reports/mondo_unsats.md
+	@echo "** Process is complete. See report files at: reports/mondo_branch_edit_diff.md and reports/mondo_unsats.md"
 
 .PHONY: mondo_feature_diff
 mondo_feature_diff: reports/robot_diff.md reports/mondo_unsats.md


### PR DESCRIPTION
reports/mondo_unsats.md is not used anywhere so its safe to change it; here we add a goal to generate a random sample of unsats, plus a markdown diff using robot for branch review.

Context: #8741 