### PR TITLE
Refactor adding the NORD_LABEL to synonyms

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -622,6 +622,17 @@ update-nord:
 	grep -vE '^(xref: NORD:|subset: nord_rare)' $(SRC) > $(TMPDIR)/mondo-edit.tmp || true
 	mv $(TMPDIR)/mondo-edit.tmp mondo-edit.obo
 	$(ROBOT) merge -i $(SRC) -i $(TMPDIR)/external/processed-nord.robot.owl --collapse-import-closure false convert -f obo --check false -o $(SRC).obo
+	# Report synonyms with existing synonymtypedef, e.g. ABBREVIATION, and NORD xref
+	@grep -E '^synonym: ".*" EXACT [A-Z_]+.*\[.*NORD:' $(SRC) > nord_synonymtypedef_conflicts.txt || true
+	@count=$$(wc -l < nord_synonymtypedef_conflicts.txt); \
+	if [ "$$count" -gt 0 ]; then \
+	  echo "\n** [WARNING] NORD_LABEL and other synonymtypedef conflict for $$count synonym(s):"; \
+	  cat nord_synonymtypedef_conflicts.txt; \
+	  echo ""; \
+	fi
+	# Add NORD_LABEL if no other synonymtypedef is present, only one synonymtypedef allowed per OBO spec
+	sed -i -E '/^synonym:.*EXACT( [A-Z_]+)? \[[^]]*NORD:/ {/EXACT [A-Z_]+/! s/^(synonym: "[^"]+" EXACT)( )/\1 NORD_LABEL\2/}' $(SRC).obo
+	# Note - NORM step merges synonyms so any existing synonymtypedef is lost for synonym where NORD_LABEL added
 	mv $(SRC).obo $(SRC) && make NORM && mv NORM $(SRC)
 
 ##### Inferred #####################

--- a/src/sparql/update/delete_nord_label_synonym_type.sparql
+++ b/src/sparql/update/delete_nord_label_synonym_type.sparql
@@ -1,0 +1,21 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# Delete NORD_LABEL annotation represented as synonymtypedef. OBO spec supports only one synonymtypedef per synonym.
+# This query is run after "insert_nord_label.sparql".
+
+DELETE {
+  ?axiom oboInOwl:hasSynonymType ?syn_type .
+}
+WHERE {
+  ?class a owl:Class ;
+         oboInOwl:hasExactSynonym ?syn_value .
+
+  ?axiom a owl:Axiom ;
+         owl:annotatedSource ?class ;
+         owl:annotatedProperty oboInOwl:hasExactSynonym ;
+         owl:annotatedTarget ?syn_value ;
+         oboInOwl:hasSynonymType ?syn_type .
+
+  FILTER(STR(?syn_type) = "http://purl.obolibrary.org/obo/mondo#NORD_LABEL")
+}

--- a/src/sparql/update/insert_nord_label.sparql
+++ b/src/sparql/update/insert_nord_label.sparql
@@ -17,7 +17,4 @@ WHERE {
          oboInOwl:hasSynonymType ?syn_type .
 
   FILTER(STR(?syn_type) = "http://purl.obolibrary.org/obo/mondo#NORD_LABEL")
-  FILTER NOT EXISTS {
-    ?axiom oboInOwl:source "MONDO:NORD_LABEL"
-  }
 }

--- a/src/sparql/update/insert_nord_label.sparql
+++ b/src/sparql/update/insert_nord_label.sparql
@@ -1,0 +1,23 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# Add MONDO:NORD_LABEL value as source annotation on synonym.
+
+INSERT {
+  ?axiom oboInOwl:source "MONDO:NORD_LABEL" .
+}
+WHERE {
+  ?class a owl:Class ;
+         oboInOwl:hasExactSynonym ?syn_value .
+
+  ?axiom a owl:Axiom ;
+         owl:annotatedSource ?class ;
+         owl:annotatedProperty oboInOwl:hasExactSynonym ;
+         owl:annotatedTarget ?syn_value ;
+         oboInOwl:hasSynonymType ?syn_type .
+
+  FILTER(STR(?syn_type) = "http://purl.obolibrary.org/obo/mondo#NORD_LABEL")
+  FILTER NOT EXISTS {
+    ?axiom oboInOwl:source "MONDO:NORD_LABEL"
+  }
+}


### PR DESCRIPTION
closes https://github.com/monarch-initiative/mondo/issues/8984

Refactor the `update-nord` make goal to add the `NORD_LABEL` with sed since the ROBOT merge does not work. Also, report cases where the synonym looses an existing synonymtypedef since only one is allowed per synonym in the OBO spec.

This was tested locally by running `sh run.sh make update-nord -B` in this branch. Once this PR merged, I will update the GH Action to include the report of conflicts with synonymtypedef into the PR comment created by the "Update Externally Provided Content" GH Action.

- [x] Submit issue for alternative modeling proposal for community labels https://github.com/monarch-initiative/mondo/issues/9122