### PR TITLE
Update OMIM gene pipeline - add goal to keep susceptibility gene associations

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -702,6 +702,14 @@ update-rare-subset:
 ####################################
 ##### OMIM #####################
 ####################################
+$(TMPDIR)/keep-susceptibility-gene-assocation-axioms.owl: $(SRC)
+	$(ROBOT) filter --input $(SRC) \
+		--term MONDO:0042489 \
+		--select "self descendants" \
+		--term RO:0004003 \
+		--axioms SubClassOf \
+		--trim false \
+		-o $@
 
 $(TMPDIR)/mondo-genes-axioms.owl: $(SRC)
 	$(ROBOT) filter --input $(SRC) \
@@ -712,14 +720,18 @@ $(TMPDIR)/mondo-genes-axioms.owl: $(SRC)
 		--drop-axiom-annotations "oboInOwl:source=~'(OMIM):.*'" \
 		-o $@
 
-
 .PHONY: update-omim-genes
 update-omim-genes:
-	$(MAKE) $(TMPDIR)/external/processed-mondo-omim-genes.robot.owl $(TMPDIR)/mondo-genes-axioms.owl -B
+	$(MAKE) $(TMPDIR)/external/processed-mondo-omim-genes.robot.owl \
+	$(TMPDIR)/keep-susceptibility-gene-assocation-axioms.owl \
+	$(TMPDIR)/mondo-genes-axioms.owl -B
 	# We need to be less aggressive here, as some gene relations were not originally sourced
 	# from OMIM, and were added, for example, for ClinGen.
 	$(ROBOT) remove -i $(SRC) --term RO:0004003 --axioms SubClassOf --preserve-structure false --trim true \
-		merge -i $(TMPDIR)/external/processed-mondo-omim-genes.robot.owl -i $(TMPDIR)/mondo-genes-axioms.owl --collapse-import-closure false \
+		merge -i $(TMPDIR)/external/processed-mondo-omim-genes.robot.owl \
+		-i $(TMPDIR)/mondo-genes-axioms.owl \
+		-i $(TMPDIR)/keep-susceptibility-gene-assocation-axioms.owl \
+		--collapse-import-closure false \
 		query --update ../sparql/update/omim-gene-equivalence.ru \
 		query --update ../sparql/update/remove_gene_associations_from_obsolete.ru \
 		convert -f obo --check false -o $(SRC).obo


### PR DESCRIPTION
closes #9397 

I tested this as: `sh run.sh make update-omim-genes` with a "test" gene association I added on MONDO:0042489 'disease susceptibility' and the test gene association was maintained. I also used a test gene association with MONDO:0012601 'autism, susceptibility to, 10' (a subclass of MONDO:0042489 'disease susceptibility') and the test gene association was maintained. 

How does the ROBOT command account for terms that are inferred subclasses of MONDO:0042489 'disease susceptibility'? I tested one inferred term and the gene association was maintained, but would be good for you to check this as well.

There were a few other additions of gene associations, but that is related to the build status of mondo-ingest and omim repos at this part of the Mondo Ingest SOP.