### PR TITLE
Patch missing `infores` (and other metadata-only) prefixes into split SSSOM files

### DIFF
--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -46,7 +46,7 @@ curie_map:
   MTH: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/MTH/"
   IMDRF: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/IMDRF/"
   LOINC: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/LOINC/"
-  MEDDRA: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/MEDDRA/"
+  # MEDDRA: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/MEDDRA/" # use MedDRA (above) instead — case collision with newer curies
   # ncithesaurus: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ncithesaurus/"
   COHD: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/COHD/"
   ONCOTREE: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ONCOTREE/"

--- a/src/scripts/split_sssom_by_source.py
+++ b/src/scripts/split_sssom_by_source.py
@@ -5,6 +5,7 @@
 author: Nico Matentzoglu, 15 March 2021
 """
 
+import os
 import re
 from datetime import datetime
 
@@ -126,3 +127,66 @@ for msdf in splitted:
     )
 
 write_tables(splitted, mapping_dir)
+
+
+def metadata_referenced_prefixes(metadata, known_prefixes):
+    """Return prefixes referenced as `prefix:id` in any metadata value."""
+    referenced = set()
+    for value in metadata.values():
+        values = value if isinstance(value, list) else [value]
+        for v in values:
+            if not isinstance(v, str) or v.startswith(("http://", "https://")):
+                continue
+            prefix = v.split(":", 1)[0]
+            if prefix in known_prefixes:
+                referenced.add(prefix)
+    return referenced
+
+
+def patch_curie_map(file_path, missing_prefixes, curie_map):
+    """Insert any missing prefix declarations into the file's curie_map block.
+
+    sssom 0.4.0 derives the on-disk curie_map from data columns only, so
+    prefixes that appear only in metadata slots (e.g. subject_source:
+    infores:mondo) get silently dropped. This patches the file in place.
+    """
+    if not missing_prefixes:
+        return
+    with open(file_path, "r") as f:
+        lines = f.readlines()
+
+    cm_start = None
+    cm_end = None
+    for i, line in enumerate(lines):
+        if line.rstrip() == "# curie_map:":
+            cm_start = i + 1
+            continue
+        if cm_start is not None and not line.startswith("#   "):
+            cm_end = i
+            break
+    if cm_start is None or cm_end is None:
+        return
+
+    block = lines[cm_start:cm_end]
+    declared = set()
+    for entry in block:
+        match = re.match(r"^#   ([^:]+):\s", entry)
+        if match:
+            declared.add(match.group(1))
+    to_add = [p for p in missing_prefixes if p not in declared]
+    if not to_add:
+        return
+    for prefix in to_add:
+        block.append(f"#   {prefix}: {curie_map[prefix]}\n")
+    block.sort()
+    new_lines = lines[:cm_start] + block + lines[cm_end:]
+    with open(file_path, "w") as f:
+        f.writelines(new_lines)
+
+
+for msdf_name, msdf in splitted.items():
+    file_path = os.path.join(mapping_dir, f"{msdf_name}.sssom.tsv")
+    if not os.path.exists(file_path):
+        continue
+    needed = metadata_referenced_prefixes(msdf.metadata, curie_map)
+    patch_curie_map(file_path, needed, curie_map)


### PR DESCRIPTION
The actual fix was made upstream in sssom-py (released as v0.4.20). However, adopting it requires the next ODK release cycle, since pulling sssom 0.4.20 into the current ODK image transitively forces linkml>=1.10, sssom-schema 1.1.0a4, and numpy 2.x, which breaks pyarrow and other co-installed packages.

Until the new sssom-py is available via ODK, this commit:

- Adds a post-process step to `split_sssom_by_source.py` that walks each generated file, scans metadata slot values for CURIE-form references, and inserts any missing prefixes (looked up from the config's curie_map) into the on-disk `# curie_map:` block. Self-deletes naturally once ODK ships sssom-py 0.4.20+.
- Comments out the duplicate `MEDDRA` entry in `mondo.sssom.config.yml`; `MedDRA` is the canonical prefix and newer `curies` versions reject the case-only collision.