### PR TITLE
Update `split_finished` target on successful split

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -1192,6 +1192,7 @@ $(TMPDIR)/mondo-with-object-labels.sssom.tsv: $(TMPDIR)/mondo-extracted.sssom.ts
 
 $(TMPDIR)/split_finished: $(TMPDIR)/mondo-with-object-labels.sssom.tsv
 	python ../scripts/split_sssom_by_source.py -s $< -m $(METADATADIR)/mondo.sssom.config.yml -o $(MAPPINGSDIR)/
+	touch $@
 
 .PHONY: split_mondo_mappings
 split_mondo_mappings: $(TMPDIR)/split_finished


### PR DESCRIPTION
In ed318edd54702a25c60a740f05aeb314572b9902, I created a sentinel target for marking when the `split_sssom_by_source` script finished. But I forgot to touch it. Oops!