### PR TITLE
Add missing NANDO and NORD prefixes to SSSOM config

### DIFF
--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -76,6 +76,8 @@ curie_map:
   GC_ID: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/GC_ID/"
   # SNOMEDCT_2010_1_31: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/SNOMEDCT_2010_1_31/"
   OMIA: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/OMIA/"
+  NANDO: "https://identifiers.org/NANDO:"
+  NORD: "https://bioregistry.io/nord:"
 
 
 subject_prefixes:


### PR DESCRIPTION
NANDO and NORD prefixes were not present in the SSSOM configuration-- this commit adds them. NANDO from `identifiers.org` and NORD from `bioregistry`.

Along with c29d3ae, this eliminates all of the errors from the `sssom parse` step in the `tmp/mondo.sssom.tsv` recipe that looked like this, which were a result of absent CURIE prefixes:

    One mapping in the mapping set is not well-formed, and therfore not included in the mapping set ({'mapping_justification': 'semapv:UnspecifiedMatching', 'subject_id': 'MONDO:0000050', 'predicate_id': 'oboInOwl:hasDbXref', 'subject_label': 'isolated congenital growth hormone deficiency'}). Error: Missing object_id

This change results in two new files when rebuilding mappings:

* mappings/mondo_hasdbxref_nando.sssom.tsv
* mappings/mondo_hasdbxref_nord.sssom.tsv

I'm purposefully not committing them here-- we'll wait until further larger changes in the mappings process.