### PR TITLE
When updating NORD, strip all synonym axioms before merging

### DIFF
--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -711,7 +711,9 @@ update-nord:
 	make $(TMPDIR)/external/processed-nord.robot.owl -B
 	grep -vE '^(xref: NORD:|subset: nord_rare)' $(SRC) > $(TMPDIR)/mondo-edit.tmp || true
 	mv $(TMPDIR)/mondo-edit.tmp mondo-edit.obo
-	$(ROBOT) merge -i $(SRC) -i $(TMPDIR)/external/processed-nord.robot.owl --collapse-import-closure false \
+	$(ROBOT) merge -i $(SRC) --collapse-import-closure false \
+		query --update ../sparql/update/cleanup-nord-synonym-attribution.ru \
+		merge -i $(TMPDIR)/external/processed-nord.robot.owl --collapse-import-closure false \
 		convert -f obo --check false -o $(SRC).obo
 	mv $(SRC).obo $(SRC) && make NORM && mv NORM $(SRC)
 

--- a/src/ontology/mondo.Makefile
+++ b/src/ontology/mondo.Makefile
@@ -706,6 +706,11 @@ update-gard:
 
 ##### NORD #########################
 
+# NOTE: the logic for removing the previous NORD contribution before re-merging
+# now lives in two places: the grep -v below (xrefs and subsets) and
+# cleanup-nord-synonym-attribution.ru (synonyms, their evidence, and community
+# label markers). If you change what NORD is allowed to contribute, both need
+# updating.
 .PHONY: update-nord
 update-nord:
 	make $(TMPDIR)/external/processed-nord.robot.owl -B

--- a/src/sparql/update/cleanup-nord-synonym-attribution.ru
+++ b/src/sparql/update/cleanup-nord-synonym-attribution.ru
@@ -1,0 +1,102 @@
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX OMO: <http://purl.obolibrary.org/obo/OMO_>
+
+# Remove all axioms derived from NORD externally managed content.
+
+# The four operations execute in order. Reordering breaks correctness:
+# operations (2) and (3) erase the NORD signal needed by (1a)/(1b) to
+# identify which synonyms were previously NORD-attributed.
+
+
+# 1a. Drop synonym axioms whose only evidence is from NORD.
+DELETE {
+  ?term ?syn_type ?syn_str .
+}
+WHERE {
+  VALUES ?syn_type {
+    oboInOwl:hasExactSynonym
+    oboInOwl:hasBroadSynonym
+    oboInOwl:hasNarrowSynonym
+    oboInOwl:hasRelatedSynonym
+  }
+
+  ?term ?syn_type ?syn_str .
+
+  ?axiom a owl:Axiom ;
+      owl:annotatedSource ?term ;
+      owl:annotatedProperty ?syn_type ;
+      owl:annotatedTarget ?syn_str ;
+      oboInOwl:hasDbXref ?nord_term .
+  FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+
+  # Leave synonyms with evidence from other sources
+  FILTER NOT EXISTS {
+    ?axiom oboInOwl:hasDbXref ?other_ref .
+    FILTER(!STRSTARTS(STR(?other_ref), "NORD:"))
+  }
+} ;
+
+# (1b) Drop all synonym axiom annotation triples for synonyms whose only evidence
+# is from NORD.
+DELETE {
+  ?axiom ?axiomP ?axiomO .
+}
+WHERE {
+  VALUES ?syn_type {
+    oboInOwl:hasExactSynonym
+    oboInOwl:hasBroadSynonym
+    oboInOwl:hasNarrowSynonym
+    oboInOwl:hasRelatedSynonym
+  }
+
+  ?axiom a owl:Axiom ;
+      owl:annotatedProperty ?syn_type ;
+      oboInOwl:hasDbXref ?nord_term .
+
+  FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+
+  FILTER NOT EXISTS {
+    ?axiom oboInOwl:hasDbXref ?other_term .
+    FILTER(!STRSTARTS(STR(?other_term), "NORD:"))
+  }
+
+  ?axiom ?axiomP ?axiomO .
+} ;
+
+# 2. Drop NORD hasDbXref axiom annotations from multi-sourced synonyms.
+DELETE {
+  ?axiom oboInOwl:hasDbXref ?nord_term .
+}
+WHERE {
+  VALUES ?syn_type {
+    oboInOwl:hasExactSynonym
+    oboInOwl:hasBroadSynonym
+    oboInOwl:hasNarrowSynonym
+    oboInOwl:hasRelatedSynonym
+  }
+
+  ?axiom a owl:Axiom ;
+      owl:annotatedProperty ?syn_type ;
+      oboInOwl:hasDbXref ?nord_term .
+  FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+} ;
+
+# (3) Strip NORD OMO:0002001 label markers for NORD from multi-sourced synonyms.
+DELETE {
+  ?axiom OMO:0002001 ?marker .
+}
+WHERE {
+  VALUES ?syn_type {
+    oboInOwl:hasExactSynonym
+    oboInOwl:hasBroadSynonym
+    oboInOwl:hasNarrowSynonym
+    oboInOwl:hasRelatedSynonym
+  }
+
+  ?axiom a owl:Axiom ;
+      owl:annotatedProperty ?syn_type ;
+      OMO:0002001 ?marker .
+
+  FILTER(STR(?marker) = "https://w3id.org/information-resource-registry/nord")
+}

