### PR TITLE
Add query to remove gene associations from obsolete classes - OMIM pipeline update

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -484,6 +484,7 @@ update-omim-genes:
 	$(ROBOT) remove -i $(SRC) --term RO:0004003 --axioms SubClassOf --preserve-structure false --trim true \
 		merge -i $(TMPDIR)/external/processed-mondo-omim-genes.robot.owl -i $(TMPDIR)/mondo-genes-axioms.owl --collapse-import-closure false \
 		query --update ../sparql/update/omim-gene-equivalence.ru \
+		query --update ../sparql/update/remove_gene_associations_from_obsolete.ru \
 		convert -f obo --check false -o $(SRC).obo
 	mv $(SRC).obo $(SRC) && make NORM && mv NORM $(SRC)
 

--- a/src/sparql/update/remove_gene_associations_from_obsolete.ru
+++ b/src/sparql/update/remove_gene_associations_from_obsolete.ru
@@ -1,0 +1,31 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# Remove gene associations with RO:0004003 'has material basis in germline mutation in' from obsolete classes
+
+DELETE {
+  ?obsoleteClass rdfs:subClassOf ?restriction .
+  ?axiom a owl:Axiom ;
+         owl:annotatedSource ?obsoleteClass ;
+         owl:annotatedProperty rdfs:subClassOf ;
+         owl:annotatedTarget ?restriction ;
+         oboInOwl:source ?source .
+}
+WHERE {
+  ?obsoleteClass owl:deprecated true ;
+                 rdfs:subClassOf ?restriction .
+
+  ?restriction a owl:Restriction ;
+               owl:onProperty obo:RO_0004003 ;
+               owl:someValuesFrom ?gene .
+
+  OPTIONAL {
+    ?axiom a owl:Axiom ;
+           owl:annotatedSource ?obsoleteClass ;
+           owl:annotatedProperty rdfs:subClassOf ;
+           owl:annotatedTarget ?restriction ;
+           oboInOwl:source ?source .
+  }
+}


### PR DESCRIPTION
closes https://github.com/monarch-initiative/mondo/issues/8464

This query and additional step in the OMIM gene pipeline is to remove any gene association that was added to a Mondo class that is now obsolete so that this case does not trigger errors with the Mondo QC checks.