### PR TITLE
Fix NIFSTD xrefs

### DIFF
--- a/src/sparql/qc/mondo/qc-illegal-prefix-on-xref.sparql
+++ b/src/sparql/qc/mondo/qc-illegal-prefix-on-xref.sparql
@@ -21,6 +21,7 @@ WHERE
   	?cls owl:deprecated ?deprecated .
   }
   FILTER( STRBEFORE(str(?value),":") not in (
+      "birnlex",
       "CSP",
       "DECIPHER",
       "DOID",
@@ -50,6 +51,7 @@ WHERE
       "NCIT",
       "NDFRT",
       "NIFSTD",
+      "nlxdys",
       "NORD",
       "OBI",
       "OGMS",


### PR DESCRIPTION
Related to #9079.

This PR does the following:

1. Updates all CURIEs looking like `NIFSTD:birnlex_XXX` to `birnlex:XXX`
2. Updates all CURIEs looking `NIFSTD:nlx_dys_XXX` to `nlxdys:XXX`
3. This also adds `birnlex` and `nlxdys` to the xrefs sparql check

cc @matentzn 