### PR TITLE
Migrate to ODK 1.6

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -8,7 +8,7 @@ jobs:
     # Do not run on forks. https://github.com/monarch-initiative/mondo/issues/5255
     if: github.repository_owner == 'monarch-initiative'
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
     strategy:
       max-parallel: 1
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   diff:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
     strategy:
       max-parallel: 1
     steps:

--- a/.github/workflows/external_content.yaml
+++ b/.github/workflows/external_content.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     steps:
       - name: Checkout main branch

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/merge_template.yml
+++ b/.github/workflows/merge_template.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     steps:
       - name: Checkout main branch

--- a/.github/workflows/obsoletes.yaml
+++ b/.github/workflows/obsoletes.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     steps:
       - name: Checkout main branch

--- a/.github/workflows/omim-genes.yaml
+++ b/.github/workflows/omim-genes.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     steps:
       - name: Checkout main branch

--- a/.github/workflows/subclass.yaml
+++ b/.github/workflows/subclass.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     steps:
       - name: Checkout main branch

--- a/.github/workflows/synonyms.yaml
+++ b/.github/workflows/synonyms.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
 
     steps:
       - name: Checkout main branch

--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -11,7 +11,7 @@
 # See README-editors.md for more details.
 
 MEMORY_GB=${MEMORY_GB:-8}
-IMAGE=${IMAGE:-odkfull:v1.5.4}
+IMAGE=${IMAGE:-odkfull:v1.6}
 MEMORY_JAVA="-Xmx${MEMORY_GB}G"
 ODK_DEBUG=${ODK_DEBUG:-no}
 


### PR DESCRIPTION
This is needed to because mondo ingest needs it, and mondo ingest depends on mondo build pipeline.