### PR TITLE
Removed conflicting prefixes

### DIFF
--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -26,14 +26,14 @@ curie_map:
   # ICD10CM__2: https://icd.codes/icd10cm/
   # ICD10WHO: https://icd.who.int/browse10/2019/en#/
   # ICD10WHO__2: http://apps.who.int/classifications/icd10/browse/2010/en#/
-  icd11.foundation: http://purl.obolibrary.org/obo/mondo/sources/icd11foundation/
+  icd11.foundation: http://id.who.int/icd/entity/
   OMIMPS: https://omim.org/phenotypicSeries/PS
   MEDGEN: http://identifiers.org/medgen/
   MedDRA: http://identifiers.org/meddra/
   rdfs: http://www.w3.org/2000/01/rdf-schema#
   owl: http://www.w3.org/2002/07/owl#
   semapv: https://w3id.org/semapv/vocab/
-  infores: https://w3id.org/infores/
+  infores: https://w3id.org/information-resource-registry/
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   sssom: https://w3id.org/sssom/
   # oio: http://www.geneontology.org/formats/oboInOwl#
@@ -59,7 +59,6 @@ curie_map:
   IEDB: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/IEDB/"
   PMID: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/PMID/"
   KEGG: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/KEGG/"
-  ICD11: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICD11/"
   DECIPHER: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/DECIPHER/"
   CSP: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/CSP/"
   Wikipedia: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/Wikipedia/"


### PR DESCRIPTION
This PR removes one conflicting prefix which we do not use in Mondo (ICD11) and changes one expansion. 

It also updates the infores prefix URI which has been set up a few days ago.

I have run a complete release and can confirm all works as expected.