### PR TITLE
create new term for NOTCH1-related AOS spectrum disorder

### DIFF
--- a/docs/editors-guide/merging-and-obsoleting.md
+++ b/docs/editors-guide/merging-and-obsoleting.md
@@ -143,7 +143,7 @@ There are 2 ways to merge classes:
 1. Rename label to: obsolete [class name]
 1. Add annotation **owl:deprecated** and indicate true (in literal)
 1. Add annotation **term replaced by** and add ID of term which replaced it (in CURIE format, such as MONDO:0010684). If the disease term is being obsoleted and an HPO term should be used instead, do not use **term replaced by**, rather use the annotation **consider.** For example, see MONDO:0001445.
-1. Add an obsoletion reason: use the annotation property 'has obsolescence reason' and add `OMO:0001000` in the IRI editor (`OMO:0001000` = out of scope). Add a source annotation to the obsolescence reason that comes from this [list of exclusion reasons](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It should look something like: `property_value: IAO:0000231 OMO:0001000 {source="MONDO:excludeObsoleteSource"}`.
+1. Add an obsoletion reason: use the annotation property 'has obsolescence reason' and add (http://purl.obolibrary.org/obo/OMO_0001000) in the IRI editor (`OMO:0001000` = out of scope). Add a source annotation to the obsolescence reason that comes from this [list of exclusion reasons](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It should look something like: `property_value: IAO:0000231 OMO:0001000 {source="MONDO:excludeObsoleteSource"}`.
 1. _Optional:_ Add an additional comment (rdfs:comment) explaining why the terms were merged.
 1. Add annotation 'term tracker item' (type xsd:anyURI) with a link to the GitHub issue that requested the obsoletion.
 1. Remove superclass axioms
@@ -162,7 +162,7 @@ Note: An obsolete Mondo class should not have an xref axiom tagged with "MONDO:e
 1. Search for the class to be obsoleted.
 1. In the Protege edit menu-> Make entity obsolete
 1. Prepend the definition with OBSOLETE. For example, OBSOLETE. Chronic form of myeloproliferative neoplasm. 
-1. Add an obsoletion reason: use the annotation property 'has obsolescence reason' and add `OMO:0001000` in the IRI editor (`OMO:0001000` = out of scope). Add a source annotation to the obsolescence reason that comes from this [list of exclusion reasons](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It should look something like: `property_value: IAO:0000231 OMO:0001000 {source="MONDO:excludeObsoleteSource"}`.
+1. Add an obsoletion reason: use the annotation property 'has obsolescence reason' and add (http://purl.obolibrary.org/obo/OMO_0001000) in the IRI editor (`OMO:0001000` = out of scope). Add a source annotation to the obsolescence reason that comes from this [list of exclusion reasons](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It should look something like: `property_value: IAO:0000231 OMO:0001000 {source="MONDO:excludeObsoleteSource"}`.
 1. Add annotation 'term tracker item' (type xsd:anyURI) with a link to the GitHub issue that requested the obsoletion.
 1. If the term has **database_cross_reference annotations** and the **source** is annotated as MONDO:equivalentTo, change the source to **source** MONDO:obsoleteEquivalent (in the literal tab). Obsolete terms should never be equivalent.
 1. Add annotation consider, add the CURIE for the term that should be considered as a replacement.
@@ -174,7 +174,7 @@ Note: An obsolete Mondo class should not have an xref axiom tagged with "MONDO:e
 1. Rename label to: obsolete [class name].
 1. Add annotation **owl:deprecated** and indicate true (in literal).
 1. Prepend the definition with OBSOLETE. For example, OBSOLETE. Chronic form of myeloproliferative neoplasm. 
-1. Add an obsoletion reason: use the annotation property 'has obsolescence reason' and add `OMO:0001000` in the IRI editor (`OMO:0001000` = out of scope). Add a source annotation to the obsolescence reason that comes from this [list of exclusion reasons](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It should look something like: `property_value: IAO:0000231 OMO:0001000 {source="MONDO:excludeObsoleteSource"}`.
+1. Add an obsoletion reason: use the annotation property 'has obsolescence reason' and add (http://purl.obolibrary.org/obo/OMO_0001000) in the IRI editor (`OMO:0001000` = out of scope). Add a source annotation to the obsolescence reason that comes from this [list of exclusion reasons](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It should look something like: `property_value: IAO:0000231 OMO:0001000 {source="MONDO:excludeObsoleteSource"}`.
 1. Add annotation 'term tracker item' (type xsd:anyURI) with a link to the GitHub issue that requested the obsoletion.
 1. Remove superclass axioms.
 1. If the class has children, remove the superclass assertions for the children.

--- a/src/ontology/debug_inference_check.owl
+++ b/src/ontology/debug_inference_check.owl
@@ -75,10 +75,31 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81</obo:IAO_0000116>
+        <rdfs:label xml:lang="en">entity</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240</obo:IAO_0000116>
+        <rdfs:label xml:lang="en">continuant</rdfs:label>
+    </Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/BFO_0000031 -->
 
     <Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <rdfs:label xml:lang="en">generically dependent continuant</rdfs:label>
     </Class>
     
 


### PR DESCRIPTION
address #9236
I reopened issue-9236 because the requester asked for a new term, not relabeling. 
I created a new term for 'NOTCH1-related AOS spectrum disorder' under 'syndromic disease'. 
- added the provided definition
- added Adams-Oliver syndrome 5  (MONDO:0014459) and aortic valve disease 1 (MONDO:0024523) as child terms

I reverted all changes I made in the other PR 
- reverted definition for Adams-Oliver syndrome 5  (MONDO:0014459) 
- removed NOTCH1-related AOS spectrum disorder as exact synonym
**Note**: I don't remember which synonym has the ClinGen label. What can I do about it?
