### PR TITLE
Fix usage of wrong uri prefix for icd11.foundation

### DIFF
--- a/src/utils/mk-skos.pl
+++ b/src/utils/mk-skos.pl
@@ -78,7 +78,7 @@ while (<>) {
             $uri = 'http://purl.bioontology.org/ontology/ICD10CM/';
         }
         elsif ($prefix eq 'icd11.foundation') {
-            $uri = 'http://purl.obolibrary.org/obo/mondo/sources/icd11foundation/';
+            $uri = 'http://id.who.int/icd/entity/';
         }
         elsif ($prefix eq 'EFO') {
             $uri = 'http://www.ebi.ac.uk/efo/EFO_';


### PR DESCRIPTION
Fixes #9269 

I have run

```
./run.sh make mappings/mondo.sssom.tsv
```

And both issues (the deleted and the added file) are solved.