### PR TITLE
Create qc-subclass-relation-no-source.sparql

### DIFF
--- a/src/sparql/qc/general/qc-subclass-relation-no-source.sparql
+++ b/src/sparql/qc/general/qc-subclass-relation-no-source.sparql
@@ -1,0 +1,30 @@
+PREFIX owl:        <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs:       <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl:   <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX eco:        <http://purl.obolibrary.org/obo/eco#>
+PREFIX RO:         <http://purl.obolibrary.org/obo/RO_>
+
+SELECT ?entity ?property ?value
+WHERE {
+
+  VALUES ?property { 
+    RO:0004003 
+  }
+  ?entity rdfs:subClassOf ?restr .
+
+  ?restr a owl:Restriction ;
+         owl:onProperty   ?property ;
+         owl:someValuesFrom ?value .
+
+  FILTER isIRI(?entity)
+  FILTER STRSTARTS(STR(?entity), "http://purl.obolibrary.org/obo/MONDO_")
+
+  FILTER NOT EXISTS {
+    ?ax a owl:Axiom ;
+        owl:annotatedSource   ?entity ;
+        owl:annotatedProperty rdfs:subClassOf ;
+        owl:annotatedTarget   ?restr ;
+        # any recognised evidence predicate
+        (oboInOwl:hasDbXref | oboInOwl:source | eco:hasEvidence) ?evidence .
+  }
+}


### PR DESCRIPTION
This QC check ensures that subclass axioms with relationships (eg gene relations) must have evidence associated with it.

@sabrinatoro there are 47 gene associations without evidence. There are three options for you to have the QC pass:

1. Manually remove them
2. Let me remove tham all in bulk now
3. Have a cleanup process that automatically removes them when they arise, for example after an OMIM update

#9418 might result in another number of relations that need to be cleaned up, but that will be a close second.
