### PR TITLE
add new general stats query to count xrefs for selected sources

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -300,7 +300,8 @@ GENERAL_STATISTICS_QUERIES = \
     $(SPARQLDIR)/reports/COUNT-non-human-genetic-diseases.sparql \
     $(SPARQLDIR)/reports/COUNT-non-human_diseases_infectious.sparql \
     $(SPARQLDIR)/reports/COUNT-non-human_diseases_cancer.sparql \
-	$(SPARQLDIR)/reports/COUNT-disease_selected_xrefs.sparql
+	$(SPARQLDIR)/reports/COUNT-disease_selected_xrefs.sparql \
+	$(SPARQLDIR)/reports/COUNT-selected_xrefs.sparql
 
 RARE_STATISTICS_QUERIES = \
     $(SPARQLDIR)/reports/COUNT-rare_subsets.sparql

--- a/src/sparql/reports/COUNT-disease_selected_xrefs.sparql
+++ b/src/sparql/reports/COUNT-disease_selected_xrefs.sparql
@@ -7,7 +7,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 # Count unique, non-obsolete Mondo classes that have an xref to the selected source
 # and also have the annotation MONDO:equivalentTo
 
-SELECT DISTINCT ?xref_source (COUNT(DISTINCT ?mondoClass) AS ?count)
+SELECT DISTINCT ?xref_source (COUNT(DISTINCT ?mondoClass) AS ?distinct_mondo_count)
 WHERE {
   # Find all MONDO classes
   ?mondoClass a owl:Class .

--- a/src/sparql/reports/COUNT-selected_xrefs.sparql
+++ b/src/sparql/reports/COUNT-selected_xrefs.sparql
@@ -1,0 +1,26 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX MONDO: <http://purl.obolibrary.org/obo/MONDO_>
+
+# Get the total count of xrefs for the list of selected sources.
+
+SELECT ?xref_source (COUNT(*) AS ?xref_count)
+WHERE {
+  ?class a owl:Class ;
+         oboInOwl:hasDbXref ?xref .
+
+  FILTER(REGEX(STR(?xref), "OMIM:|OMIMPS:|Orphanet:|DOID:|ICD10CM:|icd11.foundation:|OMIA:|SCTID:"))
+  FILTER NOT EXISTS { ?class owl:deprecated true }
+  FILTER(STRSTARTS(STR(?class), "http://purl.obolibrary.org/obo/MONDO_"))
+
+  ?annotation a owl:Axiom ;
+      owl:annotatedSource ?class ;
+      owl:annotatedProperty oboInOwl:hasDbXref ;
+      owl:annotatedTarget ?xref ;
+      oboInOwl:source "MONDO:equivalentTo" .
+
+  # Extract xref source for grouping
+  BIND(STRBEFORE(STR(?xref), ":") AS ?xref_source)
+}
+GROUP BY ?xref_source
+ORDER BY DESC(?xref_count)


### PR DESCRIPTION
A new general stats query is added to count the total number of xrefs (MONDO:equivalentTo) for selected sources. This query is in addition to the query to count the distinct number of Mondo classes that have at least one xref (MONDO:equivalentTo) to selected sources. 