### PR TITLE
Update ai-agent.yml - change to shallow repo clone

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.PAT_FOR_PR }}
 
       - name: Respond with AI Agent


### PR DESCRIPTION
When cloning the repo in the GH Action, change the `fetch-depth` to 1 for a shallow clone. Based on other GH Actions I've added for Mondo using a shallow clone, this can reduce the action run time by ~10 min.

Other example workflows using shallow clone:
- GitHub statistics - https://github.com/monarch-initiative/mondo/actions/runs/16011328941/job/45169571593#step:2:1
- Update web site statistics - https://github.com/monarch-initiative/mondo/actions/runs/16306108821/job/46052427033#step:3:1
versus the current DragonAI mentions action https://github.com/monarch-initiative/mondo/actions/runs/16325690323/job/46115133083#step:2:1