--- a/src/sparql/update/cleanup-nord-synonym-attribution.ru
+++ b/src/sparql/update/cleanup-nord-synonym-attribution.ru
@@ -3,11 +3,15 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX OMO: <http://purl.obolibrary.org/obo/OMO_>
 
 # Remove all axioms derived from NORD externally managed content.
-
+#
+# NORD attribution can be detected by two different signals:
+#   1) a NORD oboInOwl:hasDbXref
+#   2) an OMO:0002001 community label marker pointing at a NORD resource
+# Most synonyms carry both, but some only carry one.
+#
 # The four operations execute in order. Reordering breaks correctness:
-# operations (2) and (3) erase the NORD signal needed by (1a)/(1b) to
+# operations (2) and (3) erase the NORD signals needed by (1a)/(1b) to
 # identify which synonyms were previously NORD-attributed.
-
 
 # 1a. Drop synonym axioms whose only evidence is from NORD.
 DELETE {
@@ -26,9 +30,15 @@ WHERE {
   ?axiom a owl:Axiom ;
       owl:annotatedSource ?term ;
       owl:annotatedProperty ?syn_type ;
-      owl:annotatedTarget ?syn_str ;
-      oboInOwl:hasDbXref ?nord_term .
-  FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+      owl:annotatedTarget ?syn_str .
+
+  {
+    ?axiom oboInOwl:hasDbXref ?nord_term .
+    FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+  } UNION {
+    ?axiom OMO:0002001 ?nord_marker .
+    FILTER(STR(?nord_marker) = "https://w3id.org/information-resource-registry/nord")
+  }
 
   # Leave synonyms with evidence from other sources
   FILTER NOT EXISTS {
@@ -51,10 +61,15 @@ WHERE {
   }
 
   ?axiom a owl:Axiom ;
-      owl:annotatedProperty ?syn_type ;
-      oboInOwl:hasDbXref ?nord_term .
+      owl:annotatedProperty ?syn_type .
 
-  FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+  {
+    ?axiom oboInOwl:hasDbXref ?nord_term .
+    FILTER(STRSTARTS(STR(?nord_term), "NORD:"))
+  } UNION {
+    ?axiom OMO:0002001 ?nord_marker .
+    FILTER(STR(?nord_marker) = "https://w3id.org/information-resource-registry/nord")
+  }
 
   FILTER NOT EXISTS {
     ?axiom oboInOwl:hasDbXref ?other_term .


### PR DESCRIPTION
Before this commit, `update-nord` would strip xref and subset values from the OBO file, but it would leave synonyms, synonym evidence, and community label annotations untouched.  This led to the bug described in <https://github.com/monarch-initiative/mondo/pull/10465>.

This commit adds a SPARQL update query that drops all of these axioms.

We may want to think about a more generic way to achieve this in case any of our other EMC sources contribute (or especially, change) synonyms, but this works for now.