### PR TITLE
Add relax reduce step to report-reason goal

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -864,7 +864,7 @@ report-base-query-%: mondo-base.owl
 	$(ROBOT) query --use-graphs true -i mondo-base.owl -f tsv --query $(SPARQLDIR)/reports/$*.sparql reports/report-base-$*.tsv
 
 report-reason-query-%:
-	$(ROBOT) reason -i $(SRC) query --use-graphs true  -f tsv --query $(SPARQLDIR)/reports/$*.sparql reports/report-reason-$*.tsv
+	$(ROBOT) reason -i $(SRC) relax reduce query --use-graphs true  -f tsv --query $(SPARQLDIR)/reports/$*.sparql reports/report-reason-$*.tsv
 
 report-reason-materialise-query-%:
 	$(ROBOT) reason -i $(SRC) materialize --term RO:0002573 \


### PR DESCRIPTION
This is to ensure that queries that look for direct parents do not get a mix of asserted and inferred parents (too many, too redundant).