### PR TITLE
Add MONDO curation guideline for parent terms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,12 @@ This includes instructions for editing the npso ontology.
 
 ## Specific Guidelines for MONDO Curation
 - When processing a request to add a more specific parent (is_a, subclass) to a term, do not remove existing parents unless _explicitly instructed_ to do so.
+- When removing a subclass (is_a) axiom, add a corresponding "excludedSubClassOf" annotation which includes the source of the removed axiom, and the ORCID of the curator, if available. Example:
 
+```
+relationship: excluded_subClassOf MONDO:0002129 {source="https://orcid.org/0000-0001-5208-3432"} ! bone cancer
+```
+- Before finalising an edit for a session, we need to run `sh run.sh make NORM && mv NORM mondo-edit.obo` to normalise the serialisation.
 
 ## OBO Format Guidelines
 - Term ID format: MONDO:NNNNNNN (7-digit number)

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1792,6 +1792,18 @@ update-synonyms-sync: $(TMPDIR)/synonyms-confirmed.robot.owl tmp/synonyms-axioms
 	make NORM
 	mv NORM $(SRC)
 
+#############################################
+# Update scripts #
+#############################################
+
+.PHONY: update-scripts
+update-scripts: obo-checkout.pl obo-checkin.pl
+
+obo-checkout.pl:
+	wget "https://raw.githubusercontent.com/cmungall/obo-scripts/refs/heads/master/obo-checkout.pl" -O $@
+
+obo-checkin.pl:
+	wget "https://raw.githubusercontent.com/cmungall/obo-scripts/refs/heads/master/obo-checkin.pl" -O $@
 
 .PHONY: help
 help:


### PR DESCRIPTION
Added a guideline specifying that existing parent terms should not be removed when adding a more specific parent to a MONDO term, unless explicitly instructed. 