### PR TITLE
fix "contact us" link

### DIFF
--- a/_pages/rare-disease.md
+++ b/_pages/rare-disease.md
@@ -170,7 +170,7 @@ Rare disease annotations will be transferred to the surviving term as soon as th
 If you know of a rare disease not represented in Mondo or missing from the rare disease subset, please [open a GitHub issue](https://github.com/monarch-initiative/mondo/issues/new?template=rare_disease_request.md).
 
 ### Connect with Rare Disease Communities
-Mondo works closely with rare disease organizations worldwide. [Contact us](info@monarchinitiative.org) to discuss collaboration opportunities.
+Mondo works closely with rare disease organizations worldwide. [Contact us](mailto:info@monarchinitiative.org) to discuss collaboration opportunities.
 
 ### Rare Disease Day
 Join us in recognizing [Rare Disease Day](https://www.rarediseaseday.org/) on the last day of February each year, raising awareness for the 300 million people living with rare diseases worldwide.


### PR DESCRIPTION
Fix bad link mentioned by @mellybelly in Slack.

This was hard to find by searching GH because this file lives in a specific branch of the mondo repo (gh-pages) - there is no main branch on this repo, for some reason. Claude helped me find it!