### PR TITLE
Add support for custom ROBOT plugins in Makefiles

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -70,6 +70,46 @@ all: test all_artefacts mappings
 	echo "release finished"
 
 # ----------------------------------------
+# ODK-managed ROBOT plugins
+# ----------------------------------------
+
+# Make sure ROBOT knows where to find plugins
+export ROBOT_PLUGINS_DIRECTORY=$(TMPDIR)/plugins
+
+# Override this rule in hp.Makefile to install custom plugins
+.PHONY: custom_robot_plugins
+custom_robot_plugins:
+
+
+.PHONY: extra_robot_plugins
+extra_robot_plugins:  $(ROBOT_PLUGINS_DIRECTORY)/odk.jar  $(ROBOT_PLUGINS_DIRECTORY)/sssom.jar 
+
+
+# Install all ROBOT plugins to the runtime plugins directory
+.PHONY: all_robot_plugins
+all_robot_plugins: $(foreach plugin,$(notdir $(wildcard /tools/robot-plugins/*.jar)),$(ROBOT_PLUGINS_DIRECTORY)/$(plugin)) \
+		   $(foreach plugin,$(notdir $(wildcard ../../plugins/*.jar)),$(ROBOT_PLUGINS_DIRECTORY)/$(plugin)) \
+		   custom_robot_plugins extra_robot_plugins  \
+
+# Default rule to install plugins
+$(ROBOT_PLUGINS_DIRECTORY)/%.jar:
+	@mkdir -p $(ROBOT_PLUGINS_DIRECTORY)
+	@if [ -f ../../plugins/$*.jar ]; then        \
+		ln ../../plugins/$*.jar $@ ;         \
+	elif [ -f /tools/robot-plugins/$*.jar ]; then \
+		cp /tools/robot-plugins/$*.jar $@ ;  \
+	fi
+
+# Specific rules for supplementary plugins defined in configuration
+
+$(ROBOT_PLUGINS_DIRECTORY)/odk.jar:
+	#cp /Users/matentzn/ws/odk-robot-plugin/target/odk.jar $@
+	echo uncommentme
+
+$(ROBOT_PLUGINS_DIRECTORY)/sssom.jar:
+	curl -L -o $@ https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.9.1/sssom-robot-plugin-1.9.1.jar
+
+# ----------------------------------------
 # Artefacts
 # ----------------------------------------
 

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1039,6 +1039,18 @@ construct-unmerge-query-%: construct-query-%
 	make NORM
 	mv NORM $(SRC)
 
+
+SIMPLE_MERGE=tmp/e123.ttl
+
+simple-merge: $(SIMPLE_MERGE)
+	$(ROBOT) -vvv merge -i $(SRC) -i $< --collapse-import-closure false convert -f obo --check false -o $(SRC).obo
+	mv $(SRC).obo $(SRC)
+	make NORM
+	mv NORM $(SRC)
+
+obsolete-replace-test: #cp-odk-plug
+	$(ROBOT) odk:obsolete-replace --input $(SRC) --obsolete MONDO:0032564 --replacement MONDO:0032565 -o $(SRC)
+
 TMP_TEMPLATE_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vQ8cszVqBNOeClD6uFif3QRHn0Ud_Cyt_gylyTTFJ-RoJaOwNWS7Qv3c516bJoTBaKT1WLagSQ7CQqS/pub?gid=0&single=true&output=tsv"
 TMP_TEMPLATE_FILE=tmp/temporary.tsv
 TMP_TEMPLATE_OWL=tmp/temporary.owl


### PR DESCRIPTION
Introduced new Makefile rules to manage ROBOT plugins, including installation of custom and supplementary plugins. Added targets for simple merge operations and an obsolete replacement test using the odk plugin in mondo.Makefile. These changes improve plugin management and extend ontology processing capabilities.