### PR TITLE
Replace chebi slim URL in Makefile

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -638,7 +638,7 @@ mirror-ncbitaxon: | $(TMPDIR)
 .PHONY: mirror-chebi
 .PRECIOUS: $(MIRRORDIR)/chebi.owl
 mirror-chebi: | $(TMPDIR)
-	if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/http://purl.obolibrary.org/obo/upheno/chebi_slim.owl -o $@.tmp.owl && \
+	if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I http://purl.obolibrary.org/obo/upheno/chebi_slim.owl -o $@.tmp.owl && \
 		$(ROBOT) remove -i $@.tmp.owl --base-iri $(URIBASE)/CHEBI --axioms external --preserve-structure false --trim false -o $@.tmp.owl &&\
 		mv $@.tmp.owl $(TMPDIR)/$@.owl; fi
 


### PR DESCRIPTION
Replace https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl with http://purl.obolibrary.org/obo/upheno/chebi_slim.owl in Makefile.
cc @matentzn 