### PR TITLE
Update Orphanet xref of MONDO:0009106 diastematomyelia

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,13 +1,3 @@
-Click==7.0
-Jinja2==2.11.3
-livereload==2.6.1
-Markdown==3.2.1
-MarkupSafe==1.1.1
-mkdocs==1.2.3
-mkdocs-material==4.3.1
-#pkg-resources==0.0.0
-Pygments==2.7.4
-pymdown-extensions==6.0
-PyYAML==5.4
-six==1.12.0
-tornado==6.0.2
+mkdocs
+mkdocs-material
+pymdown-extensions


### PR DESCRIPTION
close #9871
checked the definitions and updated Orphanet xref to Orphanet:573278 because it represents MONDO:0009106 
https://radiopaedia.org/articles/diastematomyelia and all other databases defined "diastematomyelia" the same concept as split cord malformation

Note: 
type I: duplicated dural sac, with midline rigid osseous or cartilaginous spur; usually symptomatic
type II: single dural sac, with midline nonrigid fibrous or fibrovascular septum; impairment less marked

