### PR TITLE
Add prefixes.jsonld and update Makefile for OFN conversion

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -248,10 +248,14 @@ reasoned-plus-equivalents.owl: reasoned.owl imports/equivalencies.owl
 #
 # by default we use Elk to perform a reason-relax-reduce chain
 # after that we annotate the ontology with the release versionInfo
-$(ONT).owl: reasoned.owl
-	$(ROBOT) merge -i $< annotate -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
+$(ONT).owl tmp/mondo.owl.ofn: reasoned.owl
+	$(ROBOT) merge -i $< \
+		annotate -V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@ \
+		convert \
+			--add-prefixes config/prefixes.jsonld \
+			-f ofn -o tmp/mondo.owl.ofn
 
-$(ONT).obo: $(ONT).owl
+$(ONT).obo: tmp/mondo.owl.ofn
 	$(ROBOT) annotate -i $< \
 			-V $(ONTURI)/releases/`date +%Y-%m-%d`/$(ONT).owl \
 			--ontology-iri $(OBO)/$(ONT).owl \

--- a/src/ontology/config/prefixes.jsonld
+++ b/src/ontology/config/prefixes.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "BAO": "http://www.bioassayontology.org/bao#BAO_",
+    "CoVIC": "https://cvdb.ontodev.com/antibody/",
+    "EFO": "http://www.ebi.ac.uk/efo/EFO_",
+    "ENM": "http://purl.enanomapper.org/onto/ENM_",
+    "ICD10CM": "http://purl.bioontology.org/ontology/ICD10CM/",
+    "ICD10WHO": "https://icd.who.int/browse10/2019/en#/",
+    "ICD11": "http://id.who.int/icd/entity/",
+    "IEDB": "http://iedb.org/",
+    "MEDDRA": "http://identifiers.org/meddra/",
+    "MEDGEN": "http://identifiers.org/medgen/",
+    "MESH": "http://identifiers.org/mesh/",
+    "NPO": "http://purl.bioontology.org/ontology/npo#NPO_",
+    "OMIM": "https://omim.org/entry/",
+    "OMIMPS": "https://omim.org/phenotypicSeries/PS",
+    "ONTIE": "https://ontology.iedb.org/ontology/ONTIE_",
+    "Orphanet": "http://www.orpha.net/ORDO/Orphanet_",
+    "PRO": "http://www.uniprot.org/annotation/PRO_",
+    "SCTID": "http://identifiers.org/snomedct/",
+    "UC": "http://purl.uniprot.org/core/",
+    "UMLS": "http://linkedlifedata.com/resource/umls/id/",
+    "UP": "http://purl.uniprot.org/uniprot/",
+    "faldo": "http://biohackathon.org/resource/faldo#",
+    "gocam": "http://model.geneontology.org/",
+    "icd10cm": "http://purl.bioontology.org/ontology/ICD10CM/",
+    "icd11.foundation": "http://id.who.int/icd/entity/",
+    "iedb-protein": "http://iedb.org/taxon-protein/"
+  }
+}


### PR DESCRIPTION
Introduces config/prefixes.jsonld for ontology prefix mappings and updates the Makefile to generate tmp/mondo.owl.ofn using ROBOT with the new prefixes. The OBO file is now built from the OFN file to ensure consistent prefix usage.

Fixes #9681
