### PR TITLE
Refactor sssom-py mapping workflow

### DIFF
--- a/src/scripts/add_object_label.py
+++ b/src/scripts/add_object_label.py
@@ -1,12 +1,12 @@
+import csv
 from typing import TextIO
-from sssom.parsers import parse_sssom_table
-from oaklib import OntologyResource
-from oaklib.implementations import SqlImplementation
+
 import click
+from sssom.parsers import parse_sssom_table
 from sssom.writers import write_table
 
 SSSOM_FILE = "../ontology/tmp/mondo.sssom.tsv"
-RESOURCE = "../ontology/tmp/mondo-ingest.db"
+OBJECT_LABELS_FILE = "../ontology/tmp/mondo-labels.tsv"
 OBJECT_LABEL_COLUMN = "object_label"
 OBJECT_ID_COLUMN = "object_id"
 
@@ -30,10 +30,11 @@ def main():
 @input_argument
 @output_option
 def run(input: str = SSSOM_FILE, output: TextIO = SSSOM_FILE):
-    """Get object_label from resource via oaklib."""
+    """Populate object_label from mondo-ingest."""
     msdf = parse_sssom_table(input)
-    ontology_resource = OntologyResource(slug=RESOURCE, local=True)
-    oi = SqlImplementation(ontology_resource)
+    with open(OBJECT_LABELS_FILE) as fd:
+        reader = csv.DictReader(fd, delimiter="\t")
+        labels_by_id = {row["id"]: row["label"] for row in reader}
 
     # Condition to check if OBJECT_LABEL_COLUMN is empty
     is_empty = msdf.df[OBJECT_LABEL_COLUMN].isnull() | (
@@ -43,13 +44,9 @@ def run(input: str = SSSOM_FILE, output: TextIO = SSSOM_FILE):
     # Apply the function only where OBJECT_LABEL_COLUMN is empty
     msdf.df.loc[is_empty, OBJECT_LABEL_COLUMN] = msdf.df.loc[
         is_empty, OBJECT_ID_COLUMN
-    ].apply(lambda x: oi.label(x))
+    ].apply(lambda x: labels_by_id.get(x, ""))
 
     write_table(msdf=msdf, file=output)
-
-    # if OBJECT_LABEL_COLUMN not in msdf.df.columns:
-    #     msdf.df[OBJECT_LABEL_COLUMN] = msdf.df[OBJECT_ID_COLUMN].apply(lambda x: oi.label(x))
-    #     write_table(msdf=msdf,file=output)
 
 
 if __name__ == "__main__":

--- a/src/scripts/split_sssom_by_source.py
+++ b/src/scripts/split_sssom_by_source.py
@@ -84,7 +84,6 @@ def read_metadata(filename):
 meta, curie_map = read_metadata(metadata_file)
 msdf_main = parse_sssom_table(sssom_file)
 msdf_main.df["mapping_justification"] = SEMAPV.ManualMappingCuration.value
-subject_prefixes_allowed = meta["subject_prefixes"]
 relations_allowed = meta["relations"]
 
 
@@ -103,7 +102,7 @@ new_msdf = from_sssom_dataframe(
 today = datetime.today().strftime("%Y-%m-%d")
 
 splitted = split_dataframe_by_prefix(
-    new_msdf, subject_prefixes_allowed, object_prefixes, relations_allowed
+    new_msdf, ["MONDO"], object_prefixes, relations_allowed
 )
 for msdf in splitted:
     fromS = msdf.split("_")[0].upper()


### PR DESCRIPTION
This splits up the `mappings/mondo.sssom/tsv` target into multiple intermediate targets, and makes some of the steps significantly more efficient.

Those intermediate targets are:

1. `tmp/mondo-extracted.sssom.tsv`: The extracted SSSOM table from `mirror-mondo.json`.
2. `tmp/mondo-with-object-labels.sssom.tsv`: The table in (1), with `object_label` values filled in.
3. `mappings/mondo.sssom.tsv`: The table in (2), with only values for `skos:exactMatch` and `skos:broadMatch` included.
4. `tmp/split_finished`: A sentinel target marking that the `split_sssom_by_source.py` script has been run on (2).

The increased effiencies are:

* In (2), object labels are filled in with the newly published `mondo-labels.tsv` artifact from `mondo-ingest`, obviating the need for the `mondo-ingest.db` artifact, the target for which has been removed.
* In (4), only splits with the subject prefix `MONDO` are searched, which reduces the number of splits by an order or two of magnitude.

The end result is that the whole mapping pipeline needed by `mondo-ingest`, which is just steps 1-3 above, now takes about 4 minutes on my machine (down from 30).

---

I ended up taking this route instead of the `sssom-java` one mentioned in #9888 because there were too many small incompatibilities between the two tools. Not huge ones, but ones that would take some more doing to get acting the same. It still may be a good idea in the longer term, but this will help immensely in the meantime.

Supercedes #9888.