### PR TITLE
Scope duplicate-exact-synonym QC to within human/animal branches

### DIFF
--- a/src/sparql/qc/general/qc-duplicate-exact-synonym-no-abbrev.sparql
+++ b/src/sparql/qc/general/qc-duplicate-exact-synonym-no-abbrev.sparql
@@ -16,7 +16,17 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   }
   ?entity1 ?property1 ?value.
   ?entity2 ?property2 ?value .
-  
+
+  # Scope uniqueness to within the human (MONDO:0700096) or non-human animal
+  # (MONDO:0005583) disease branch. Cross-branch duplicates are allowed
+  # (e.g. human "diabetes mellitus" vs feline "diabetes mellitus").
+  VALUES ?branch {
+    obo:MONDO_0700096
+    obo:MONDO_0005583
+  }
+  ?entity1 rdfs:subClassOf* ?branch .
+  ?entity2 rdfs:subClassOf* ?branch .
+
   FILTER NOT EXISTS {
     ?axiom owl:annotatedSource ?entity1 ;
          owl:annotatedProperty ?property1 ;

--- a/src/sparql/reports/duplicate-exact-synonym.sparql
+++ b/src/sparql/reports/duplicate-exact-synonym.sparql
@@ -13,7 +13,14 @@ WHERE
       ?term2 oboInOwl:hasExactSynonym ?exact .
       ?term2 a owl:Class .
       FILTER (?term != ?term2)
-      ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/MONDO_0000001> .
+      # Scope to within the human (MONDO:0700096) or non-human animal
+      # (MONDO:0005583) disease branch. Cross-branch duplicates are allowed.
+      VALUES ?branch {
+        <http://purl.obolibrary.org/obo/MONDO_0700096>
+        <http://purl.obolibrary.org/obo/MONDO_0005583>
+      }
+      ?term rdfs:subClassOf* ?branch .
+      ?term2 rdfs:subClassOf* ?branch .
       FILTER (STRSTARTS(STR(?term), "http://purl.obolibrary.org/obo/MONDO_"))
       FILTER (STRSTARTS(STR(?term2), "http://purl.obolibrary.org/obo/MONDO_"))
     }


### PR DESCRIPTION
Fixes #10261.

Flags a duplicate exact synonym only when both terms descend from the same root: `MONDO:0700096` (human disease) or `MONDO:0005583` (non-human animal disease). Cross-branch pairs (e.g. human vs feline "diabetes mellitus") are now allowed.

Touches `src/sparql/qc/general/qc-duplicate-exact-synonym-no-abbrev.sparql` and `src/sparql/reports/duplicate-exact-synonym.sparql` only.