### PR TITLE
Update main.yaml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Run ontology QC checks
         env:


### PR DESCRIPTION
Update the GH Action to use a shallow clone of mondo to reduce time to run the Mondo QC checks since they are now taking ~35 min. Based on past experience with other GH Actions using a shallow clone of Mondo should save ~10min due to the long history of Mondo that is pulled without this setting.