### PR TITLE
DO NOT MERGE: Evaluating synonym sync QC checks (1 of 2)

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1312,9 +1312,9 @@ $(TMPDIR)/subclass-confirmed.robot.tsv:
 	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/main/src/ontology/reports/sync-subClassOf.confirmed.tsv" -O $@
 
 # TODO: Run QC by fetching -confirmed from different branches and see results
-# TODO: SYN_SYNC_SRC=main
-# TODO: SYN_SYNC_SRC=_main_data-build-10Mar2025
-SYN_SYNC_SRC=qc-duplicate-exact-synonym-no-abbrev--updates--mini-build-5
+# TODO: SYN_SYNC_SRC=main? prolly not
+SYN_SYNC_SRC=_main_data-build-10Mar2025
+# SYN_SYNC_SRC=qc-duplicate-exact-synonym-no-abbrev--updates--mini-build-5  # fail
 $(TMPDIR)/synonyms-confirmed.robot.tsv:
 	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/refs/heads/$(SYN_SYNC_SRC)/src/ontology/reports/sync-synonym/sync-synonyms.confirmed.robot.tsv" -O $@
 

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1311,8 +1311,12 @@ all: config/exclusion_reasons.tsv
 $(TMPDIR)/subclass-confirmed.robot.tsv:
 	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/main/src/ontology/reports/sync-subClassOf.confirmed.tsv" -O $@
 
+# TODO: Run QC by fetching -confirmed from different branches and see results
+# TODO: SYN_SYNC_SRC=main
+# TODO: SYN_SYNC_SRC=_main_data-build-10Mar2025
+SYN_SYNC_SRC=qc-duplicate-exact-synonym-no-abbrev--updates--mini-build-5
 $(TMPDIR)/synonyms-confirmed.robot.tsv:
-	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/refs/heads/main/src/ontology/reports/sync-synonym/sync-synonyms.confirmed.robot.tsv" -O $@
+	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/refs/heads/$(SYN_SYNC_SRC)/src/ontology/reports/sync-synonym/sync-synonyms.confirmed.robot.tsv" -O $@
 
 $(TMPDIR)/new-exact-matches-%.tsv:
 	wget "https://raw.githubusercontent.com/monarch-initiative/mondo-ingest/main/src/ontology/lexmatch/unmapped_$*_lex_exact.tsv" -O $@


### PR DESCRIPTION
Trying to address:
- https://github.com/monarch-initiative/mondo-ingest/issues/801

Related:
- #8838 

All QC from above issue passed in this PR using `mondo-ingest` branch `_main_data-build-10Mar2025`: QC results ([1](https://github.com/monarch-initiative/mondo/actions/runs/13825101000/job/38678481593?pr=8835), [2](https://github.com/monarch-initiative/mondo/actions/runs/13825707345/job/38680119661?pr=8835))