### PR TITLE
Overhaul mapping pipeline to use sssom-java

### DIFF
--- a/src/scripts/extract_all_labels.py
+++ b/src/scripts/extract_all_labels.py
@@ -1,0 +1,30 @@
+from xml.etree.ElementTree import iterparse
+from rdflib import URIRef, Literal
+from rdflib.namespace import RDF, RDFS, OWL
+
+RDF_ABOUT  = "{" + str(RDF) + "}about"
+RDFS_LABEL = "{" + str(RDFS) + "}label"
+
+about_stack: list[str | None] = []
+seen: set[str] = set()
+
+for event, el in iterparse("tmp/mondo-ingest.owl", events=("start", "end")):
+    if event == "start":
+        about_stack.append(el.attrib.get(RDF_ABOUT))
+        continue
+
+    if el.tag == RDFS_LABEL:
+        # direct parent subject
+        subj = about_stack[-2] if len(about_stack) >= 2 else None
+        if subj and subj not in seen:
+            txt = (el.text or "").strip()
+            if txt:
+                seen.add(subj)
+
+                s = URIRef(subj).n3()
+                print(f"{s} {RDF.type.n3()} {OWL.Class.n3()} .")
+                print(f"{s} {RDFS.label.n3()} {Literal(txt).n3()} .")
+
+    about_stack.pop()
+    el.clear()
+


### PR DESCRIPTION
This mostly removes our use of sssom-py in the mapping pipeline in favor of using the CLI of sssom-java. Before merging, I need to change a couple things, mostly related to embedding metadata in output SSSOM files.

On my machine, the end effect is:

Before:
Elapsed time: 30:34.81
Peak memory: 6160944 kb

After:
Elapsed time:
7:13.24
Peak memory: 3572144 kb

The big time save comes from 1) not building `mondo-ingest.db` using semsql and 2) not splitting the SSSOM dataframe in sssom-py. There are also numerous other timesaves which stem from sssom-java being faster to parse files than sssom-py. There is also the benefit of just using a CLI rather than maintaining external scripts.

There is one new script added: `extract_all_labels.py`. This *may* not be necessary, but I included it to make one-to-one parity with the output of the previous pipeline. What this script does is make an n-triples file containing every URI in an OWL XML ontology that has an `rdfs:label`. A triple is emitted with the *first* `rdfs:label` that is encountered. The resulting n-triples file is passed to the `--update-from-ontology` flag in sssom-java.

Why is this even necessary, and why can't the base `mondo-ingest.owl` file be passed to that flag? Again, it is for absolute parity with the sssom-py pipeline. There were some object labels being populated there that were *not* OWL classes, but rather rdf:Description classes. (I think these were NCIT, but I don't quite recall). I would gladly delete this script and take out this logic if including those is not important. Or maybe something in the mondo-ingest pipeline needs to be fixed.