### PR TITLE
Add back gene associations for susceptibility terms

### DIFF
--- a/src/sparql/construct/construct-susceptibility-term-gene-associations.sparql
+++ b/src/sparql/construct/construct-susceptibility-term-gene-associations.sparql
@@ -1,0 +1,33 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+CONSTRUCT {
+  ?disease rdfs:subClassOf ?r .
+
+  ?axiom a owl:Axiom ;
+         owl:annotatedSource ?disease ;
+         owl:annotatedProperty rdfs:subClassOf ;
+         owl:annotatedTarget ?r ;
+         oboInOwl:source ?source .
+         
+  ?r a owl:Restriction ;
+     owl:onProperty <http://purl.obolibrary.org/obo/RO_0004003> ;
+     owl:someValuesFrom ?gene .
+}
+WHERE {
+  ?disease rdfs:subClassOf* obo:MONDO_0042489 .
+  ?disease rdfs:subClassOf ?r .
+  ?r a owl:Restriction ;
+     owl:onProperty <http://purl.obolibrary.org/obo/RO_0004003> ;
+     owl:someValuesFrom ?gene .
+
+  OPTIONAL {
+    ?axiom a owl:Axiom ;
+           owl:annotatedSource ?disease ;
+           owl:annotatedProperty rdfs:subClassOf ;
+           owl:annotatedTarget ?r ;
+           oboInOwl:source ?source .
+  }
+}


### PR DESCRIPTION
These are the steps I ran to create the updates in `mondo-edit.obo`. I only used content from Mondo v2024-12-03.

- Step 1: `sh run.sh make extract-susceptibility-patches`

- Step 2: Open mondo-edit.obo and susceptibility-v2024-12-03.ttl in Protege and use "Refactor --> Merge ontologies" to merge susceptibility-v2024-12-03.ttl into mondo-edit.obo and then save merged file. 

- Step 3: Run NORM as:
```
sh run.sh make NORM
mv NORM mondo-edit.obo
```