### PR TITLE
Reinstate MONDO:includedEntryInOMIM xrefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ claude.local.md
 src/scripts/notebooks/mondo_rd_provider_summary.csv
 src/scripts/notebooks/mondo_rd_provider_summary.tsv
 src/ontology/tasks/NHA top level classification task
+reinstatement_report.md
+reinstatement_report.tsv


### PR DESCRIPTION
Reinstate MONDO:includedEntryInOMIM xref annotations that were removed in PR #10092 ("Remove 4309 redundant non-equivalent xrefs to core   namespaces"). These annotations identify OMIM entries that are included within a MONDO term (as opposed to equivalent to it), and their removal caused information loss that this commit restores.

 PR #10092 removed 186 such annotations across 186 distinct MONDO terms.
 After this commit, all 186 of those MONDO terms have the MONDO:includedEntryInOMIM xref present again:
  - 185 are reinstated by line insertions in this commit
  - 1 (MONDO:0800304) was already present in the current file with the exact desired form and required no edit

  Per curation decision, reinstated xrefs carry only the MONDO:includedEntryInOMIM source qualifier. 
- In 19 of the 185 inserted cases, the original removed line had additional source qualifiers (EFO:, DOID:, Orphanet:); those additional sources are NOT restored
- The single obsolete term affected (MONDO:0007264 "obsolete sudden cardiac death") is included in the reinstatement.

  Summary of action per term (186 total):
  - Reinstated as-is (original line had only MONDO:includedEntryInOMIM): 166
  - Reinstated with additional sources stripped: 19
  - Not modified (already present in current form): 1