### PR TITLE
Term relabeling for RAPID proposal

### DIFF
--- a/src/ontology/mondo-edit.properties
+++ b/src/ontology/mondo-edit.properties
@@ -1,5 +1,0 @@
-#Fri Apr 25 13:00:13 EDT 2025
-jdbc.password=
-jdbc.user=
-jdbc.url=
-jdbc.driver=

--- a/src/ontology/mondo-edit.properties
+++ b/src/ontology/mondo-edit.properties
@@ -1,0 +1,5 @@
+#Fri Apr 25 13:00:13 EDT 2025
+jdbc.password=
+jdbc.user=
+jdbc.url=
+jdbc.driver=


### PR DESCRIPTION
close #8975 
1. MONDO:0800029
- kept idiopathic pulmonary fibrosis as synonmym and added OMIM:178500 as xref

2. MONDO:0700285
- updated label to DMD-related muscular dystrophy
- can't find xref for original term (DMD-related musculodystrophy)

3. MONDO:0011382
- updated to sickle cell disease
- not sure if we should just keep the original definition
- deleted one duplicate synoynm (in upper case)

4. MONDO:0008814
- updated to arginase deficiency

5. MONDO:0008564
- updated to 22q11.2 deletion syndrome

6. MONDO:0017287
- immunoglobulin G4-related sclerosing disease