### PR TITLE
Update mondo-edit.obo normalization workflow.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,8 +28,24 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Normalize mondo-edit.obo
+        run: |
+          cd src/ontology
+          make NORM && mv NORM mondo-edit.obo
+
+      - name: Fail if mondo-edit.obo is not normalized
+        run: |
+          cd src/ontology
+          if ! git diff --quiet -- mondo-edit.obo; then
+            echo "::error file=src/ontology/mondo-edit.obo::mondo-edit.obo is not normalized. Comment /normalize-mondo-edit to run normalization, or run make NORM && mv NORM mondo-edit.obo yourself and commit the changes."
+            git --no-pager diff -- mondo-edit.obo
+            exit 1
+          fi
+
       - name: Run ontology QC checks
         env:
           DEFAULT_BRANCH: master
-        run: cd src/ontology; make GITHUB_ACTION=true IMP=false PAT=false test -B
+        run: |
+          cd src/ontology
+          make GITHUB_ACTION=true IMP=false PAT=false test -B
 

--- a/.github/workflows/normalize-mondo-edit.yaml
+++ b/.github/workflows/normalize-mondo-edit.yaml
@@ -1,56 +1,162 @@
 name: Normalize mondo-edit.obo
 
 on:
-  # Trigger on pushes that modify mondo-edit.obo
-  #push:
-  #  paths:
-  #    - 'src/ontology/mondo-edit.obo'
-  #  branches:
-  #    - '**'  # Run on all branches
+  # Triggers on comments that start with /normalize-mondo-edit
+  issue_comment:
+    types: [created]
 
-  # Allow manual triggering
-  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: read
+  issues: write
+  actions: write
 
 jobs:
+  prepare:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/normalize-mondo-edit')
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.perms.outputs.allowed }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      same_repo: ${{ steps.pr.outputs.same_repo }}
+    steps:
+      # Check if commenter has applicable permissions, to prevent untrusted
+      # repeated runs of the workflow.
+      - name: Check commenter permission
+        id: perms
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          perm="$(gh api repos/$REPO/collaborators/$ACTOR/permission --jq .permission)"
+          case "$perm" in
+            push|write|maintain|admin) echo "allowed=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "allowed=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Comment if requester is not allowed
+        if: steps.perms.outputs.allowed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "Normalization can only be requested by a collaborator with write access."
+
+      # Store the name of the PR branch, and whether the PR is from a fork
+      - name: Read PR metadata
+        id: pr
+        if: steps.perms.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName)" >> "$GITHUB_OUTPUT"
+          echo "same_repo=$(gh pr view "$PR" --repo "$REPO" --json isCrossRepository --jq 'if .isCrossRepository then "false" else "true" end')" >> "$GITHUB_OUTPUT"
+
+      # Fork PRs are not supported because we cannot safely push commits back to them
+      # using the repository GITHUB_TOKEN.
+      - name: Comment if PR is from a fork
+        if: steps.perms.outputs.allowed == 'true' && steps.pr.outputs.same_repo != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "This helper currently only supports same-repo PR branches. For fork PRs, please run normalization locally."
+
   normalize:
+    needs: prepare
+    if: needs.prepare.outputs.allowed == 'true' && needs.prepare.outputs.same_repo == 'true'
     runs-on: ubuntu-latest
     container: obolibrary/odkfull:v1.6
-
+    outputs:
+      changed: ${{ steps.push.outputs.changed }}
     steps:
-      - name: Checkout repository
+      - name: Check out trusted default branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted
+          fetch-depth: 1
+
+      # Use a sparse checkout to only pull in mondo-edit.obo from the PR branch
+      - name: Check out mondo-edit.obo from PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.head_ref }}
+          path: pr
+          fetch-depth: 1
+          token: ${{ github.token }}
+          sparse-checkout: |
+            src/ontology/mondo-edit.obo
+          sparse-checkout-cone-mode: false
 
       - name: Configure git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/trusted"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/pr"
 
-      - name: Run normalization
+      # Run normalization using code from the default branch (trusted), not
+      # the PR branch, to avoid executing potentially modified arbitrary code
+      # in Makefiles or scripts
+      - name: Normalize PR file using trusted code
         run: |
-          cd src/ontology && make NORM && mv NORM mondo-edit.obo
+          cp pr/src/ontology/mondo-edit.obo trusted/src/ontology/mondo-edit.obo
+          cd trusted/src/ontology
+          make NORM && mv NORM mondo-edit.obo
+          cp mondo-edit.obo "$GITHUB_WORKSPACE/pr/src/ontology/mondo-edit.obo"
 
-      - name: Check for changes
-        id: check_changes
+      - name: Commit and push if changed
+        id: push
         run: |
-          cd src/ontology
-          if git diff --quiet mondo-edit.obo; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No changes detected after normalization"
+          cd "$GITHUB_WORKSPACE/pr"
+          if git diff --quiet -- src/ontology/mondo-edit.obo; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "Changes detected after normalization"
+            git add src/ontology/mondo-edit.obo
+            git commit -m "Normalize mondo-edit.obo"
+            git push origin "HEAD:${{ needs.prepare.outputs.head_ref }}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push changes
-        if: steps.check_changes.outputs.changed == 'true'
-        run: |
-          git add src/ontology/mondo-edit.obo
-          git commit -m "Normalize mondo-edit.obo
+  finish:
+    needs: [prepare, normalize]
+    if: needs.prepare.outputs.allowed == 'true' && needs.prepare.outputs.same_repo == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CI if normalization changed the file
+        if: needs.normalize.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ needs.prepare.outputs.head_ref }}
 
-          Automated normalization via GitHub Actions"
-          git pull --rebase
-          git push
+        # NOTE: This runs the main.yaml workflow on the *default branch*. If it
+        # has changed in the PR, those changes will not be reflected.
+        run: |
+          gh workflow run main.yaml --repo "$REPO" --ref "$HEAD_REF"
+
+      - name: Comment result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.prepare.outputs.pr_number }}
+        run: |
+          if [ "${{ needs.normalize.outputs.changed }}" = "true" ]; then
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "Applied normalization to src/ontology/mondo-edit.obo, pushed a commit to this PR branch, and triggered CI again."
+          else
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "No normalization changes were needed for src/ontology/mondo-edit.obo."
+          fi


### PR DESCRIPTION
This commit makes two major changes.

First, running the QC workflow depends on `mondo-edit.obo` being normalized. If normalization modifies the file, the workflow fails early and `make test` is not run at all.

Second, it adds a way to trigger `mondo-edit.obo` normalization via a comment on a pull request. If someone types `/normalize-mondo-edit`, then:

1. The commenter's permissions are checked to see if they have write access to the repo

2. The default branch is checked out as a trusted workspace

3. `mondo-edit.obo` is shallow-cloned from the PR branch and copied into the trusted workspace

4. `make NORM` is run using trusted code from the default branch

5. If normalization changed anything, the result is committed to the PR branch and the QC CI workflow is manually re-triggered.

6. A comment is added to the PR with the result.

This ensures normalization is enforced without requiring contributors to run ODK locally.

NOTE: This adds the normalization step to every PR, even ones that don't touch `mondo-edit.obo`. It's possible to change this, but it would add some complexity and `make NORM` is not particulary expensive.