### PR TITLE
Add misspelling-synonym audit report (unmarked MISSPELLING synonyms + common misspellings absent from MONDO)

### DIFF
--- a/scratch/misspelling-synonyms-audit/README.md
+++ b/scratch/misspelling-synonyms-audit/README.md
@@ -1,0 +1,139 @@
+# MONDO synonyms that are misspellings but not marked `MISSPELLING`
+
+**Source:** `mondo.obo`, release `2026-07-06` (95,023 synonyms across 35,996 non-obsolete `MONDO:` classes).
+**Method:** within each class, compare every *untyped* synonym against the class's own label and other synonyms; treat a difference as a **misspelling candidate** only if the two names are still within edit-distance 1 (or a single adjacent transposition) *after* normalizing away legitimate variation (accents, UK/US spelling, hyphen/space/punctuation, roman↔arabic numerals, Latin/English plural and noun↔adjective morphology). Then auto-classify each surviving candidate by *what the single edit is*.
+
+## Headline
+
+MONDO defines a `MISSPELLING` synonym type but **only 2 synonyms in the entire ontology currently use it** (`holocarboxylase synthase deficiency`, `intellectual disability, XMEN-linked 88`). The misspelling population is essentially entirely unmarked.
+
+The scan surfaced **852 untyped near-duplicate synonyms**, which classify as:
+
+| Category | Count | Misspelling? |
+|---|---:|---|
+| **Genuine typo** | 367 raw → **138 unique** (52 vs label, 86 vs a sibling synonym) | **Yes — candidates for `MISSPELLING`** |
+| UK/US spelling (`foetal`, `caecum`, `tumour`, `naevus`, `pheochromocytoma`) | 265 | No — should be `OMO:0003005` (UK spelling) |
+| Acronym / sibling-code differences (`TRH`/`TRF`, `ASL`/`ASA`, `M6a`/`M6b`) | 111 | No — distinct entities |
+| `disk` / `disc` | 57 | No — both valid |
+| `c` / `k` (`phako`/`phaco`, `pycno`/`pykno`) | 25 | No — both valid |
+| `i` / `y` (`piri`/`pyri`) | 19 | No — both valid |
+| Numbered subtype codes | 8 | No |
+
+For context, MONDO already tags **5,922** UK-spelling synonyms with `OMO:0003005` — so the 265 untyped UK spellings are a genuine tagging gap, but a *different* one from misspellings.
+
+## The 138 genuine-typo candidates
+
+Full machine-readable list: `typos_final.tsv` (columns: `mondo_id`, `term_label`, `correct_form`, `misspelled_synonym`, `anchor`).
+
+### Highest confidence — label-anchored (the class's own label is the correct form)
+
+Unambiguous single-letter typos (a curator would tag `MISSPELLING` on sight):
+
+- `Congential` → congenital aortic valve insufficiency
+- `congenitla` → facial palsy, congenital, …
+- `infaracts` → cerebral arteriopathy with subcortical **infarcts** … (CADASIL)
+- `accululation` → neurodegeneration with brain iron **accumulation** 5
+- `Paroxysomal` → **paroxysmal** nonkinesigenic dyskinesia
+- `Sulfemoglobinemia` → **sulfhemoglobinemia**
+- `essential thrombocytemia` → **thrombocythemia**
+- `gluthathione` → **glutathione** peroxidase deficiency
+- `Camurati-Englemann` → Camurati-**Engelmann** disease
+- `Axenfeldt-Rieger` → **Axenfeld**-Rieger syndrome
+- `Boerhave` → **Boerhaave** syndrome
+- `Bonnevie-Ulrich` → Bonnevie-**Ullrich** syndrome
+- `Li-Ghorgani-…` → Li-**Ghorbani**-Weisz-Hubshman syndrome
+- `ondontochondrodysplasia` → **odontochondrodysplasia** 2 …
+- `otospondylmegaepiphyseal` → **otospondylo**megaepiphyseal dysplasia
+- `spondylocarpostarsal` → **spondylocarpotarsal** fusion syndrome 1A
+- `Vernal Keratonconjunctivitis` → **keratoconjunctivitis**
+- `tonsilitis` → **tonsillitis**
+- `Polyrhinia` → **polyrrhinia**
+- `proteosome-associated…` → **proteasome**-associated autoinflammatory syndrome  ⚠️ *the primary label is the misspelling*
+
+Borderline in this bucket (arguably accepted variant spellings rather than errors — curator judgment): `pseudarthrosis`/pseudoarthrosis (×6), `tendonitis`/tendinitis, `sialoadenitis`/sialadenitis, `spondylarthropathy`/spondyloarthropathy, `pilomatricoma`/pilomatrixoma, `lung hilus`/hilum (×3), `hyperexplexia`/hyperekplexia, `lipid proteinosis`/lipoid.
+
+### Synonym-anchored (neither side is the label; both are synonyms)
+
+Notable clean typos:
+
+- **`wooly` → `woolly` hair** — the single largest cluster: ~30 synonyms across the woolly-hair / keratoderma-cardiomyopathy disease family all carry `wooly`.
+- `Mediterraneanl` → Mediterranean lymphoma
+- `Arthogryposis` → arthrogryposis
+- `mineral duct` → mineral **dust** pneumoconiosis
+- `Strept throat` → Strep throat
+- `sydrome` → syndrome
+- `Maligant` / `Beryllliosis` / `Perenial` / `ichtyosis` / `hypertropic` / `triations`(→striations) / `choanal atrsia` / `neurdegeneration` / `none-erupting`(→non) / `Deficincy` / `Epitherlioma`(→epithelioma) / `Neurogastrointestingal`
+- `Somatotrophinoma` → somatotropinoma (×5), `gammapathy` → gammopathy, `renal Glycosuria` → glucosuria
+- Eponym typos: `Kallman`→Kallmann, `Bechet`→Behcet, `Elsching`→Elschnig, `howel-Evans`→Howell, `Werdnig-Hoffman`→Hoffmann, `Minorbs`→Minor's, `bonnet-Decaume`→Dechaume, `Carotodynia`→Carotidynia
+- Wrong word: `abductor` vs `adductor spasmodic dysphonia`, `S penetrans` vs `T penetrans`
+
+A few residual non-typos survive here (e.g. `Kenya`/`Kenyan`, `spastic paraplegia 3`/`3a`) — dropped on final human review.
+
+## Method limitations (recall)
+
+This is a **high-precision, bounded-recall** approach. It only finds a misspelling when MONDO *also* carries a correctly-spelled name for the same class to compare against, and only within one edit / one transposition. It therefore **misses**:
+- misspellings on a class whose only names are all mis-spelled (nothing to compare to),
+- multi-error misspellings (edit distance ≥ 2 that aren't a single transposition).
+
+Catching those is the domain of a dictionary/spell-checker sweep — which is essentially **Step 2** (common misspellings *not yet in* MONDO).
+
+## Reproduce
+
+```
+python3 detect_misspellings.py mondo.obo   # -> candidates.tsv
+python3 classify.py                        # -> classified.tsv (category per candidate)
+python3 finalize_typos.py                  # -> typos_final.tsv (deduped genuine typos)
+```
+
+---
+
+# Step 2 — common misspellings NOT yet in MONDO (candidates to add)
+
+**Goal:** surface frequently-typed misspellings of well-known diseases that MONDO
+does **not** currently carry as any synonym, so they could be added (as
+`MISSPELLING` synonyms) to improve search/lookup recall.
+
+**Method:** a curated seed of documented lay/phonetic misspellings for 62
+high-prevalence conditions, each checked programmatically against the full set of
+143k MONDO names (labels + synonyms, MONDO classes only). Kept only those (a)
+absent from MONDO and (b) whose *correct* term resolves to a real MONDO class
+(ID captured). Result: **250 candidate misspellings across 62 diseases**
+(`step2_candidates.tsv`).
+
+**Grounding.** "Common" here is anchored to documented usage, not invented:
+- Dellavalle et al., *Common Misspellings and Their Impact on Health Sciences
+  Literature Search Results* (J Hosp Librariansh, 2023) documents the pattern and
+  its top offenders (`arrhythmia`, `ophthalmology`, `pruritus`, `hemorrhage`,
+  `syphilis`, `ilium`/`ileum`).
+- The misspellings occur in real biomedical text — e.g. a PMC case-report title
+  reads "Guillian-Barré syndrome" — which is precisely MONDO's stated rationale
+  for the type: *"recorded for consistency with another source but is a misspelling."*
+
+**Recommendation on scope:** MONDO curators should validate frequency against
+search-log / "did-you-mean" data before bulk-adding; treat this list as vetted
+*candidates*, tiered:
+
+### Tier A — classic, high-frequency misspellings (strongest add candidates)
+`prostrate cancer` (prostate cancer, MONDO:0005159); `chrons disease`/`chron disease`
+(Crohn disease, MONDO:0005011); `diabetis`/`diabeties` (diabetes mellitus);
+`arthritus` (arthritis); `hemroid`/`hemorroid` (hemorrhoid, MONDO:0004872);
+`guillian-barre`/`gullian-barre` (Guillain-Barré, via MONDO GBS class);
+`asma`/`athsma` (asthma); `siphilis`/`sifilis`/`syphillis` (syphilis, MONDO:0005976);
+`sjogrens`/`sjorgens` (Sjögren); `cerebal palsy`/`cerebral palsey` (cerebral palsy,
+MONDO:0006497); `alzeimers`/`altzheimers` (Alzheimer disease, MONDO:0004975);
+`parkisons`→`parkison` (Parkinson disease); `tay-sachs desease`; `wilsons disease`.
+
+### Tier B — plausible generated variants (need frequency confirmation)
+The remaining phonetic/keyboard variants (`ashma`, `siyatica`, `meazles`,
+`gonorreaha`, `epalepsy`, …). Real but lower-frequency; confirm before adding.
+
+### Tier C — informal apostrophe/possessive forms (style, not strictly typos)
+`parkinsons disease`, `huntingtons disease`, `tourettes syndrome`,
+`downs syndrome`, `wilsons disease`. Common in lay usage; MONDO uses the
+non-possessive label, so these are arguably worth adding but as a distinct class
+from true misspellings.
+
+**Method limitation:** the seed is hand-curated (high precision, bounded
+coverage). A complete Step-2 sweep would apply an empirical typo model + a
+frequency corpus (search logs) across *all* MONDO labels — out of scope here but
+the natural next iteration.

--- a/scratch/misspelling-synonyms-audit/classified.tsv
+++ b/scratch/misspelling-synonyms-audit/classified.tsv
@@ -1,0 +1,853 @@
+category	mondo_id	term_label	suspect_synonym	closest_correct	match	edit
+TYPO	MONDO:0008306	ABri amyloidosis	Bri amyloidosis	ABri amyloidosis	label	edit1
+TYPO	MONDO:0019187	Axenfeld-Rieger syndrome	Axenfeldt-Rieger syndrome	Axenfeld-Rieger syndrome	label	edit1
+TYPO	MONDO:0022013	Boerhaave syndrome	Boerhave syndrome	Boerhaave syndrome	label	edit1
+TYPO	MONDO:0100492	Bonnevie-Ullrich syndrome	Bonnevie-Ulrich syndrome	Bonnevie-Ullrich syndrome	label	edit1
+TYPO	MONDO:0007542	Camurati-Engelmann disease	Camurati-Englemann disease	Camurati-Engelmann disease	label	edit1
+TYPO	MONDO:0003736	cancerophobia	Cancerphobia	cancerophobia	label	edit1
+TYPO	MONDO:0007432	cerebral arteriopathy with subcortical infarcts and leukoencephalopathy	cerebral arteriopathy with subcortical infaracts and leukoencephalopathy	cerebral arteriopathy with subcortical infarcts and leukoencephalopathy	label	edit1
+TYPO	MONDO:0019149	cholesteryl ester storage disease	cholesterol ester storage disease	cholesteryl ester storage disease	label	edit1
+TYPO	MONDO:0019809	congenital aortic valve insufficiency	Congential aortic valve insufficiency	congenital aortic valve insufficiency	label	edit1
+TYPO	MONDO:0017463	congenital pseudoarthrosis of the femur	congenital pseudarthrosis of the femur	congenital pseudoarthrosis of the femur	label	edit1
+TYPO	MONDO:0017464	congenital pseudoarthrosis of the fibula	congenital pseudarthrosis of the fibula	congenital pseudoarthrosis of the fibula	label	edit1
+TYPO	MONDO:0015525	congenital pseudoarthrosis of the limbs	congenital pseudarthrosis of the limbs	congenital pseudoarthrosis of the limbs	label	edit1
+TYPO	MONDO:0017465	congenital pseudoarthrosis of the radius	congenital pseudarthrosis of the radius	congenital pseudoarthrosis of the radius	label	edit1
+TYPO	MONDO:0017462	congenital pseudoarthrosis of the tibia	congenital pseudarthrosis of the tibia	congenital pseudoarthrosis of the tibia	label	edit1
+TYPO	MONDO:0017466	congenital pseudoarthrosis of the ulna	congenital pseudarthrosis of the ulna	congenital pseudoarthrosis of the ulna	label	edit1
+TYPO	MONDO:0008338	contractures, pterygia, and spondylocarpotarsal fusion syndrome 1A	contractures, pterygia, and spondylocarpostarsal fusion syndrome 1A	contractures, pterygia, and spondylocarpotarsal fusion syndrome 1A	label	edit1
+TYPO	MONDO:0005413	cystic fibrosis associated meconium ileus	cystic fibrosis associated meconium ileum	cystic fibrosis associated meconium ileus	label	edit1
+TYPO	MONDO:0005029	essential thrombocythemia	essential thrombocytemia	essential thrombocythemia	label	edit1
+TYPO	MONDO:0060589	facial palsy, congenital, with ptosis and velopharyngeal dysfunction	facial palsy, congenitla, with ptosis and velopharyngeal dysfunction	facial palsy, congenital, with ptosis and velopharyngeal dysfunction	label	edit1
+TYPO	MONDO:0013601	gluthathione peroxidase deficiency	glutathione peroxidase deficiency	gluthathione peroxidase deficiency	label	edit1
+TYPO	MONDO:0009288	glycogen storage disease Ib	glycogen storage disease Ic	glycogen storage disease Ib	label	edit1
+TYPO	MONDO:0010768	gonadoblastoma	gonad blastoma	gonadoblastoma	label	edit1
+TYPO	MONDO:0007707	hemangiomas of small intestine	hemangioma of small intestine	hemangiomas of small intestine	label	edit1
+TYPO	MONDO:0021022	hereditary hyperekplexia	hereditary hyperexplexia	hereditary hyperekplexia	label	edit1
+TYPO	MONDO:0016344	hydranencephaly	Hydroanencephaly	hydranencephaly	label	edit1
+TYPO	MONDO:0032796	hyper-IgE recurrent infection syndrome 4, autosomal recessive	hyper-IgE recurrent infection syndrome 4B, autosomal recessive	hyper-IgE recurrent infection syndrome 4, autosomal recessive	label	edit1
+TYPO	MONDO:0033547	Li-Ghorbani-Weisz-Hubshman syndrome	Li-Ghorgani-Weisz-Hubshman syndrome	Li-Ghorbani-Weisz-Hubshman syndrome	label	edit1
+TYPO	MONDO:0018856	lichen amyloidosis	lichen amyloidosus	lichen amyloidosis	label	edit1
+TYPO	MONDO:0007899	lichen sclerosus et atrophicus	lichen sclerosis et atrophicus	lichen sclerosus et atrophicus	label	edit1
+TYPO	MONDO:0009530	lipoid proteinosis	lipid proteinosis	lipoid proteinosis	label	edit1
+TYPO	MONDO:0005060	liposarcoma	lip sarcoma	liposarcoma	label	edit1
+TYPO	MONDO:0004332	lung hilum cancer	lung hilus cancer	lung hilum cancer	label	edit1
+TYPO	MONDO:0004499	lung hilum carcinoma	lung hilus carcinoma	lung hilum carcinoma	label	edit1
+TYPO	MONDO:0003639	lung hilum neoplasm	lung hilus neoplasm	lung hilum neoplasm	label	edit1
+TYPO	MONDO:0004387	luteoma of pregnancy	leuteoma of pregnancy	luteoma of pregnancy	label	edit1
+TYPO	MONDO:0014820	mitochondrial DNA depletion syndrome 14B (cardioencephalomyopathic type)	mitochondrial DNA depletion syndrome 14 (cardioencephalomyopathic type)	mitochondrial DNA depletion syndrome 14B (cardioencephalomyopathic type)	label	edit1
+TYPO	MONDO:0014249	multiple fibroadenoma of the breast	multiple fibroadenomas of the breast	multiple fibroadenoma of the breast	label	edit1
+TYPO	MONDO:0010476	neurodegeneration with brain iron accumulation 5	neurodegeneration with brain iron accululation 5	neurodegeneration with brain iron accumulation 5	label	edit1
+TYPO	MONDO:0031010	odontochondrodysplasia 2 with hearing loss and diabetes	ondontochondrodysplasia 2 with hearing loss and diabetes	odontochondrodysplasia 2 with hearing loss and diabetes	label	edit1
+TYPO	MONDO:0008975	otospondylomegaepiphyseal dysplasia	otospondylmegaepiphyseal dysplasia	otospondylomegaepiphyseal dysplasia	label	edit1
+TYPO	MONDO:0700088	paroxysmal nonkinesigenic dyskinesia	Paroxysomal nonkinesigenic dyskinesia	paroxysmal nonkinesigenic dyskinesia	label	edit1
+TYPO	MONDO:0001042	patellar tendinitis	patellar tendonitis	patellar tendinitis	label	edit1
+TYPO	MONDO:0007564	pilomatrixoma	pilomatricoma	pilomatrixoma	label	edit1
+TYPO	MONDO:0015388	polyrrhinia	Polyrhinia	polyrrhinia	label	edit1
+TYPO	MONDO:0009726	proteosome-associated autoinflammatory syndrome	proteasome-associated autoinflammatory syndrome	proteosome-associated autoinflammatory syndrome	label	edit1
+TYPO	MONDO:0025382	sarcoma, avian	sarcomas, Avian	sarcoma, avian	label	edit1
+TYPO	MONDO:0006969	sialadenitis	sialoadenitis	sialadenitis	label	edit1
+TYPO	MONDO:0005095	spondyloarthropathy	spondylarthropathy	spondyloarthropathy	label	edit1
+TYPO	MONDO:0006988	sulfhemoglobinemia	Sulfemoglobinemia	sulfhemoglobinemia	label	edit1
+TYPO	MONDO:0010434	synovial sarcoma	Synovialosarcoma	synovial sarcoma	label	edit1
+TYPO	MONDO:0004857	tendinitis	tendonitis	tendinitis	label	edit1
+TYPO	MONDO:0006469	tibial adamantinoma	tibia adamantinoma	tibial adamantinoma	label	edit1
+TYPO	MONDO:0001039	tonsillitis	tonsilitis	tonsillitis	label	edit1
+TYPO	MONDO:0019085	vernal keratoconjunctivitis	Vernal Keratonconjunctivitis	vernal keratoconjunctivitis	label	edit1
+TYPO	MONDO:0008306	ABri amyloidosis	ABri amyloidosis	Bri amyloidosis	synonym	edit1
+TYPO	MONDO:0043468	acne keloid	acne, nuchal keloid	Acnes, nuchal keloid	synonym	edit1
+TYPO	MONDO:0043468	acne keloid	Acnes, nuchal keloid	acne, nuchal keloid	synonym	edit1
+TYPO	MONDO:0043468	acne keloid	keloid acne, nuchal	keloid Acnes, nuchal	synonym	edit1
+TYPO	MONDO:0043468	acne keloid	keloid Acnes, nuchal	keloid acne, nuchal	synonym	edit1
+TYPO	MONDO:0001569	acoustic neuroma	acoustic neurilemmoma	acoustic neurilemoma	synonym	edit1
+TYPO	MONDO:0001569	acoustic neuroma	acoustic neurilemoma	acoustic neurilemmoma	synonym	edit1
+TYPO	MONDO:0017858	acute erythroid leukemia	acute erythroleukemia M6a subtype	acute erythroleukemia M6b subtype	synonym	edit1
+TYPO	MONDO:0017858	acute erythroid leukemia	acute erythroleukemia M6b subtype	acute erythroleukemia M6a subtype	synonym	edit1
+TYPO	MONDO:0011786	allergic rhinitis	Perenial allergic rhinitis	perennial allergic rhinitis	synonym	edit1
+TYPO	MONDO:0011786	allergic rhinitis	perennial allergic rhinitis	Perenial allergic rhinitis	synonym	edit1
+TYPO	MONDO:0015045	alpha-heavy chain disease	Mediterranean lymphoma	Mediterraneanl lymphoma	synonym	edit1
+TYPO	MONDO:0015045	alpha-heavy chain disease	Mediterraneanl lymphoma	Mediterranean lymphoma	synonym	edit1
+TYPO	MONDO:0007104	amyotrophic lateral sclerosis-parkinsonism-dementia complex	Lytico-Bodig disease	Lytigo-Bodig disease	synonym	edit1
+TYPO	MONDO:0007104	amyotrophic lateral sclerosis-parkinsonism-dementia complex	Lytigo-Bodig disease	Lytico-Bodig disease	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	epidermolytic palmoplantar keratoderma woolly hair and dilated cardiomyopathy	epidermolytic palmoplantar keratoderma wooly hair and dilated cardiomyopathy	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	epidermolytic palmoplantar keratoderma wooly hair and dilated cardiomyopathy	epidermolytic palmoplantar keratoderma woolly hair and dilated cardiomyopathy	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	keratoderma with woolly hair type II	keratoderma with wooly hair type II	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	keratoderma with wooly hair type II	keratoderma with woolly hair type II	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	palmoplantar keratoderma with left ventricular cardiomyopathy and woolly hair	palmoplantar keratoderma with left ventricular cardiomyopathy and wooly hair	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	palmoplantar keratoderma with left ventricular cardiomyopathy and wooly hair	palmoplantar keratoderma with left ventricular cardiomyopathy and woolly hair	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	woolly hair - palmoplantar keratoderma - dilated cardiomyopathy	wooly hair - palmoplantar keratoderma - dilated cardiomyopathy	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	woolly hair-palmoplantar hyperkeratosis-dilated cardiomyopathy syndrome	wooly hair-palmoplantar hyperkeratosis-dilated cardiomyopathy syndrome	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	wooly hair - palmoplantar keratoderma - dilated cardiomyopathy	woolly hair - palmoplantar keratoderma - dilated cardiomyopathy	synonym	edit1
+TYPO	MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	wooly hair-palmoplantar hyperkeratosis-dilated cardiomyopathy syndrome	woolly hair-palmoplantar hyperkeratosis-dilated cardiomyopathy syndrome	synonym	edit1
+TYPO	MONDO:0012506	arrhythmogenic right ventricular dysplasia 11	arrhythmogenic right ventricular dysplasia 11 with mild palmoplantar keratoderma and woolly hair	arrhythmogenic right ventricular dysplasia 11 with mild palmoplantar keratoderma and wooly hair	synonym	edit1
+TYPO	MONDO:0012506	arrhythmogenic right ventricular dysplasia 11	arrhythmogenic right ventricular dysplasia 11 with mild palmoplantar keratoderma and wooly hair	arrhythmogenic right ventricular dysplasia 11 with mild palmoplantar keratoderma and woolly hair	synonym	edit1
+TYPO	MONDO:0007158	arthrogryposis- oculomotor limitation-electroretinal anomalies syndrome	Arthogryposis with oculomotor limitation and electroretinal abnormalities	arthrogryposis with oculomotor limitation and electroretinal abnormalities	synonym	edit1
+TYPO	MONDO:0007158	arthrogryposis- oculomotor limitation-electroretinal anomalies syndrome	arthrogryposis with oculomotor limitation and electroretinal abnormalities	Arthogryposis with oculomotor limitation and electroretinal abnormalities	synonym	edit1
+TYPO	MONDO:0008830	aspartylglucosaminuria	aspartylglucosaminuria	Aspartylglycosaminuria	synonym	edit1
+TYPO	MONDO:0022535	autonomic facial cephalgia	Carotodynia	Carotidynia	synonym	edit1
+TYPO	MONDO:0008312	autosomal dominant prognathism	Habsburg jaw	Hapsburg jaw	synonym	edit1
+TYPO	MONDO:0008312	autosomal dominant prognathism	Hapsburg jaw	Habsburg jaw	synonym	edit1
+TYPO	MONDO:0020717	autosomal dominant wooly hair	woolly hair, autosomal dominant	wooly hair, autosomal dominant	synonym	edit1
+TYPO	MONDO:0020717	autosomal dominant wooly hair	wooly hair, autosomal dominant	woolly hair, autosomal dominant	synonym	edit1
+TYPO	MONDO:0007191	Behcet disease	Bechet syndrome	Behcet syndrome	synonym	edit1
+TYPO	MONDO:0006115	blast phase chronic myelogenous leukemia, BCR-ABL1 positive	blast crises	blast crisis	synonym	edit1
+TYPO	MONDO:0006115	blast phase chronic myelogenous leukemia, BCR-ABL1 positive	blast crisis	blast crises	synonym	edit1
+TYPO	MONDO:0006115	blast phase chronic myelogenous leukemia, BCR-ABL1 positive	crises, blast	crisis, blast	synonym	edit1
+TYPO	MONDO:0006115	blast phase chronic myelogenous leukemia, BCR-ABL1 positive	crisis, blast	crises, blast	synonym	edit1
+TYPO	MONDO:0007339	blepharocheilodontic syndrome	blepharo-cheilo-odontic syndrome	blepharo-cheilo-dontic syndrome	synonym	edit1
+TYPO	MONDO:0007339	blepharocheilodontic syndrome	Elsching syndrome	Elschnig syndrome	synonym	edit1
+TYPO	MONDO:0007339	blepharocheilodontic syndrome	Elschnig syndrome	Elsching syndrome	synonym	edit1
+TYPO	MONDO:0022013	Boerhaave syndrome	Boerhaave syndrome	Boerhave syndrome	synonym	edit1
+TYPO	MONDO:0100492	Bonnevie-Ullrich syndrome	Bonnevie-Ullrich syndrome	Bonnevie-Ulrich syndrome	synonym	edit1
+TYPO	MONDO:0024472	boutonneuse fever	Kenya tick typhus	Kenyan tick typhus	synonym	edit1
+TYPO	MONDO:0024472	boutonneuse fever	Kenyan tick typhus	Kenya tick typhus	synonym	edit1
+TYPO	MONDO:0008904	camptomelic syndrome, long-limb type	campomelic syndrome long limb type	Camptomelic syndrome long limb type	synonym	edit1
+TYPO	MONDO:0007542	Camurati-Engelmann disease	Camurati-Engelmann disease	Camurati-Englemann disease	synonym	edit1
+TYPO	MONDO:0014355	cardiomyopathy, dilated, with wooly hair, keratoderma, and tooth agenesis	dilated cardiomyopathy with woolly hair, keratoderma, and tooth agenesis	dilated cardiomyopathy with wooly hair, keratoderma, and tooth agenesis	synonym	edit1
+TYPO	MONDO:0014355	cardiomyopathy, dilated, with wooly hair, keratoderma, and tooth agenesis	dilated cardiomyopathy with wooly hair, keratoderma, and tooth agenesis	dilated cardiomyopathy with woolly hair, keratoderma, and tooth agenesis	synonym	edit1
+TYPO	MONDO:0019165	central precocious puberty	gonadotropin-dependant precocious puberty	gonadotropin-dependent precocious puberty	synonym	edit1
+TYPO	MONDO:0019165	central precocious puberty	gonadotropin-dependent precocious puberty	gonadotropin-dependant precocious puberty	synonym	edit1
+TYPO	MONDO:0004731	central sleep apnea syndrome	apnea, central	Apneas, central	synonym	edit1
+TYPO	MONDO:0004731	central sleep apnea syndrome	apnea, central sleep	Apneas, central sleep	synonym	edit1
+TYPO	MONDO:0004731	central sleep apnea syndrome	Apneas, central	apnea, central	synonym	edit1
+TYPO	MONDO:0004731	central sleep apnea syndrome	Apneas, central sleep	apnea, central sleep	synonym	edit1
+TYPO	MONDO:0007432	cerebral arteriopathy with subcortical infarcts and leukoencephalopathy	cerebral arteriopathy with subcortical infarcts and leukoencephalopathy	cerebral arteriopathy with subcortical infaracts and leukoencephalopathy	synonym	edit1
+TYPO	MONDO:0043343	Chilaiditi syndrome	Chilaiditi anomaly	Chilaiditis anomaly	synonym	edit1
+TYPO	MONDO:0015274	chronic beryllium disease	berylliosis	Beryllliosis	synonym	edit1
+TYPO	MONDO:0015274	chronic beryllium disease	Beryllliosis	berylliosis	synonym	edit1
+TYPO	MONDO:0044092	collagenous sprue	sprue, collagenous	Sprues, collagenous	synonym	edit1
+TYPO	MONDO:0044092	collagenous sprue	Sprues, collagenous	sprue, collagenous	synonym	edit1
+TYPO	MONDO:0012833	Crouzon syndrome-acanthosis nigricans syndrome	Crouzon-dermoskeletal syndrome	Crouzonodermoskeletal syndrome	synonym	edit1
+TYPO	MONDO:0012833	Crouzon syndrome-acanthosis nigricans syndrome	Crouzonodermoskeletal syndrome	Crouzon-dermoskeletal syndrome	synonym	edit1
+TYPO	MONDO:0003963	diffuse infiltrative lymphocytosis syndrome	diffuse infiltra. lymph. sydrome	diffuse infiltra. lymph. syndrome	synonym	edit1
+TYPO	MONDO:0003963	diffuse infiltrative lymphocytosis syndrome	diffuse infiltra. lymph. syndrome	diffuse infiltra. lymph. sydrome	synonym	edit1
+TYPO	MONDO:0015240	digitotalar dysmorphism	distal arthrogryposis type 1A (sub-type)	distal arthrogryposis type 1B (sub-type)	synonym	edit1
+TYPO	MONDO:0015240	digitotalar dysmorphism	distal arthrogryposis type 1B (sub-type)	distal arthrogryposis type 1A (sub-type)	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	acrospiroma, eccrine	acrospiromas, eccrine	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	acrospiromas, eccrine	acrospiroma, eccrine	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	hidradenoma, solid-cystic	Hidradenomas, solid-cystic	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	Hidradenomas, solid-cystic	hidradenoma, solid-cystic	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	Hidradrenoma, clear-cell	Hidradrenomas, clear-cell	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	Hidradrenoma, nodular	Hidradrenomas, nodular	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	Hidradrenomas, clear-cell	Hidradrenoma, clear-cell	synonym	edit1
+TYPO	MONDO:0006738	eccrine acrospiroma	Hidradrenomas, nodular	Hidradrenoma, nodular	synonym	edit1
+TYPO	MONDO:0016002	Ehlers-Danlos syndrome, kyphoscoliotic type 1	Ehlers-Danlos syndrome type 6 (formerly)	Ehlers-Danlos syndrome type 6A (formerly)	synonym	edit1
+TYPO	MONDO:0016002	Ehlers-Danlos syndrome, kyphoscoliotic type 1	Ehlers-Danlos syndrome type 6A (formerly)	Ehlers-Danlos syndrome type 6 (formerly)	synonym	edit1
+TYPO	MONDO:0006745	endometrioid stromal sarcoma	stromal sarcoma, endometrial	stromal sarcomas, endometrial	synonym	edit1
+TYPO	MONDO:0006745	endometrioid stromal sarcoma	stromal sarcomas, endometrial	stromal sarcoma, endometrial	synonym	edit1
+TYPO	MONDO:0025489	enzootic bovine leukosis	lymphoma, bovine	lymphomas, bovine	synonym	edit1
+TYPO	MONDO:0025489	enzootic bovine leukosis	lymphomas, bovine	lymphoma, bovine	synonym	edit1
+TYPO	MONDO:0025489	enzootic bovine leukosis	lymphosarcoma, bovine	lymphosarcomas, bovine	synonym	edit1
+TYPO	MONDO:0025489	enzootic bovine leukosis	lymphosarcomas, bovine	lymphosarcoma, bovine	synonym	edit1
+TYPO	MONDO:0007554	epidermolysis bullosa simplex 1B, generalized intermediate	epidermolysis bullosa simplex, Koebner type	epidermolysis bullosa simplex, Kobner type	synonym	edit1
+TYPO	MONDO:0005029	essential thrombocythemia	essential thrombocythemia	essential thrombocytemia	synonym	edit1
+TYPO	MONDO:0060589	facial palsy, congenital, with ptosis and velopharyngeal dysfunction	facial palsy, congenital, with ptosis and velopharyngeal dysfunction	facial palsy, congenitla, with ptosis and velopharyngeal dysfunction	synonym	edit1
+TYPO	MONDO:0024466	facial paresis, hereditary congenital, 1	Mobius syndrome 2	Moebius syndrome 2	synonym	edit1
+TYPO	MONDO:0024466	facial paresis, hereditary congenital, 1	Moebius syndrome 2	Mobius syndrome 2	synonym	edit1
+TYPO	MONDO:0011407	facial paresis, hereditary congenital, 2	Mobius syndrome 3	Moebius syndrome 3	synonym	edit1
+TYPO	MONDO:0011407	facial paresis, hereditary congenital, 2	Moebius syndrome 3	Mobius syndrome 3	synonym	edit1
+TYPO	MONDO:0000995	familial periodic paralysis	familial periodic paralysis	familial periodic paralyses	synonym	edit1
+TYPO	MONDO:0000995	familial periodic paralysis	normokalemic periodic paralysis	normokalemic periodic paralyses	synonym	edit1
+TYPO	MONDO:0009297	familial renal glucosuria	renal glucosuria	Renal Glycosuria	synonym	edit1
+TYPO	MONDO:0003962	Froelich syndrome	Froehlich's syndrome	Froelich's syndrome	synonym	edit1
+TYPO	MONDO:0003962	Froelich syndrome	Froelich's syndrome	Froehlich's syndrome	synonym	edit1
+TYPO	MONDO:0003962	Froelich syndrome	Frohlich's syndrome	Froehlich's syndrome	synonym	edit1
+TYPO	MONDO:0003962	Froelich syndrome	Frolich's syndrome	Froelich's syndrome	synonym	edit1
+TYPO	MONDO:0013601	gluthathione peroxidase deficiency	gluthathione peroxidase deficiency	glutathione peroxidase deficiency	synonym	edit1
+TYPO	MONDO:0009288	glycogen storage disease Ib	glycogen storage disease Ib	glycogen storage disease Ic	synonym	edit1
+TYPO	MONDO:0010768	gonadoblastoma	gonadoblastoma	gonad blastoma	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant pituitary gland Somatotrophinoma	malignant pituitary gland somatotropinoma	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant pituitary gland somatotropinoma	malignant pituitary gland Somatotrophinoma	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant pituitary Somatotrophinoma	malignant pituitary somatotropinoma	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant pituitary somatotropinoma	malignant pituitary Somatotrophinoma	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant Somatotrophinoma of pituitary	malignant somatotropinoma of pituitary	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant Somatotrophinoma of pituitary gland	malignant somatotropinoma of pituitary gland	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant Somatotrophinoma of the pituitary gland	malignant somatotropinoma of the pituitary gland	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant somatotropinoma of pituitary	malignant Somatotrophinoma of pituitary	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant somatotropinoma of pituitary gland	malignant Somatotrophinoma of pituitary gland	synonym	edit1
+TYPO	MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant somatotropinoma of the pituitary gland	malignant Somatotrophinoma of the pituitary gland	synonym	edit1
+TYPO	MONDO:0007707	hemangiomas of small intestine	hemangiomas of small intestine	hemangioma of small intestine	synonym	edit1
+TYPO	MONDO:0021022	hereditary hyperekplexia	hereditary hyperekplexia	hereditary hyperexplexia	synonym	edit1
+TYPO	MONDO:0008437	hereditary spastic paraplegia 3A	spastic paraplegia 3, autosomal dominant	spastic paraplegia 3a, autosomal dominant	synonym	edit1
+TYPO	MONDO:0008437	hereditary spastic paraplegia 3A	spastic paraplegia 3a, autosomal dominant	spastic paraplegia 3, autosomal dominant	synonym	edit1
+TYPO	MONDO:0043653	herpes labialis	Sore, cold	Sores, cold	synonym	edit1
+TYPO	MONDO:0043653	herpes labialis	Sores, cold	Sore, cold	synonym	edit1
+TYPO	MONDO:0016344	hydranencephaly	hydranencephaly	Hydroanencephaly	synonym	edit1
+TYPO	MONDO:0012528	hypogonadotropic hypogonadism 4 with or without anosmia	Kallman syndrome 4	Kallmann syndrome 4	synonym	edit1
+TYPO	MONDO:0012528	hypogonadotropic hypogonadism 4 with or without anosmia	Kallmann syndrome 4	Kallman syndrome 4	synonym	edit1
+TYPO	MONDO:0014390	hypotrichosis 13	hypotrichosis with woolly hair	hypotrichosis with wooly hair	synonym	edit1
+TYPO	MONDO:0014390	hypotrichosis 13	hypotrichosis with wooly hair	hypotrichosis with woolly hair	synonym	edit1
+TYPO	MONDO:0011452	hypotrichosis 7	wooly hair, autosomal recessive 2 with or without hypotrichosis	woolly hair, autosomal recessive 2 with or without hypotrichosis	synonym	edit1
+TYPO	MONDO:0019122	idiopathic acute eosinophilic pneumonia	Loeffler syndrome	Loffler syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	familial woolly hair (autosomal recessive)	familial wooly hair (autosomal recessive)	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	familial woolly hair syndrome	familial wooly hair syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	familial wooly hair (autosomal recessive)	familial woolly hair (autosomal recessive)	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	familial wooly hair syndrome	familial woolly hair syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	hereditary woolly hair (autosomal dominant)	hereditary wooly hair (autosomal dominant)	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	hereditary woolly hair syndrome	hereditary wooly hair syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	hereditary wooly hair (autosomal dominant)	hereditary woolly hair (autosomal dominant)	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	hereditary wooly hair syndrome	hereditary woolly hair syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	woolly hair	wooly hair	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	woolly hair syndrome	wooly hair syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	woolly hair, autosomal dominant	wooly hair, autosomal dominant	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	wooly hair	woolly hair	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	wooly hair syndrome	woolly hair syndrome	synonym	edit1
+TYPO	MONDO:0008686	isolated familial wooly hair disorder	wooly hair, autosomal dominant	woolly hair, autosomal dominant	synonym	edit1
+TYPO	MONDO:0011090	isolated hereditary congenital facial paralysis	Mobius syndrome 2 (formerly)	Moebius syndrome 2 (formerly)	synonym	edit1
+TYPO	MONDO:0011090	isolated hereditary congenital facial paralysis	Moebius syndrome 2 (formerly)	Mobius syndrome 2 (formerly)	synonym	edit1
+TYPO	MONDO:0018971	isolated oxycephaly	hypsicephaly	hypsocephaly	synonym	edit1
+TYPO	MONDO:0018971	isolated oxycephaly	hypsocephaly	hypsicephaly	synonym	edit1
+TYPO	MONDO:0009394	juvenile Paget disease	hyperostosid corticalis deformans juvenilis	hyperostosis corticalis deformans juvenilis	synonym	edit1
+TYPO	MONDO:0009394	juvenile Paget disease	hyperostosis corticalis deformans juvenilis	hyperostosid corticalis deformans juvenilis	synonym	edit1
+TYPO	MONDO:0009697	Lafora disease	epilepsy, progressive myoclonic 2A (Lafora)	epilepsy, progressive myoclonic 2B (Lafora)	synonym	edit1
+TYPO	MONDO:0009697	Lafora disease	epilepsy, progressive myoclonic 2B (Lafora)	epilepsy, progressive myoclonic 2A (Lafora)	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Immunoblastic Lymphoma, Large-Cell	Immunoblastic Lymphomas, Large-Cell	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Immunoblastic Lymphomas, Large-Cell	Immunoblastic Lymphoma, Large-Cell	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Immunoblastic Lymphosarcoma, Diffuse	Immunoblastic Lymphosarcomas, Diffuse	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Immunoblastic Lymphosarcomas, Diffuse	Immunoblastic Lymphosarcoma, Diffuse	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Large-Cell Lymphoma, Immunoblastic	Large-Cell Lymphomas, Immunoblastic	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Large-Cell Lymphomas, Immunoblastic	Large-Cell Lymphoma, Immunoblastic	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Lymphomas, Immunoblastic Large-Cell	Lymphoma, Immunoblastic Large-Cell	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Lymphomas, Large-Cell Immunoblastic	Lymphoma, Large-Cell Immunoblastic	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Lymphosarcoma, Diffuse Immunoblastic	Lymphosarcomas, Diffuse Immunoblastic	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Lymphosarcomas, Diffuse Immunoblastic	Lymphosarcoma, Diffuse Immunoblastic	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Sarcoma, Immunoblastic	Sarcomas, Immunoblastic	synonym	edit1
+TYPO	MONDO:0022037	large-cell immunoblastic lymphoma	Sarcomas, Immunoblastic	Sarcoma, Immunoblastic	synonym	edit1
+TYPO	MONDO:0020974	laryngeal granuloma	Granuloma, Laryngeal	Granulomas, Laryngeal	synonym	edit1
+TYPO	MONDO:0020974	laryngeal granuloma	Granulomas, Laryngeal	Granuloma, Laryngeal	synonym	edit1
+TYPO	MONDO:0007899	lichen sclerosus et atrophicus	lichen sclerosis	lichen sclerosus	synonym	edit1
+TYPO	MONDO:0007899	lichen sclerosus et atrophicus	lichen sclerosus	lichen sclerosis	synonym	edit1
+TYPO	MONDO:0007899	lichen sclerosus et atrophicus	lichen sclerosus et atrophicus	lichen sclerosis et atrophicus	synonym	edit1
+TYPO	MONDO:0043294	linear scleroderma	en coup de saber	en coup de sabre	synonym	edit1
+TYPO	MONDO:0043294	linear scleroderma	en coup de sabre	en coup de saber	synonym	edit1
+TYPO	MONDO:0009530	lipoid proteinosis	lipoid proteinosis	lipid proteinosis	synonym	edit1
+TYPO	MONDO:0005060	liposarcoma	liposarcoma	lip sarcoma	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	glaucoma, Low tension	Glaucomas, Low tension	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	glaucoma, normal tension	Glaucomas, normal tension	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	Glaucomas, Low tension	glaucoma, Low tension	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	Glaucomas, normal tension	glaucoma, normal tension	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	tension glaucoma, Low	tension Glaucomas, Low	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	tension glaucoma, normal	tension Glaucomas, normal	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	tension Glaucomas, Low	tension glaucoma, Low	synonym	edit1
+TYPO	MONDO:0006837	low tension glaucoma	tension Glaucomas, normal	tension glaucoma, normal	synonym	edit1
+TYPO	MONDO:0004332	lung hilum cancer	malignant lung hilum neoplasm	malignant lung hilus neoplasm	synonym	edit1
+TYPO	MONDO:0004332	lung hilum cancer	malignant lung hilus neoplasm	malignant lung hilum neoplasm	synonym	edit1
+TYPO	MONDO:0004332	lung hilum cancer	malignant neoplasm of lung hilum	malignant neoplasm of lung hilus	synonym	edit1
+TYPO	MONDO:0004332	lung hilum cancer	malignant neoplasm of lung hilus	malignant neoplasm of lung hilum	synonym	edit1
+TYPO	MONDO:0004499	lung hilum carcinoma	lung hilum carcinoma	lung hilus carcinoma	synonym	edit1
+TYPO	MONDO:0003639	lung hilum neoplasm	lung hilum neoplasm	lung hilus neoplasm	synonym	edit1
+TYPO	MONDO:0005834	lymphogranuloma venereum	lymph granuloma inguinale	lymphogranuloma inguinale	synonym	edit1
+TYPO	MONDO:0005834	lymphogranuloma venereum	lymphogranuloma inguinale	lymph granuloma inguinale	synonym	edit1
+TYPO	MONDO:0019245	lysosomal lipid storage disorder	lipid storage disease	lipoid storage disease	synonym	edit1
+TYPO	MONDO:0019245	lysosomal lipid storage disorder	lipoid storage disease	lipid storage disease	synonym	edit1
+TYPO	MONDO:0043731	lytic metastatic bone lesion	Osteolyses	osteolysis	synonym	edit1
+TYPO	MONDO:0043731	lytic metastatic bone lesion	osteolysis	Osteolyses	synonym	edit1
+TYPO	MONDO:0009552	mal de Meleda	keratosis palmoplantaris transgradiens of Siemens	keratosis palmoplantaris transgrediens of Siemens	synonym	edit1
+TYPO	MONDO:0009552	mal de Meleda	keratosis palmoplantaris transgrediens of Siemens	keratosis palmoplantaris transgradiens of Siemens	synonym	edit1
+TYPO	MONDO:0020541	maligant granulosa cell tumor of ovary	Maligant granulosa cell tumour of the ovary	malignant granulosa cell tumour of the ovary	synonym	edit1
+TYPO	MONDO:0017827	malignant peripheral nerve sheath tumor	malignant neurilemmoma	malignant neurilemoma	synonym	edit1
+TYPO	MONDO:0017827	malignant peripheral nerve sheath tumor	malignant neurilemoma	malignant neurilemmoma	synonym	edit1
+TYPO	MONDO:0025483	mammary neoplasms, animal	carcinoma, animal mammary	carcinomas, animal mammary	synonym	edit1
+TYPO	MONDO:0025483	mammary neoplasms, animal	carcinomas, animal mammary	carcinoma, animal mammary	synonym	edit1
+TYPO	MONDO:0025483	mammary neoplasms, animal	mammary carcinoma, animal	mammary carcinomas, animal	synonym	edit1
+TYPO	MONDO:0025483	mammary neoplasms, animal	mammary carcinomas, animal	mammary carcinoma, animal	synonym	edit1
+TYPO	MONDO:0009571	Meckel syndrome, type 1	Dysencephalia splachnocystica	Dysencephalia Splanchnocystica	synonym	edit1
+TYPO	MONDO:0009571	Meckel syndrome, type 1	Dysencephalia Splanchnocystica	Dysencephalia splachnocystica	synonym	edit1
+TYPO	MONDO:0002012	methylmalonic acidemia	methylmalonic acidemia, cblA type	methylmalonic acidemia, cblB type	synonym	edit1
+TYPO	MONDO:0002012	methylmalonic acidemia	methylmalonic acidemia, cblB type	methylmalonic acidemia, cblA type	synonym	edit1
+TYPO	MONDO:0002012	methylmalonic acidemia	methylmalonic aciduria type cblA	methylmalonic aciduria type cblB	synonym	edit1
+TYPO	MONDO:0002012	methylmalonic acidemia	methylmalonic aciduria type cblB	methylmalonic aciduria type cblA	synonym	edit1
+TYPO	MONDO:0002012	methylmalonic acidemia	methylmalonic aciduria, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin, cblA type	methylmalonic aciduria, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin, cblB type	synonym	edit1
+TYPO	MONDO:0002012	methylmalonic acidemia	methylmalonic aciduria, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin, cblB type	methylmalonic aciduria, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin, cblA type	synonym	edit1
+TYPO	MONDO:0008855	MHC class II deficiency	BARE lymphocyte syndrome, type II, complementation group B, included	BARE lymphocyte syndrome, type II, complementation group C, included	synonym	edit1
+TYPO	MONDO:0008855	MHC class II deficiency	BARE lymphocyte syndrome, type II, complementation group C, included	BARE lymphocyte syndrome, type II, complementation group B, included	synonym	edit1
+TYPO	MONDO:0008855	MHC class II deficiency	BARE lymphocyte syndrome, type II, complementation group D, included	BARE lymphocyte syndrome, type II, complementation group B, included	synonym	edit1
+TYPO	MONDO:0008855	MHC class II deficiency	BARE lymphocyte syndrome, type II, complementation group E, included	BARE lymphocyte syndrome, type II, complementation group B, included	synonym	edit1
+TYPO	MONDO:0017575	mitochondrial neurogastrointestinal encephalomyopathy	mitochondrial Neurogastrointestingal encephalopathy	Mitochondrial Neurogastrointestinal Encephalopathy	synonym	edit1
+TYPO	MONDO:0001000	mixed mineral dust pneumoconiosis	mineral duct pneumoconiosis	mineral dust pneumoconiosis	synonym	edit1
+TYPO	MONDO:0001000	mixed mineral dust pneumoconiosis	mineral dust pneumoconiosis	mineral duct pneumoconiosis	synonym	edit1
+TYPO	MONDO:0009282	multiple acyl-CoA dehydrogenase deficiency	Etfa deficiency	Etfb deficiency	synonym	edit1
+TYPO	MONDO:0009282	multiple acyl-CoA dehydrogenase deficiency	Etfb deficiency	Etfa deficiency	synonym	edit1
+TYPO	MONDO:0011017	Naxos disease	keratoderma with woolly hair type I	keratoderma with wooly hair type I	synonym	edit1
+TYPO	MONDO:0011017	Naxos disease	keratoderma with wooly hair type I	keratoderma with woolly hair type I	synonym	edit1
+TYPO	MONDO:0011017	Naxos disease	keratosis palmoplantaris arrythmogenic cardiomyopathy woolly hair	keratosis palmoplantaris arrythmogenic cardiomyopathy wooly hair	synonym	edit1
+TYPO	MONDO:0011017	Naxos disease	keratosis palmoplantaris arrythmogenic cardiomyopathy wooly hair	keratosis palmoplantaris arrythmogenic cardiomyopathy woolly hair	synonym	edit1
+TYPO	MONDO:0011017	Naxos disease	woolly hair palmoplantar keratoderma cardiac abnormalities	wooly hair palmoplantar keratoderma cardiac abnormalities	synonym	edit1
+TYPO	MONDO:0011017	Naxos disease	wooly hair palmoplantar keratoderma cardiac abnormalities	woolly hair palmoplantar keratoderma cardiac abnormalities	synonym	edit1
+TYPO	MONDO:0010476	neurodegeneration with brain iron accumulation 5	neurodegeneration with brain iron accumulation 5	neurodegeneration with brain iron accululation 5	synonym	edit1
+TYPO	MONDO:0010476	neurodegeneration with brain iron accumulation 5	static encephalopathy of childhood with neurdegeneration in adulthood	static encephalopathy Of childhood with neurodegeneration In adulthood	synonym	edit1
+TYPO	MONDO:0010476	neurodegeneration with brain iron accumulation 5	static encephalopathy Of childhood with neurodegeneration In adulthood	static encephalopathy of childhood with neurdegeneration in adulthood	synonym	edit1
+TYPO	MONDO:0016101	neurolymphomatosis	fowl paralysis	fowl paralyses	synonym	edit1
+TYPO	MONDO:0008093	nevus, epidermal	nevus sebaceous or woolly hair nevus, somatic	nevus sebaceous or wooly hair nevus, somatic	synonym	edit1
+TYPO	MONDO:0008093	nevus, epidermal	nevus sebaceous or wooly hair nevus, somatic	nevus sebaceous or woolly hair nevus, somatic	synonym	edit1
+TYPO	MONDO:0010104	non-eruption of teeth-maxillary hypoplasia-genu valgum syndrome	multiple non-erupting teeth, maxillo-zygomatical hypoplasia and other congenital defects	multiple none-erupting teeth, maxillo-zygomatical hypoplasia and other congenital defects	synonym	edit1
+TYPO	MONDO:0010104	non-eruption of teeth-maxillary hypoplasia-genu valgum syndrome	multiple none-erupting teeth, maxillo-zygomatical hypoplasia and other congenital defects	multiple non-erupting teeth, maxillo-zygomatical hypoplasia and other congenital defects	synonym	edit1
+TYPO	MONDO:0007147	obstructive sleep apnea syndrome	apnea, obstructive sleep	Apneas, obstructive sleep	synonym	edit1
+TYPO	MONDO:0007147	obstructive sleep apnea syndrome	Apneas, obstructive sleep	apnea, obstructive sleep	synonym	edit1
+TYPO	MONDO:0043251	odontoma	fibro-odontomas, ameloblastic	fibro-odontoma, ameloblastic	synonym	edit1
+TYPO	MONDO:0043251	odontoma	odontoma, compound	odontomas, compound	synonym	edit1
+TYPO	MONDO:0043251	odontoma	odontomas, compound	odontoma, compound	synonym	edit1
+TYPO	MONDO:0010457	Ogden syndrome	premature ageing appearance-developmental delay-cardiac arrhythmia syndrome	premature aging appearance-developmental delay-cardiac arrhythmia syndrome	synonym	edit1
+TYPO	MONDO:0010457	Ogden syndrome	premature aging appearance-developmental delay-cardiac arrhythmia syndrome	premature ageing appearance-developmental delay-cardiac arrhythmia syndrome	synonym	edit1
+TYPO	MONDO:0017178	osteochondritis dissecans	Koenig disease	Konig disease	synonym	edit1
+TYPO	MONDO:0017198	osteopetrosis	Albers-Schoenberg disease	Albers-Schonberg disease	synonym	edit1
+TYPO	MONDO:0017198	osteopetrosis	Albers-Schonberg disease	Albers-Schoenberg disease	synonym	edit1
+TYPO	MONDO:0007856	palmoplantar keratoderma-esophageal carcinoma syndrome	howel-Evans syndrome	Howell-Evans syndrome	synonym	edit1
+TYPO	MONDO:0007856	palmoplantar keratoderma-esophageal carcinoma syndrome	Howell-Evans syndrome	howel-Evans syndrome	synonym	edit1
+TYPO	MONDO:0024677	pancreatic insulinoma	adenomas, beta-cell	adenoma, beta-cell	synonym	edit1
+TYPO	MONDO:0002470	photosensitive trichothiodystrophy	trichothiodystrophy with congenital ichthyosis	trichothiodystrophy with congenital ichtyosis	synonym	edit1
+TYPO	MONDO:0002470	photosensitive trichothiodystrophy	trichothiodystrophy with congenital ichtyosis	trichothiodystrophy with congenital ichthyosis	synonym	edit1
+TYPO	MONDO:0007564	pilomatrixoma	benign pilomatricoma	benign pilomatrixoma	synonym	edit1
+TYPO	MONDO:0007564	pilomatrixoma	benign pilomatrixoma	benign pilomatricoma	synonym	edit1
+TYPO	MONDO:0007564	pilomatrixoma	calcifying epithelioma of Malherbe	calcifying Epitherlioma of Malherbe	synonym	edit1
+TYPO	MONDO:0007564	pilomatrixoma	calcifying Epitherlioma of Malherbe	calcifying epithelioma of Malherbe	synonym	edit1
+TYPO	MONDO:0007564	pilomatrixoma	pilomatrixoma	pilomatricoma	synonym	edit1
+TYPO	MONDO:0017416	postpoliomyelitis syndrome	postpoliomyelitis syndrome	postpoliomyelitic syndrome	synonym	edit1
+TYPO	MONDO:0011149	premature aging syndrome, Okamoto type	premature ageing Okamoto type	premature aging Okamoto type	synonym	edit1
+TYPO	MONDO:0011149	premature aging syndrome, Okamoto type	premature ageing syndrome with osteosarcoma cataracts diabetes osteoporosis erythroid macrocytosis severe developmental delay	premature aging syndrome with osteosarcoma cataracts diabetes osteoporosis erythroid macrocytosis severe developmental delay	synonym	edit1
+TYPO	MONDO:0011149	premature aging syndrome, Okamoto type	premature aging Okamoto type	premature ageing Okamoto type	synonym	edit1
+TYPO	MONDO:0011149	premature aging syndrome, Okamoto type	premature aging syndrome with osteosarcoma cataracts diabetes osteoporosis erythroid macrocytosis severe developmental delay	premature ageing syndrome with osteosarcoma cataracts diabetes osteoporosis erythroid macrocytosis severe developmental delay	synonym	edit1
+TYPO	MONDO:0016620	primary hypertrophic osteoarthropathy	hypertrophic osteoarthropathy, primary	hypertropic osteoarthropathy, primary	synonym	edit1
+TYPO	MONDO:0016620	primary hypertrophic osteoarthropathy	hypertropic osteoarthropathy, primary	hypertrophic osteoarthropathy, primary	synonym	edit1
+TYPO	MONDO:0010911	prolactin-producing pituitary gland adenoma	lactotrope adenoma	lactotroph adenoma	synonym	edit1
+TYPO	MONDO:0010911	prolactin-producing pituitary gland adenoma	lactotroph adenoma	lactotrope adenoma	synonym	edit1
+TYPO	MONDO:0025457	pulmonary adenomatosis, ovine	carcinoma, Ovine pulmonary	carcinomas, Ovine pulmonary	synonym	edit1
+TYPO	MONDO:0025457	pulmonary adenomatosis, ovine	carcinomas, Ovine pulmonary	carcinoma, Ovine pulmonary	synonym	edit1
+TYPO	MONDO:0025457	pulmonary adenomatosis, ovine	pulmonary carcinoma, Ovine	pulmonary carcinomas, Ovine	synonym	edit1
+TYPO	MONDO:0025457	pulmonary adenomatosis, ovine	pulmonary carcinomas, Ovine	pulmonary carcinoma, Ovine	synonym	edit1
+TYPO	MONDO:0004574	pyridoxine deficiency anemia	pyridoxine deficiency	pyridoxine Deficincy	synonym	edit1
+TYPO	MONDO:0004574	pyridoxine deficiency anemia	pyridoxine Deficincy	pyridoxine deficiency	synonym	edit1
+TYPO	MONDO:0011970	rolandic epilepsy-paroxysmal exercise-induced dystonia-writer's cramp syndrome	epilepsy, rolandic, with paroxysmal exercise-induce dystonia and writer's cramp	epilepsy, ROLANDIC, with paroxysmal exercise-induced dystonia and writer'S cramp	synonym	edit1
+TYPO	MONDO:0011970	rolandic epilepsy-paroxysmal exercise-induced dystonia-writer's cramp syndrome	epilepsy, ROLANDIC, with paroxysmal exercise-induced dystonia and writer'S cramp	epilepsy, rolandic, with paroxysmal exercise-induce dystonia and writer's cramp	synonym	edit1
+TYPO	MONDO:0018304	Schnitzler syndrome	chronic urticaria with gammapathy	chronic urticaria with gammopathy	synonym	edit1
+TYPO	MONDO:0018304	Schnitzler syndrome	chronic urticaria with gammopathy	chronic urticaria with gammapathy	synonym	edit1
+TYPO	MONDO:0002546	schwannoma	neurilemmoma	neurolemmoma	synonym	edit1
+TYPO	MONDO:0002546	schwannoma	neurolemmoma	neurilemmoma	synonym	edit1
+TYPO	MONDO:0018484	semicircular canal dehiscence syndrome	Minor's syndrome	Minorbs syndrome	synonym	edit1
+TYPO	MONDO:0018484	semicircular canal dehiscence syndrome	Minorbs syndrome	Minor's syndrome	synonym	edit1
+TYPO	MONDO:0009833	Shwachman-Diamond syndrome	Schwachmann-Diamond syndrome	Schwachman-Diamond syndrome	synonym	edit1
+TYPO	MONDO:0011882	skin fragility-woolly hair-palmoplantar keratoderma syndrome	skin fragility wooly hair syndrome	skin fragility woolly hair syndrome	synonym	edit1
+TYPO	MONDO:0005296	sleep apnea syndrome	apnea, sleep	apneas, sleep	synonym	edit1
+TYPO	MONDO:0005296	sleep apnea syndrome	apneas, sleep	apnea, sleep	synonym	edit1
+TYPO	MONDO:0005296	sleep apnea syndrome	sleep apnea, mixed	sleep apneas, mixed	synonym	edit1
+TYPO	MONDO:0005296	sleep apnea syndrome	sleep apneas, mixed	sleep apnea, mixed	synonym	edit1
+TYPO	MONDO:0005235	smoldering plasma cell myeloma	smoldering multiple myeloma	smouldering multiple myeloma	synonym	edit1
+TYPO	MONDO:0005235	smoldering plasma cell myeloma	smoldering Multiple myeloma/plasma cell myeloma	smouldering Multiple myeloma/plasma cell myeloma	synonym	edit1
+TYPO	MONDO:0005235	smoldering plasma cell myeloma	smoldering myeloma	smouldering myeloma	synonym	edit1
+TYPO	MONDO:0005235	smoldering plasma cell myeloma	smouldering multiple myeloma	smoldering multiple myeloma	synonym	edit1
+TYPO	MONDO:0005235	smoldering plasma cell myeloma	smouldering Multiple myeloma/plasma cell myeloma	smoldering Multiple myeloma/plasma cell myeloma	synonym	edit1
+TYPO	MONDO:0005235	smoldering plasma cell myeloma	smouldering myeloma	smoldering myeloma	synonym	edit1
+TYPO	MONDO:0000485	spasmodic dystonia	abductor spasmodic dysphonia	adductor spasmodic dysphonia	synonym	edit1
+TYPO	MONDO:0000485	spasmodic dystonia	adductor spasmodic dysphonia	abductor spasmodic dysphonia	synonym	edit1
+TYPO	MONDO:0009669	spinal muscular atrophy, type 1	Werdnig-Hoffman disease	Werdnig-Hoffmann Disease	synonym	edit1
+TYPO	MONDO:0010068	spondyloepimetaphyseal dysplasia, sponastrime type	spondylar and nasal changes with striations of the metaphyses (SPONASTRIME) dysplasia	spondylar and nasal changes with triations of the metaphyses (SPONASTRIME) dysplasia	synonym	edit1
+TYPO	MONDO:0010068	spondyloepimetaphyseal dysplasia, sponastrime type	spondylar and nasal changes with triations of the metaphyses (SPONASTRIME) dysplasia	spondylar and nasal changes with striations of the metaphyses (SPONASTRIME) dysplasia	synonym	edit1
+TYPO	MONDO:0021783	streptococcal sore throat	Strept throat	Strep throat	synonym	edit1
+TYPO	MONDO:0010434	synovial sarcoma	synovial sarcoma	Synovialosarcoma	synonym	edit1
+TYPO	MONDO:0006469	tibial adamantinoma	tibial adamantinoma	tibia adamantinoma	synonym	edit1
+TYPO	MONDO:0019611	TSH-secreting pituitary adenoma	thyrotrope adenoma	thyrotroph adenoma	synonym	edit1
+TYPO	MONDO:0019498	tungiasis	S penetrans	T penetrans	synonym	edit1
+TYPO	MONDO:0019498	tungiasis	T penetrans	S penetrans	synonym	edit1
+TYPO	MONDO:0010931	vitamin D-dependent rickets, type 2B	vitamin D receptor signaling defect rickets	vitamin D receptor signalling defect rickets	synonym	edit1
+TYPO	MONDO:0010931	vitamin D-dependent rickets, type 2B	vitamin D receptor signalling defect rickets	vitamin D receptor signaling defect rickets	synonym	edit1
+TYPO	MONDO:0014765	wooly hair, autosomal recessive 3	KRT25 woolly hair (disease)	KRT25 wooly hair (disease)	synonym	edit1
+TYPO	MONDO:0014765	wooly hair, autosomal recessive 3	KRT25 wooly hair (disease)	KRT25 woolly hair (disease)	synonym	edit1
+TYPO	MONDO:0014765	wooly hair, autosomal recessive 3	woolly hair (disease) caused by mutation in KRT25	wooly hair (disease) caused by mutation in KRT25	synonym	edit1
+TYPO	MONDO:0014765	wooly hair, autosomal recessive 3	woolly hair, autosomal recessive type 3	wooly hair, autosomal recessive type 3	synonym	edit1
+TYPO	MONDO:0014765	wooly hair, autosomal recessive 3	wooly hair (disease) caused by mutation in KRT25	woolly hair (disease) caused by mutation in KRT25	synonym	edit1
+TYPO	MONDO:0014765	wooly hair, autosomal recessive 3	wooly hair, autosomal recessive type 3	woolly hair, autosomal recessive type 3	synonym	edit1
+TYPO	MONDO:0010207	wooly hair-hypotrichosis-everted lower lip-outstanding ears syndrome	wooly hair hypotrichosis everted lower lip and outstanding ears	woolly hair hypotrichosis everted lower lip and outstanding ears	synonym	edit1
+TYPO	MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	keratoderma with woolly hair type IV	keratoderma with wooly hair type IV	synonym	edit1
+TYPO	MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	keratoderma with wooly hair type IV	keratoderma with woolly hair type IV	synonym	edit1
+TYPO	MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	palmoplantar keratoderma and woolly hair	palmoplantar keratoderma and wooly hair	synonym	edit1
+TYPO	MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	palmoplantar keratoderma and wooly hair	palmoplantar keratoderma and woolly hair	synonym	edit1
+TYPO	MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	woolly hair-palmoplantar hyperkeratosis syndrome	wooly hair-palmoplantar hyperkeratosis syndrome	synonym	edit1
+TYPO	MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	wooly hair-palmoplantar hyperkeratosis syndrome	woolly hair-palmoplantar hyperkeratosis syndrome	synonym	edit1
+TYPO	MONDO:0018892	Wyburn-Mason syndrome	bonnet-Decaume-Blanc syndrome	bonnet-Dechaume-Blanc syndrome	synonym	edit1
+TYPO	MONDO:0018892	Wyburn-Mason syndrome	bonnet-Dechaume-Blanc syndrome	bonnet-Decaume-Blanc syndrome	synonym	edit1
+TYPO	MONDO:0018821	X-linked female restricted facial dysmorphism-short stature-choanal atresia-intellectual disability	X-linked facial dysmorphism-short stature-choanal atresia-intellectual disability syndrome limited to females	X-linked facial dysmorphism-short stature-choanal atrsia-intellectual disability syndrome limited to females	synonym	edit1
+TYPO	MONDO:0018821	X-linked female restricted facial dysmorphism-short stature-choanal atresia-intellectual disability	X-linked facial dysmorphism-short stature-choanal atrsia-intellectual disability syndrome limited to females	X-linked facial dysmorphism-short stature-choanal atresia-intellectual disability syndrome limited to females	synonym	edit1
+ACRONYM_CODE	MONDO:0018588	ALECT2 amyloidosis	LECT2 amyloidosis	ALECT2 amyloidosis	label	edit1
+ACRONYM_CODE	MONDO:0012719	combined PSAP deficiency	combined SAP deficiency	combined PSAP deficiency	label	edit1
+ACRONYM_CODE	MONDO:0007872	LADD syndrome	lard syndrome	LADD syndrome	label	edit1
+ACRONYM_CODE	MONDO:0008861	3-methylcrotonyl-CoA carboxylase 1 deficiency	Bmcc deficiency	MCC deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0008861	3-methylcrotonyl-CoA carboxylase 1 deficiency	MCC deficiency	Bmcc deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0019339	47,XYY syndrome	YY syndrome	XYY Syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0008815	argininosuccinic aciduria	ASA deficiency	ASL deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0008815	argininosuccinic aciduria	ASL deficiency	ASA deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0011158	autoimmune lymphoproliferative syndrome type 1	autoimmune lymphoproliferative syndrome, type IA	autoimmune lymphoproliferative syndrome, type IB	synonym	edit1
+ACRONYM_CODE	MONDO:0011158	autoimmune lymphoproliferative syndrome type 1	autoimmune lymphoproliferative syndrome, type IB	autoimmune lymphoproliferative syndrome, type IA	synonym	edit1
+ACRONYM_CODE	MONDO:0014121	autosomal dominant childhood-onset proximal spinal muscular atrophy with contractures	spinal muscular atrophy, lower extremity-predominant, 2A, autosomal dominant	spinal muscular atrophy, LOWER extremity-predominant, 2, autosomal dominant	synonym	edit1
+ACRONYM_CODE	MONDO:0011776	CINCA syndrome	IOMID syndrome	NOMID syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0011776	CINCA syndrome	NOMID syndrome	IOMID syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0006156	colon sessile serrated adenoma/polyp	colon SSA	colon SSP	synonym	edit1
+ACRONYM_CODE	MONDO:0006156	colon sessile serrated adenoma/polyp	colon SSP	colon SSA	synonym	edit1
+ACRONYM_CODE	MONDO:0006164	colorectal sessile serrated adenoma/polyp	colorectal SSA	colorectal SSP	synonym	edit1
+ACRONYM_CODE	MONDO:0006164	colorectal sessile serrated adenoma/polyp	colorectal SSP	colorectal SSA	synonym	edit1
+ACRONYM_CODE	MONDO:0017249	congenital pulmonary airway malformation type 1	CCAM type 1	CPAM type 1	synonym	edit1
+ACRONYM_CODE	MONDO:0017249	congenital pulmonary airway malformation type 1	CPAM type 1	CCAM type 1	synonym	edit1
+ACRONYM_CODE	MONDO:0017250	congenital pulmonary airway malformation type 2	CCAM type 2	CPAM type 2	synonym	edit1
+ACRONYM_CODE	MONDO:0017250	congenital pulmonary airway malformation type 2	CPAM type 2	CCAM type 2	synonym	edit1
+ACRONYM_CODE	MONDO:0017251	congenital pulmonary airway malformation type 3	CCAM type 3	CPAM type 3	synonym	edit1
+ACRONYM_CODE	MONDO:0017251	congenital pulmonary airway malformation type 3	CPAM type 3	CCAM type 3	synonym	edit1
+ACRONYM_CODE	MONDO:0005132	cytomegalovirus infection	CMV infection	HCMV infection	synonym	edit1
+ACRONYM_CODE	MONDO:0005132	cytomegalovirus infection	HCMV infection	CMV infection	synonym	edit1
+ACRONYM_CODE	MONDO:0100114	dry age related macular degeneration	dry AMD	dry ARMD	synonym	edit1
+ACRONYM_CODE	MONDO:0100114	dry age related macular degeneration	dry ARMD	dry AMD	synonym	edit1
+ACRONYM_CODE	MONDO:0035337	Duane retraction syndrome with congenital deafness	DRS with deafness	DURS with deafness	synonym	edit1
+ACRONYM_CODE	MONDO:0035337	Duane retraction syndrome with congenital deafness	DRS with hearing loss	DURS with hearing loss	synonym	edit1
+ACRONYM_CODE	MONDO:0035337	Duane retraction syndrome with congenital deafness	DURS with deafness	DRS with deafness	synonym	edit1
+ACRONYM_CODE	MONDO:0035337	Duane retraction syndrome with congenital deafness	DURS with hearing loss	DRS with hearing loss	synonym	edit1
+ACRONYM_CODE	MONDO:0015553	dystrophic epidermolysis bullosa, nails only	nails-only DDEB	nails-only DEB	synonym	edit1
+ACRONYM_CODE	MONDO:0015553	dystrophic epidermolysis bullosa, nails only	nails-only DEB	nails-only DDEB	synonym	edit1
+ACRONYM_CODE	MONDO:0025149	encephalopathy, bovine spongiform	BSE (bovine spongiform encephalopathy)	BSEs (bovine spongiform encephalopathy)	synonym	edit1
+ACRONYM_CODE	MONDO:0025149	encephalopathy, bovine spongiform	BSEs (bovine spongiform encephalopathy)	BSE (bovine spongiform encephalopathy)	synonym	edit1
+ACRONYM_CODE	MONDO:0003649	esophageal neuroendocrine tumor	esophageal NEN	esophageal NET	synonym	edit1
+ACRONYM_CODE	MONDO:0018453	familial atypical multiple mole melanoma syndrome	FAMM syndrome	FAMMM syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0018453	familial atypical multiple mole melanoma syndrome	FAMMM syndrome	FAMM syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0016342	familial isolated arrhythmogenic right ventricular dysplasia	familial isolated ARVC	familial isolated ARVD	synonym	edit1
+ACRONYM_CODE	MONDO:0016342	familial isolated arrhythmogenic right ventricular dysplasia	familial isolated ARVD	familial isolated ARVC	synonym	edit1
+ACRONYM_CODE	MONDO:0015267	Feingold syndrome	MODED syndrome	ODED syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0015267	Feingold syndrome	ODED syndrome	MODED syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0008115	Feingold syndrome type 1	MODED syndrome type 1	ODED syndrome type 1	synonym	edit1
+ACRONYM_CODE	MONDO:0008115	Feingold syndrome type 1	ODED syndrome type 1	MODED syndrome type 1	synonym	edit1
+ACRONYM_CODE	MONDO:0000408	fetal alcohol spectrum disorder	FAE (fetal alcohol effects)	FAEs (fetal alcohol effects)	synonym	edit1
+ACRONYM_CODE	MONDO:0000408	fetal alcohol spectrum disorder	FAEs (fetal alcohol effects)	FAE (fetal alcohol effects)	synonym	edit1
+ACRONYM_CODE	MONDO:0017677	focal acral hyperkeratosis	PPKP3 without elastoidosis	PPPK3 without elastoidosis	synonym	edit1
+ACRONYM_CODE	MONDO:0017677	focal acral hyperkeratosis	PPPK3 without elastoidosis	PPKP3 without elastoidosis	synonym	edit1
+ACRONYM_CODE	MONDO:0003219	gastroesophageal junction adenocarcinoma	adenocarcinoma of the EG junction	adenocarcinoma of the GE junction	synonym	edit1
+ACRONYM_CODE	MONDO:0003219	gastroesophageal junction adenocarcinoma	adenocarcinoma of the GE junction	adenocarcinoma of the EG junction	synonym	edit1
+ACRONYM_CODE	MONDO:0009288	glycogen storage disease Ib	glycogen storage disease type IB	glycogen storage disease type Ic	synonym	edit1
+ACRONYM_CODE	MONDO:0009288	glycogen storage disease Ib	glycogen storage disease type Ic	glycogen storage disease type IB	synonym	edit1
+ACRONYM_CODE	MONDO:0007698	hand-foot-genital syndrome	HFG syndrome	HFU syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0007698	hand-foot-genital syndrome	HFU syndrome	HFG syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0100083	hereditary thrombocytopenia and hematological cancer predisposition syndrome associated with RUNX1	FPD/AML syndrome	FPS/AML syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0100083	hereditary thrombocytopenia and hematological cancer predisposition syndrome associated with RUNX1	FPS/AML syndrome	FPD/AML syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0004952	Hodgkins lymphoma	stage I subdiaphragmatic Hodgkin lymphoma	stage II subdiaphragmatic Hodgkin lymphoma	synonym	edit1
+ACRONYM_CODE	MONDO:0004952	Hodgkins lymphoma	stage II subdiaphragmatic Hodgkin lymphoma	stage I subdiaphragmatic Hodgkin lymphoma	synonym	edit1
+ACRONYM_CODE	MONDO:0012382	hyperinsulinemic hypoglycemia, familial, 4	had deficiency	HADH deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0012382	hyperinsulinemic hypoglycemia, familial, 4	HADH deficiency	had deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010140	isolated thyrotropin-releasing hormone deficiency	isolated TRF deficiency	isolated TRH deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010140	isolated thyrotropin-releasing hormone deficiency	isolated TRH deficiency	isolated TRF deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009180	junctional epidermolysis bullosa, non-Herlitz type	JEB-nH	JEN-nH	synonym	edit1
+ACRONYM_CODE	MONDO:0009180	junctional epidermolysis bullosa, non-Herlitz type	JEN-nH	JEB-nH	synonym	edit1
+ACRONYM_CODE	MONDO:0007872	LADD syndrome	LADD syndrome	lard syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0009563	maple syrup urine disease	BCKD deficiency	BCKDH deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009563	maple syrup urine disease	BCKDH deficiency	BCKD deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010674	mucopolysaccharidosis type 2	IDS deficiency	SIDS deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010674	mucopolysaccharidosis type 2	SIDS deficiency	IDS deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0018938	mucopolysaccharidosis type 4	mucopolysaccharidosis type IVB	mucopolysaccharidosis type IV	synonym	edit1
+ACRONYM_CODE	MONDO:0009661	mucopolysaccharidosis type 6	ARSB deficiency	ASB deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009661	mucopolysaccharidosis type 6	ASB deficiency	ARSB deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009282	multiple acyl-CoA dehydrogenase deficiency	glutaric acidemia IIB	glutaric acidemia IIA	synonym	edit1
+ACRONYM_CODE	MONDO:0008234	multiple endocrine neoplasia type 2A	MEA type 2a	men type 2a	synonym	edit1
+ACRONYM_CODE	MONDO:0008234	multiple endocrine neoplasia type 2A	MEA type II	men type II	synonym	edit1
+ACRONYM_CODE	MONDO:0008234	multiple endocrine neoplasia type 2A	men type 2a	MEA type 2a	synonym	edit1
+ACRONYM_CODE	MONDO:0008234	multiple endocrine neoplasia type 2A	men type II	MEA type II	synonym	edit1
+ACRONYM_CODE	MONDO:0018358	neonatal autoimmune hemolytic anemia	neonatal AHA	neonatal AIHA	synonym	edit1
+ACRONYM_CODE	MONDO:0018358	neonatal autoimmune hemolytic anemia	neonatal AIHA	neonatal AHA	synonym	edit1
+ACRONYM_CODE	MONDO:0024309	neuropathy, hereditary sensory and autonomic, type 2A	HSN 2A	HSAN 2A	synonym	edit1
+ACRONYM_CODE	MONDO:0018587	non-recovering obstetric brachial plexus lesion	non-recovering OBPI	non-recovering OBPL	synonym	edit1
+ACRONYM_CODE	MONDO:0018587	non-recovering obstetric brachial plexus lesion	non-recovering OBPL	non-recovering OBPI	synonym	edit1
+ACRONYM_CODE	MONDO:0008111	oculodentodigital dysplasia	odd syndrome	ODDD syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0008111	oculodentodigital dysplasia	ODDD syndrome	odd syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0017138	Opitz G/BBB syndrome	BBB syndrome	GBBB syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0017138	Opitz G/BBB syndrome	GBBB syndrome	BBB syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0015247	opsoclonus-myoclonus syndrome	oma syndrome	POMA syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0015247	opsoclonus-myoclonus syndrome	POMA syndrome	oma syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0009796	ornithine aminotransferase deficiency	OAT deficiency	OKT deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009796	ornithine aminotransferase deficiency	OKT deficiency	OAT deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010703	ornithine carbamoyltransferase deficiency	OCT deficiency	OTC deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010703	ornithine carbamoyltransferase deficiency	OTC deficiency	OCT deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009908	pterin-4 alpha-carbinolamine dehydratase 1 deficiency	PCBD deficiency	PCD deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0009908	pterin-4 alpha-carbinolamine dehydratase 1 deficiency	PCD deficiency	PCBD deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0006392	rectal hyperplastic polyp	rectal Hp	rectal MP	synonym	edit1
+ACRONYM_CODE	MONDO:0006392	rectal hyperplastic polyp	rectal MP	rectal Hp	synonym	edit1
+ACRONYM_CODE	MONDO:0018955	recurrent respiratory papillomatosis	AORRP (type)	JORRP (type)	synonym	edit1
+ACRONYM_CODE	MONDO:0018955	recurrent respiratory papillomatosis	JORRP (type)	AORRP (type)	synonym	edit1
+ACRONYM_CODE	MONDO:0018353	refractory celiac disease	type I refractory sprue	type II refractory sprue	synonym	edit1
+ACRONYM_CODE	MONDO:0018353	refractory celiac disease	type II refractory sprue	type I refractory sprue	synonym	edit1
+ACRONYM_CODE	MONDO:0014205	severe feeding difficulties-failure to thrive-microcephaly due to ASXL3 deficiency syndrome	BAINBRIDGE-ROPERS syndrome	Bainbridge-Roppers syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0014205	severe feeding difficulties-failure to thrive-microcephaly due to ASXL3 deficiency syndrome	Bainbridge-Roppers syndrome	BAINBRIDGE-ROPERS syndrome	synonym	edit1
+ACRONYM_CODE	MONDO:0025484	simian acquired immunodeficiency syndrome	AIDS, Simian	AIDSs, Simian	synonym	edit1
+ACRONYM_CODE	MONDO:0025484	simian acquired immunodeficiency syndrome	AIDSs, Simian	AIDS, Simian	synonym	edit1
+ACRONYM_CODE	MONDO:0019457	therapy related acute myeloid leukemia and myelodysplastic syndrome	Secondary AGL	secondary AML	synonym	edit1
+ACRONYM_CODE	MONDO:0019457	therapy related acute myeloid leukemia and myelodysplastic syndrome	secondary AML	Secondary AGL	synonym	edit1
+ACRONYM_CODE	MONDO:0019642	vitamin D-dependent rickets, type 2	VDRR II	VDDR II	synonym	edit1
+ACRONYM_CODE	MONDO:0005417	wet macular degeneration	wet AMD	wet ARMD	synonym	edit1
+ACRONYM_CODE	MONDO:0005417	wet macular degeneration	wet ARMD	wet AMD	synonym	edit1
+ACRONYM_CODE	MONDO:0010209	xanthinuria type I	XO deficiency	XOR deficiency	synonym	edit1
+ACRONYM_CODE	MONDO:0010209	xanthinuria type I	XOR deficiency	XO deficiency	synonym	edit1
+C_K_VARIANT	MONDO:0008753	alkaptonuria	alcaptonuria	alkaptonuria	label	edit1
+C_K_VARIANT	MONDO:0017906	amyloidosis cutis dyschromia	amyloidosis cutis dyschromica	amyloidosis cutis dyschromia	label	edit1
+C_K_VARIANT	MONDO:0005357	Creutzfeldt Jacob disease	Creutzfeldt Jakob Disease	Creutzfeldt Jacob disease	label	edit1
+C_K_VARIANT	MONDO:0018913	malakoplakia	malacoplakia	malakoplakia	label	edit1
+C_K_VARIANT	MONDO:0017317	phakomatosis pigmentokeratotica	Phacomatosis pigmentokeratotica	phakomatosis pigmentokeratotica	label	edit1
+C_K_VARIANT	MONDO:0017318	phakomatosis pigmentovascularis	Phacomatosis pigmentovascularis	phakomatosis pigmentovascularis	label	edit1
+C_K_VARIANT	MONDO:0009940	pycnodysostosis	Pyknodysostosis	pycnodysostosis	label	edit1
+C_K_VARIANT	MONDO:0009833	Shwachman-Diamond syndrome	Schwachman-Diamond syndrome	Shwachman-Diamond syndrome	label	edit1
+C_K_VARIANT	MONDO:0018747	acquired epidermolysis bullosa	epidermolysis bullosa acquisita	epidermolysis bullosa Aquisita	synonym	edit1
+C_K_VARIANT	MONDO:0018747	acquired epidermolysis bullosa	epidermolysis bullosa Aquisita	epidermolysis bullosa acquisita	synonym	edit1
+C_K_VARIANT	MONDO:0008753	alkaptonuria	alkaptonuria	alcaptonuria	synonym	edit1
+C_K_VARIANT	MONDO:0011099	human HOXA1 syndromes	Athabascan brainstem dysgenesis syndrome	Athabaskan brainstem dysgenesis syndrome	synonym	edit1
+C_K_VARIANT	MONDO:0011099	human HOXA1 syndromes	Athabaskan brainstem dysgenesis syndrome	Athabascan brainstem dysgenesis syndrome	synonym	edit1
+C_K_VARIANT	MONDO:0008224	hyperkalemic periodic paralysis	hyperKPP	hyperPP	synonym	edit1
+C_K_VARIANT	MONDO:0008224	hyperkalemic periodic paralysis	hyperPP	hyperKPP	synonym	edit1
+C_K_VARIANT	MONDO:0018694	isolated tracheo-esophageal fistula	tracheo-esophageal fistula	tracheoesophageal fistula	synonym	edit1
+C_K_VARIANT	MONDO:0018694	isolated tracheo-esophageal fistula	tracheoesophageal fistula	tracheo-esophageal fistula	synonym	edit1
+C_K_VARIANT	MONDO:0017318	phakomatosis pigmentovascularis	phakomatosis pigmentovascularis	Phacomatosis pigmentovascularis	synonym	edit1
+C_K_VARIANT	MONDO:0003670	posteroinferior myocardial infarction	posteroinferior myocardial infarction by ECG finding	posteroinferior myocardial infarction by EKG finding	synonym	edit1
+C_K_VARIANT	MONDO:0003670	posteroinferior myocardial infarction	posteroinferior myocardial infarction by EKG finding	posteroinferior myocardial infarction by ECG finding	synonym	edit1
+C_K_VARIANT	MONDO:0009940	pycnodysostosis	pycnodysostosis	Pyknodysostosis	synonym	edit1
+C_K_VARIANT	MONDO:0011225	severe combined immunodeficiency due to DCLRE1C deficiency	SCID, Athabascan type	SCID, Athabaskan type	synonym	edit1
+C_K_VARIANT	MONDO:0011225	severe combined immunodeficiency due to DCLRE1C deficiency	SCID, Athabaskan type	SCID, Athabascan type	synonym	edit1
+C_K_VARIANT	MONDO:0018896	thrombotic thrombocytopenic purpura	Moschcowitz disease	Moschowitz disease	synonym	edit1
+C_K_VARIANT	MONDO:0018896	thrombotic thrombocytopenic purpura	Moschowitz disease	Moschcowitz disease	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	cervical Disc degenerative disorder	cervical disk degenerative disorder	label	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	intervertebral Disc degenerative disorder	intervertebral disk degenerative disorder	label	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	lumbar Disc degenerative disorder	lumbar disk degenerative disorder	label	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	thoracic Disc degenerative disorder	thoracic disk degenerative disorder	label	edit1
+DISK_DISC	MONDO:0011599	birdshot chorioretinopathy	multiple small, cream-colored lesions, symmetrically scattered mainly around the optic disc	multiple small, cream-colored lesions, symmetrically scattered mainly around the optic disk	synonym	edit1
+DISK_DISC	MONDO:0011599	birdshot chorioretinopathy	multiple small, cream-colored lesions, symmetrically scattered mainly around the optic disk	multiple small, cream-colored lesions, symmetrically scattered mainly around the optic disc	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	cervical region of vertebral column intervertebral disc degenerative disorder	cervical region of vertebral column intervertebral disk degenerative disorder	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	cervical region of vertebral column intervertebral disk degenerative disorder	cervical region of vertebral column intervertebral disc degenerative disorder	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	degeneration of cervical intervertebral disc	degeneration of cervical intervertebral disk	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	degeneration of cervical intervertebral disk	degeneration of cervical intervertebral disc	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	intervertebral disc degenerative disorder of cervical region of vertebral column	intervertebral disk degenerative disorder of cervical region of vertebral column	synonym	edit1
+DISK_DISC	MONDO:0044343	cervical disk degenerative disorder	intervertebral disk degenerative disorder of cervical region of vertebral column	intervertebral disc degenerative disorder of cervical region of vertebral column	synonym	edit1
+DISK_DISC	MONDO:0011992	hereditary spastic paraplegia 25	spinal disc herniation with autosomal recessive spastic paraplegia	spinal disk herniation with autosomal recessive spastic paraplegia	synonym	edit1
+DISK_DISC	MONDO:0011992	hereditary spastic paraplegia 25	spinal disk herniation with autosomal recessive spastic paraplegia	spinal disc herniation with autosomal recessive spastic paraplegia	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	cervical disc degenerative disease	cervical disk degenerative disease	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	cervical disk degenerative disease	cervical disc degenerative disease	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	degenerative disorder of intervertebral disc	degenerative disorder of intervertebral disk	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	degenerative disorder of intervertebral disk	degenerative disorder of intervertebral disc	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	intervertebral disc disease	intervertebral disk disease	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	intervertebral disk degeneration	intervertebral Disc Degeneration	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	intervertebral disk degenerative disorder	intervertebral Disc degenerative disorder	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	intervertebral disk disease	intervertebral disc disease	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	lumbar disc degeneration	lumbar disk degeneration	synonym	edit1
+DISK_DISC	MONDO:0011385	intervertebral disk degenerative disorder	lumbar disk degeneration	lumbar disc degeneration	synonym	edit1
+DISK_DISC	MONDO:0012605	isolated microphthalmia 5	microphthalmia-retinitis pigmentosa-foveoschisis-optic disc drusen syndrome	microphthalmia-retinitis pigmentosa-foveoschisis-optic disk drusen syndrome	synonym	edit1
+DISK_DISC	MONDO:0012605	isolated microphthalmia 5	microphthalmia-retinitis pigmentosa-foveoschisis-optic disk drusen syndrome	microphthalmia-retinitis pigmentosa-foveoschisis-optic disc drusen syndrome	synonym	edit1
+DISK_DISC	MONDO:0012605	isolated microphthalmia 5	Nanophtalmos-retinitis pigmentosa-foveoschisis-optic disc drusen syndrome	Nanophtalmos-retinitis pigmentosa-foveoschisis-optic disk drusen syndrome	synonym	edit1
+DISK_DISC	MONDO:0012605	isolated microphthalmia 5	Nanophtalmos-retinitis pigmentosa-foveoschisis-optic disk drusen syndrome	Nanophtalmos-retinitis pigmentosa-foveoschisis-optic disc drusen syndrome	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	degeneration of lumbar intervertebral disc	degeneration of lumbar intervertebral disk	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	degeneration of lumbar intervertebral disk	degeneration of lumbar intervertebral disc	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	degenerative disc disease	degenerative disk disease	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	degenerative disc disorder	degenerative disk disorder	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	degenerative disk disease	degenerative disc disease	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	degenerative disk disorder	degenerative disc disorder	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	intervertebral disc degenerative disorder of lumbar region of vertebral column	intervertebral disk degenerative disorder of lumbar region of vertebral column	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	intervertebral disc disease, susceptibility to	intervertebral disk disease, susceptibility to	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	intervertebral disk degenerative disorder of lumbar region of vertebral column	intervertebral disc degenerative disorder of lumbar region of vertebral column	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	intervertebral disk disease	intervertebral DISC disease	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	intervertebral disk disease, susceptibility to	intervertebral disc disease, susceptibility to	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	lumbar disc disease, susceptibility to	lumbar disk disease, susceptibility to	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	lumbar disk disease, susceptibility to	lumbar disc disease, susceptibility to	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	lumbar region of vertebral column intervertebral disc degenerative disorder	lumbar region of vertebral column intervertebral disk degenerative disorder	synonym	edit1
+DISK_DISC	MONDO:0044339	lumbar disk degenerative disorder	lumbar region of vertebral column intervertebral disk degenerative disorder	lumbar region of vertebral column intervertebral disc degenerative disorder	synonym	edit1
+DISK_DISC	MONDO:0001746	optic disk drusen	drusen of optic disc	drusen of optic disk	synonym	edit1
+DISK_DISC	MONDO:0001746	optic disk drusen	drusen of optic disk	drusen of optic disc	synonym	edit1
+DISK_DISC	MONDO:0006879	optic papillitis	inflammation of optic disc	inflammation of optic disk	synonym	edit1
+DISK_DISC	MONDO:0006879	optic papillitis	inflammation of optic disk	inflammation of optic disc	synonym	edit1
+DISK_DISC	MONDO:0006879	optic papillitis	optic disc inflammation	optic disk inflammation	synonym	edit1
+DISK_DISC	MONDO:0006879	optic papillitis	optic disk inflammation	optic disc inflammation	synonym	edit1
+DISK_DISC	MONDO:0010064	spastic ataxia-corneal dystrophy syndrome	spastic ataxia, macular corneal dystrophy, congenital cataracts, myopia and vertically oval temporally tilted discs	spastic ataxia, macular corneal dystrophy, congenital cataracts, myopia and vertically oval temporally tilted disks	synonym	edit1
+DISK_DISC	MONDO:0010064	spastic ataxia-corneal dystrophy syndrome	spastic ataxia, macular corneal dystrophy, congenital cataracts, myopia and vertically oval temporally tilted disks	spastic ataxia, macular corneal dystrophy, congenital cataracts, myopia and vertically oval temporally tilted discs	synonym	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	degeneration of thoracic intervertebral disc	degeneration of thoracic intervertebral disk	synonym	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	degeneration of thoracic intervertebral disk	degeneration of thoracic intervertebral disc	synonym	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	intervertebral disc degenerative disorder of thoracic region of vertebral column	intervertebral disk degenerative disorder of thoracic region of vertebral column	synonym	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	intervertebral disk degenerative disorder of thoracic region of vertebral column	intervertebral disc degenerative disorder of thoracic region of vertebral column	synonym	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	thoracic region of vertebral column intervertebral disc degenerative disorder	thoracic region of vertebral column intervertebral disk degenerative disorder	synonym	edit1
+DISK_DISC	MONDO:0044342	thoracic disk degenerative disorder	thoracic region of vertebral column intervertebral disk degenerative disorder	thoracic region of vertebral column intervertebral disc degenerative disorder	synonym	edit1
+I_Y_VARIANT	MONDO:0002806	bronchogenic carcinoma	bronchiogenic carcinoma	bronchogenic carcinoma	label	edit1
+I_Y_VARIANT	MONDO:0020980	hair nevus	hairy nevus	hair nevus	label	edit1
+I_Y_VARIANT	MONDO:0006787	hidrocystoma	Hydrocystoma	hidrocystoma	label	edit1
+I_Y_VARIANT	MONDO:0007765	hyperostosis cranialis interna	hyperostosis cranalis interna	hyperostosis cranialis interna	label	edit1
+I_Y_VARIANT	MONDO:0043320	piriformis syndrome	pyriformis syndrome	piriformis syndrome	label	edit1
+I_Y_VARIANT	MONDO:0015871	benign breast phyllodes tumor	cystosarcoma phyllode of the breast	cystosarcoma phylloide of the breast	synonym	edit1
+I_Y_VARIANT	MONDO:0015871	benign breast phyllodes tumor	cystosarcoma phylloide of the breast	cystosarcoma phyllode of the breast	synonym	edit1
+I_Y_VARIANT	MONDO:0015871	benign breast phyllodes tumor	phyllode tumour of the breast	phylloide tumour of the breast	synonym	edit1
+I_Y_VARIANT	MONDO:0021047	breast phyllodes tumor	cystosarcoma phyllodes of the breast	cystosarcoma phylloides of the breast	synonym	edit1
+I_Y_VARIANT	MONDO:0021047	breast phyllodes tumor	cystosarcoma phylloides of the breast	cystosarcoma phyllodes of the breast	synonym	edit1
+I_Y_VARIANT	MONDO:0002806	bronchogenic carcinoma	bronchogenic carcinoma	bronchiogenic carcinoma	synonym	edit1
+I_Y_VARIANT	MONDO:0012815	Coats plus syndrome	cerebroretinal microangiopathy with calcfications and cysts	cerebroretinal microangiopathy with calcifications and cysts	synonym	edit1
+I_Y_VARIANT	MONDO:0012815	Coats plus syndrome	cerebroretinal microangiopathy with calcifications and cysts	cerebroretinal microangiopathy with calcfications and cysts	synonym	edit1
+I_Y_VARIANT	MONDO:0020980	hair nevus	hair nevus	hairy nevus	synonym	edit1
+I_Y_VARIANT	MONDO:0006787	hidrocystoma	hidrocystoma	Hydrocystoma	synonym	edit1
+I_Y_VARIANT	MONDO:0007765	hyperostosis cranialis interna	hyperostosis cranialis interna	hyperostosis cranalis interna	synonym	edit1
+I_Y_VARIANT	MONDO:0007808	ichthyosis hystrix of Curth-Macklin	ichthyosis histrix, curth-macklin type	ichthyosis HYSTRIX, Curth-Macklin type	synonym	edit1
+I_Y_VARIANT	MONDO:0018067	triploidy	triploid syndrome	triploidy syndrome	synonym	edit1
+I_Y_VARIANT	MONDO:0018067	triploidy	triploidy syndrome	triploid syndrome	synonym	edit1
+SUBTYPE_CODE	MONDO:0002012	methylmalonic acidemia	METHYLMALONICACIDURIA, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin--Cbl A	METHYLMALONICACIDURIA, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin--Cbl B	synonym	edit1
+SUBTYPE_CODE	MONDO:0002012	methylmalonic acidemia	METHYLMALONICACIDURIA, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin--Cbl B	METHYLMALONICACIDURIA, vitamin B12-responsive, due to defect in synthesis of adenosylcobalamin--Cbl A	synonym	edit1
+SUBTYPE_CODE	MONDO:0009613	methylmalonic aciduria, cblA type	cobalamin A disease	cobalamin B disease	synonym	edit1
+SUBTYPE_CODE	MONDO:0009613	methylmalonic aciduria, cblA type	cobalamin B disease	cobalamin A disease	synonym	edit1
+SUBTYPE_CODE	MONDO:0018938	mucopolysaccharidosis type 4	MPS IV - Morquio syndrome A	MPS IV - Morquio syndrome B	synonym	edit1
+SUBTYPE_CODE	MONDO:0018938	mucopolysaccharidosis type 4	MPS IV - Morquio syndrome B	MPS IV - Morquio syndrome A	synonym	edit1
+SUBTYPE_CODE	MONDO:0018626	paratyphoid fever	paratyphoid fever B	paratyphoid fever A	synonym	edit1
+SUBTYPE_CODE	MONDO:0018626	paratyphoid fever	paratyphoid fever C	paratyphoid fever A	synonym	edit1
+UK_US_SPELLING	MONDO:0024275	amebic dysentery	amoebic dysentery	amebic dysentery	label	edit1
+UK_US_SPELLING	MONDO:0021289	carcinoma in situ of cecum	carcinoma in situ of caecum	carcinoma in situ of cecum	label	edit1
+UK_US_SPELLING	MONDO:0006028	cecum adenocarcinoma	caecum adenocarcinoma	cecum adenocarcinoma	label	edit1
+UK_US_SPELLING	MONDO:0002033	cecum cancer	caecum cancer	cecum cancer	label	edit1
+UK_US_SPELLING	MONDO:0006029	cecum carcinoma	caecum carcinoma	cecum carcinoma	label	edit1
+UK_US_SPELLING	MONDO:0002034	cecum lymphoma	caecum lymphoma	cecum lymphoma	label	edit1
+UK_US_SPELLING	MONDO:0000525	cecum villous adenoma	caecum villous adenoma	cecum villous adenoma	label	edit1
+UK_US_SPELLING	MONDO:0000293	coenurosis	caenurosis	coenurosis	label	edit1
+UK_US_SPELLING	MONDO:0019318	inflammatory linear verrucous epidermal nevus	inflammatory linear verrucous epidermal naevus	inflammatory linear verrucous epidermal nevus	label	edit1
+UK_US_SPELLING	MONDO:0004020	mediastinal gray zone lymphoma	mediastinal Grey zone lymphoma	mediastinal gray zone lymphoma	label	edit1
+UK_US_SPELLING	MONDO:0019326	phakomatosis cesiomarmorata	phakomatosis caesiomarmorata	phakomatosis cesiomarmorata	label	edit1
+UK_US_SPELLING	MONDO:0008233	pheochromocytoma	phaeochromocytoma	pheochromocytoma	label	edit1
+UK_US_SPELLING	MONDO:0005918	placenta praevia	placenta previa	placenta praevia	label	edit1
+UK_US_SPELLING	MONDO:0044793	spitz nevus	spitz naevus	spitz nevus	label	edit1
+UK_US_SPELLING	MONDO:0018442	acitretin/etretinate embryopathy	fetal acitretin syndrome	foetal acitretin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018442	acitretin/etretinate embryopathy	fetal acitretin/etretinate syndrome	foetal acitretin/etretinate syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018442	acitretin/etretinate embryopathy	foetal acitretin syndrome	fetal acitretin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018442	acitretin/etretinate embryopathy	foetal acitretin/etretinate syndrome	fetal acitretin/etretinate syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0022428	aluminosis	aluminium lung	aluminum lung	synonym	edit1
+UK_US_SPELLING	MONDO:0022428	aluminosis	aluminum lung	aluminium lung	synonym	edit1
+UK_US_SPELLING	MONDO:0009934	alveolar capillary dysplasia with misalignment of pulmonary veins	persistent fetal circulation	persistent foetal circulation	synonym	edit1
+UK_US_SPELLING	MONDO:0009934	alveolar capillary dysplasia with misalignment of pulmonary veins	persistent foetal circulation	persistent fetal circulation	synonym	edit1
+UK_US_SPELLING	MONDO:0024275	amebic dysentery	amebic dysenteries	amoebic dysenteries	synonym	edit1
+UK_US_SPELLING	MONDO:0024275	amebic dysentery	amebic dysentery	amoebic dysentery	synonym	edit1
+UK_US_SPELLING	MONDO:0024275	amebic dysentery	amoebic dysenteries	amebic dysenteries	synonym	edit1
+UK_US_SPELLING	MONDO:0024275	amebic dysentery	dysenteries, amebic	dysenteries, amoebic	synonym	edit1
+UK_US_SPELLING	MONDO:0024275	amebic dysentery	dysenteries, amoebic	dysenteries, amebic	synonym	edit1
+UK_US_SPELLING	MONDO:0016004	aminopterin/methotrexate embryofetopathy	fetal aminopterin syndrome	foetal aminopterin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016004	aminopterin/methotrexate embryofetopathy	fetal methotrexate syndrome	foetal methotrexate syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016004	aminopterin/methotrexate embryofetopathy	foetal aminopterin syndrome	fetal aminopterin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016004	aminopterin/methotrexate embryofetopathy	foetal methotrexate syndrome	fetal methotrexate syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0013301	aromatase deficiency	congenital estrogen deficiency	congenital oestrogen deficiency	synonym	edit1
+UK_US_SPELLING	MONDO:0013301	aromatase deficiency	congenital oestrogen deficiency	congenital estrogen deficiency	synonym	edit1
+UK_US_SPELLING	MONDO:0009441	autosomal recessive congenital ichthyosis 1	collodion fetus	collodion foetus	synonym	edit1
+UK_US_SPELLING	MONDO:0009441	autosomal recessive congenital ichthyosis 1	collodion foetus	collodion fetus	synonym	edit1
+UK_US_SPELLING	MONDO:0009443	autosomal recessive congenital ichthyosis 4B	Harlequin fetus	Harlequin foetus	synonym	edit1
+UK_US_SPELLING	MONDO:0009443	autosomal recessive congenital ichthyosis 4B	Harlequin foetus	Harlequin fetus	synonym	edit1
+UK_US_SPELLING	MONDO:0003658	B-cell lymphoma, unclassifiable, with features intermediate between diffuse large b-cell lymphoma and classical Hodgkin lymphoma	Gray zone lymphoma	Grey zone lymphoma	synonym	edit1
+UK_US_SPELLING	MONDO:0003658	B-cell lymphoma, unclassifiable, with features intermediate between diffuse large b-cell lymphoma and classical Hodgkin lymphoma	Grey zone lymphoma	Gray zone lymphoma	synonym	edit1
+UK_US_SPELLING	MONDO:0008874	Bangstad syndrome	Bird-headed dwarfism with progressive ataxia, insulin-resistant diabetes, goiter and primary gonadal insufficiency	Bird-headed dwarfism with progressive ataxia, insulin-resistant diabetes, goitre and primary gonadal insufficiency	synonym	edit1
+UK_US_SPELLING	MONDO:0008874	Bangstad syndrome	Bird-headed dwarfism with progressive ataxia, insulin-resistant diabetes, goitre and primary gonadal insufficiency	Bird-headed dwarfism with progressive ataxia, insulin-resistant diabetes, goiter and primary gonadal insufficiency	synonym	edit1
+UK_US_SPELLING	MONDO:0008870	bird headed-dwarfism, Montreal type	premature senility, premature graying and loss of scalp hair and wrinkled skin of the palms	premature senility, premature greying and loss of scalp hair and wrinkled skin of the palms	synonym	edit1
+UK_US_SPELLING	MONDO:0008870	bird headed-dwarfism, Montreal type	premature senility, premature greying and loss of scalp hair and wrinkled skin of the palms	premature senility, premature graying and loss of scalp hair and wrinkled skin of the palms	synonym	edit1
+UK_US_SPELLING	MONDO:0015265	bronchiolitis obliterans syndrome	organising pneumonia	organizing pneumonia	synonym	edit1
+UK_US_SPELLING	MONDO:0015265	bronchiolitis obliterans syndrome	organizing pneumonia	organising pneumonia	synonym	edit1
+UK_US_SPELLING	MONDO:0040728	Campylobacter fetus infectious disease	infection by Campylobacter fetus	infection by Campylobacter foetus	synonym	edit1
+UK_US_SPELLING	MONDO:0040728	Campylobacter fetus infectious disease	infection by Campylobacter foetus	infection by Campylobacter fetus	synonym	edit1
+UK_US_SPELLING	MONDO:0021289	carcinoma in situ of cecum	caecum carcinoma in situ	cecum carcinoma in situ	synonym	edit1
+UK_US_SPELLING	MONDO:0021289	carcinoma in situ of cecum	cecum carcinoma in situ	caecum carcinoma in situ	synonym	edit1
+UK_US_SPELLING	MONDO:0021289	carcinoma in situ of cecum	stage 0 caecum carcinoma	stage 0 cecum carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0021289	carcinoma in situ of cecum	stage 0 cecum carcinoma	stage 0 caecum carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0010439	cardiomyopathy, fatal fetal, due to myocardial calcification	myocardial calcifications resulting in intrauterine fetal death	myocardial calcifications resulting in intrauterine foetal death	synonym	edit1
+UK_US_SPELLING	MONDO:0010439	cardiomyopathy, fatal fetal, due to myocardial calcification	myocardial calcifications resulting in intrauterine foetal death	myocardial calcifications resulting in intrauterine fetal death	synonym	edit1
+UK_US_SPELLING	MONDO:0005694	cecal neoplasm	caecum neoplasm	cecum neoplasm	synonym	edit1
+UK_US_SPELLING	MONDO:0005694	cecal neoplasm	cecum neoplasm	caecum neoplasm	synonym	edit1
+UK_US_SPELLING	MONDO:0005694	cecal neoplasm	neoplasm of caecum	neoplasm of cecum	synonym	edit1
+UK_US_SPELLING	MONDO:0005694	cecal neoplasm	neoplasm of cecum	neoplasm of caecum	synonym	edit1
+UK_US_SPELLING	MONDO:0006028	cecum adenocarcinoma	cecum adenocarcinoma	caecum adenocarcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0002033	cecum cancer	malignant caecum neoplasm	malignant cecum neoplasm	synonym	edit1
+UK_US_SPELLING	MONDO:0002033	cecum cancer	malignant cecum neoplasm	malignant caecum neoplasm	synonym	edit1
+UK_US_SPELLING	MONDO:0002033	cecum cancer	malignant neoplasm of caecum	malignant neoplasm of cecum	synonym	edit1
+UK_US_SPELLING	MONDO:0002033	cecum cancer	malignant neoplasm of cecum	malignant neoplasm of caecum	synonym	edit1
+UK_US_SPELLING	MONDO:0006029	cecum carcinoma	carcinoma of caecum	carcinoma of cecum	synonym	edit1
+UK_US_SPELLING	MONDO:0006029	cecum carcinoma	carcinoma of cecum	carcinoma of caecum	synonym	edit1
+UK_US_SPELLING	MONDO:0006029	cecum carcinoma	cecum carcinoma	caecum carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0002034	cecum lymphoma	cecum lymphoma	caecum lymphoma	synonym	edit1
+UK_US_SPELLING	MONDO:0002034	cecum lymphoma	lymphoma of caecum	lymphoma of cecum	synonym	edit1
+UK_US_SPELLING	MONDO:0002034	cecum lymphoma	lymphoma of cecum	lymphoma of caecum	synonym	edit1
+UK_US_SPELLING	MONDO:0006126	cecum neuroendocrine tumor G1	caecum NET G1	cecum NET G1	synonym	edit1
+UK_US_SPELLING	MONDO:0006126	cecum neuroendocrine tumor G1	cecum NET G1	caecum NET G1	synonym	edit1
+UK_US_SPELLING	MONDO:0000525	cecum villous adenoma	cecum villous adenoma	caecum villous adenoma	synonym	edit1
+UK_US_SPELLING	MONDO:0012650	Cernunnos-XLF deficiency	combined immunodeficiency-microcephaly-growth retardation-sensitivity to ionising radiation syndrome	combined immunodeficiency-microcephaly-growth retardation-sensitivity to ionizing radiation syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0012650	Cernunnos-XLF deficiency	combined immunodeficiency-microcephaly-growth retardation-sensitivity to ionizing radiation syndrome	combined immunodeficiency-microcephaly-growth retardation-sensitivity to ionising radiation syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0000409	chorioamnionitis	fetal membrane inflammation	foetal membrane inflammation	synonym	edit1
+UK_US_SPELLING	MONDO:0000409	chorioamnionitis	foetal membrane inflammation	fetal membrane inflammation	synonym	edit1
+UK_US_SPELLING	MONDO:0000409	chorioamnionitis	inflammation of fetal membrane	inflammation of foetal membrane	synonym	edit1
+UK_US_SPELLING	MONDO:0000409	chorioamnionitis	inflammation of foetal membrane	inflammation of fetal membrane	synonym	edit1
+UK_US_SPELLING	MONDO:0016007	cocaine embryofetopathy	fetal cocaine syndrome	foetal cocaine syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016007	cocaine embryofetopathy	foetal cocaine syndrome	fetal cocaine syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0013334	cocoon syndrome	fetal encasement syndrome	foetal encasement syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0013334	cocoon syndrome	foetal encasement syndrome	fetal encasement syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018029	congenital factor XIII deficiency	fibrin stabilising factor deficiency	fibrin stabilizing factor deficiency	synonym	edit1
+UK_US_SPELLING	MONDO:0017361	congenital rubella syndrome	fetal rubella syndrome	foetal rubella syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0017361	congenital rubella syndrome	foetal rubella syndrome	fetal rubella syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0007384	congenital trigeminal anesthesia	familial trigeminal anaesthesia	familial trigeminal anesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0007384	congenital trigeminal anesthesia	familial trigeminal anesthesia	familial trigeminal anaesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	fetal effects of chickenpox	foetal effects of chickenpox	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	fetal effects of varicella zoster virus	foetal effects of varicella zoster virus	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	fetal varicella infection	foetal varicella infection	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	fetal varicella zoster syndrome	foetal varicella zoster syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	foetal effects of chickenpox	fetal effects of chickenpox	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	foetal effects of varicella zoster virus	fetal effects of varicella zoster virus	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	foetal varicella infection	fetal varicella infection	synonym	edit1
+UK_US_SPELLING	MONDO:0017372	congenital varicella syndrome	foetal varicella zoster syndrome	fetal varicella zoster syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0015264	cryptogenic organizing pneumonia	idiopathic bronchiolitis obliterans organising pneumonia	idiopathic bronchiolitis obliterans organizing pneumonia	synonym	edit1
+UK_US_SPELLING	MONDO:0015264	cryptogenic organizing pneumonia	idiopathic bronchiolitis obliterans organizing pneumonia	idiopathic bronchiolitis obliterans organising pneumonia	synonym	edit1
+UK_US_SPELLING	MONDO:0015264	cryptogenic organizing pneumonia	organising pneumonia	Organizing Pneumonia	synonym	edit1
+UK_US_SPELLING	MONDO:0016012	diethylstilbestrol syndrome	fetal diethylstilbestrol syndrome	foetal diethylstilbestrol syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016012	diethylstilbestrol syndrome	foetal diethylstilbestrol syndrome	fetal diethylstilbestrol syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0014148	estrogen resistance syndrome	estrogen resistance	oestrogen resistance	synonym	edit1
+UK_US_SPELLING	MONDO:0014148	estrogen resistance syndrome	oestrogen resistance	estrogen resistance	synonym	edit1
+UK_US_SPELLING	MONDO:0006512	estrogen-receptor positive breast cancer	oestrogen receptor positive breast cancer	estrogen receptor positive breast cancer	synonym	edit1
+UK_US_SPELLING	MONDO:0010242	fetal akinesia syndrome, X-linked	foetal akinesia syndrome X-linked	fetal akinesia syndrome X-linked	synonym	edit1
+UK_US_SPELLING	MONDO:0010242	fetal akinesia syndrome, X-linked	X-linked form of fetal akinesia syndrome	X-linked form of foetal akinesia syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0010242	fetal akinesia syndrome, X-linked	X-linked form of foetal akinesia syndrome	X-linked form of fetal akinesia syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	fetal alcohol syndrome	foetal alcohol syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	fetal alcohol syndrome (FAS) - type	foetal alcohol syndrome (FAS) - type	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	foetal alcohol spectrum disorders	fetal alcohol spectrum disorders	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	foetal alcohol syndrome	fetal alcohol syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	foetal alcohol syndrome (FAS) - type	fetal alcohol syndrome (FAS) - type	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	partial fetal alcohol syndrome	partial foetal alcohol syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	partial foetal alcohol syndrome	partial fetal alcohol syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	syndrome, fetal alcohol	syndrome, foetal alcohol	synonym	edit1
+UK_US_SPELLING	MONDO:0000408	fetal alcohol spectrum disorder	syndrome, foetal alcohol	syndrome, fetal alcohol	synonym	edit1
+UK_US_SPELLING	MONDO:0016011	fetal alcohol syndrome	fetal alcohol spectrum disorders	foetal alcohol spectrum disorders	synonym	edit1
+UK_US_SPELLING	MONDO:0016011	fetal alcohol syndrome	foetal alcohol spectrum disorders	fetal alcohol spectrum disorders	synonym	edit1
+UK_US_SPELLING	MONDO:0006760	fetal erythroblastosis	hemolytic disease of the fetus or newborn	hemolytic disease of the foetus or newborn	synonym	edit1
+UK_US_SPELLING	MONDO:0006760	fetal erythroblastosis	hemolytic disease of the foetus or newborn	hemolytic disease of the fetus or newborn	synonym	edit1
+UK_US_SPELLING	MONDO:0005030	fetal growth restriction	fetal SGA	foetal SGA	synonym	edit1
+UK_US_SPELLING	MONDO:0005030	fetal growth restriction	foetal SGA	fetal SGA	synonym	edit1
+UK_US_SPELLING	MONDO:0016008	fetal hydantoin syndrome	fetal dihydantoin syndrome	foetal dihydantoin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016008	fetal hydantoin syndrome	foetal dihydantoin syndrome	fetal dihydantoin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0009224	fetal iodine syndrome	fetal iodine deficiency disorder	foetal iodine deficiency disorder	synonym	edit1
+UK_US_SPELLING	MONDO:0009224	fetal iodine syndrome	foetal iodine deficiency disorder	fetal iodine deficiency disorder	synonym	edit1
+UK_US_SPELLING	MONDO:0011945	Gaucher disease perinatal lethal	fetal Gaucher disease	foetal Gaucher disease	synonym	edit1
+UK_US_SPELLING	MONDO:0011945	Gaucher disease perinatal lethal	foetal Gaucher disease	fetal Gaucher disease	synonym	edit1
+UK_US_SPELLING	MONDO:0005397	goiter	goiter (disease)	goitre (disease)	synonym	edit1
+UK_US_SPELLING	MONDO:0005397	goiter	goitre (disease)	goiter (disease)	synonym	edit1
+UK_US_SPELLING	MONDO:0007681	goiter, multinodular 1, with or without Sertoli-Leydig cell tumors	euthyroid goiter	euthyroid goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0007681	goiter, multinodular 1, with or without Sertoli-Leydig cell tumors	euthyroid goitre	euthyroid goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0007681	goiter, multinodular 1, with or without Sertoli-Leydig cell tumors	simple goiter	simple goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0007681	goiter, multinodular 1, with or without Sertoli-Leydig cell tumors	simple goitre	simple goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0010046	hereditary spastic paraplegia 23	spastic paraplegia vitiligo premature graying and characteristic facies	spastic paraplegia vitiligo premature greying and characteristic facies	synonym	edit1
+UK_US_SPELLING	MONDO:0010046	hereditary spastic paraplegia 23	spastic paraplegia vitiligo premature greying and characteristic facies	spastic paraplegia vitiligo premature graying and characteristic facies	synonym	edit1
+UK_US_SPELLING	MONDO:0021168	hibernoma	fetal fat cell lipoma	foetal fat cell lipoma	synonym	edit1
+UK_US_SPELLING	MONDO:0021168	hibernoma	foetal fat cell lipoma	fetal fat cell lipoma	synonym	edit1
+UK_US_SPELLING	MONDO:0015193	hydrops fetalis	fetal anasarca	foetal anasarca	synonym	edit1
+UK_US_SPELLING	MONDO:0015193	hydrops fetalis	fetal hydrops	foetal hydrops	synonym	edit1
+UK_US_SPELLING	MONDO:0015193	hydrops fetalis	foetal anasarca	fetal anasarca	synonym	edit1
+UK_US_SPELLING	MONDO:0015193	hydrops fetalis	foetal hydrops	fetal hydrops	synonym	edit1
+UK_US_SPELLING	MONDO:0018221	immune hydrops fetalis	immune fetal hydrops	immune foetal hydrops	synonym	edit1
+UK_US_SPELLING	MONDO:0018221	immune hydrops fetalis	immune foetal hydrops	immune fetal hydrops	synonym	edit1
+UK_US_SPELLING	MONDO:0016005	indomethacin embryofetopathy	fetal indomethacin syndrome	foetal indomethacin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016005	indomethacin embryofetopathy	foetal indomethacin syndrome	fetal indomethacin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	Accutane fetal effects of	Accutane foetal effects of	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	Accutane foetal effects of	Accutane fetal effects of	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	fetal isotretinoin syndrome	foetal isotretinoin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	foetal isotretinoin syndrome	fetal isotretinoin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	foetal retinoid syndrome	Fetal Retinoid Syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	Isotretinoin fetal effects of	Isotretinoin foetal effects of	synonym	edit1
+UK_US_SPELLING	MONDO:0016467	isotretinoin syndrome	Isotretinoin foetal effects of	Isotretinoin fetal effects of	synonym	edit1
+UK_US_SPELLING	MONDO:0006567	kernicterus due to isoimmunization	kernicterus due to isoimmunization of fetus or newborn	kernicterus due to isoimmunization of foetus or newborn	synonym	edit1
+UK_US_SPELLING	MONDO:0006567	kernicterus due to isoimmunization	kernicterus due to isoimmunization of foetus or newborn	kernicterus due to isoimmunization of fetus or newborn	synonym	edit1
+UK_US_SPELLING	MONDO:0018864	Kikuchi-Fujimoto disease	histiocytic necrotising lymphadenitis	histiocytic necrotizing lymphadenitis	synonym	edit1
+UK_US_SPELLING	MONDO:0018864	Kikuchi-Fujimoto disease	histiocytic necrotizing lymphadenitis	histiocytic necrotising lymphadenitis	synonym	edit1
+UK_US_SPELLING	MONDO:0001099	lactocele	galactocele	Galactocoele	synonym	edit1
+UK_US_SPELLING	MONDO:0001099	lactocele	Galactocoele	galactocele	synonym	edit1
+UK_US_SPELLING	MONDO:0016611	lipoblastoma	fetal lipoma	foetal lipoma	synonym	edit1
+UK_US_SPELLING	MONDO:0016611	lipoblastoma	foetal lipoma	fetal lipoma	synonym	edit1
+UK_US_SPELLING	MONDO:0021116	luminal A breast carcinoma	Luminal A estrogen receptor positive subtype of breast carcinoma	Luminal A oestrogen receptor positive subtype of breast carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0021116	luminal A breast carcinoma	Luminal A oestrogen receptor positive subtype of breast carcinoma	Luminal A estrogen receptor positive subtype of breast carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0021115	luminal B breast carcinoma	Luminal B estrogen receptor positive subtype of breast carcinoma	Luminal B oestrogen receptor positive subtype of breast carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0021115	luminal B breast carcinoma	Luminal B oestrogen receptor positive subtype of breast carcinoma	Luminal B estrogen receptor positive subtype of breast carcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0018493	malignant hyperthermia of anesthesia	hyperthermia of anaesthesia	hyperthermia of anesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0018493	malignant hyperthermia of anesthesia	hyperthermia of anesthesia	hyperthermia of anaesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0007783	malignant hyperthermia, susceptibility to, 1	hyperthermia of anaesthesia	hyperthermia of anesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0007783	malignant hyperthermia, susceptibility to, 1	hyperthermia of anesthesia	hyperthermia of anaesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0007783	malignant hyperthermia, susceptibility to, 1	malignant hyperthermia of anaesthesia caused by mutation in RYR1	malignant hyperthermia of anesthesia caused by mutation in RYR1	synonym	edit1
+UK_US_SPELLING	MONDO:0007783	malignant hyperthermia, susceptibility to, 1	malignant hyperthermia of anesthesia caused by mutation in RYR1	malignant hyperthermia of anaesthesia caused by mutation in RYR1	synonym	edit1
+UK_US_SPELLING	MONDO:0007783	malignant hyperthermia, susceptibility to, 1	RYR1 malignant hyperthermia of anaesthesia	RYR1 malignant hyperthermia of anesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0007783	malignant hyperthermia, susceptibility to, 1	RYR1 malignant hyperthermia of anesthesia	RYR1 malignant hyperthermia of anaesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0011163	malignant hyperthermia, susceptibility to, 5	CACNA1S malignant hyperthermia of anaesthesia	CACNA1S malignant hyperthermia of anesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0011163	malignant hyperthermia, susceptibility to, 5	CACNA1S malignant hyperthermia of anesthesia	CACNA1S malignant hyperthermia of anaesthesia	synonym	edit1
+UK_US_SPELLING	MONDO:0011163	malignant hyperthermia, susceptibility to, 5	malignant hyperthermia of anaesthesia caused by mutation in CACNA1S	malignant hyperthermia of anesthesia caused by mutation in CACNA1S	synonym	edit1
+UK_US_SPELLING	MONDO:0011163	malignant hyperthermia, susceptibility to, 5	malignant hyperthermia of anesthesia caused by mutation in CACNA1S	malignant hyperthermia of anaesthesia caused by mutation in CACNA1S	synonym	edit1
+UK_US_SPELLING	MONDO:0016017	methimazole embryofetopathy	fetal methimazole syndrome	foetal methimazole syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016017	methimazole embryofetopathy	foetal methimazole syndrome	fetal methimazole syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016509	microcornea-posterior megalolenticonus-persistent fetal vasculature-coloboma syndrome	microcornea posterior megalolenticonus persistent fetal vasculature coloboma	microcornea posterior megalolenticonus persistent foetal vasculature coloboma	synonym	edit1
+UK_US_SPELLING	MONDO:0016509	microcornea-posterior megalolenticonus-persistent fetal vasculature-coloboma syndrome	microcornea posterior megalolenticonus persistent foetal vasculature coloboma	microcornea posterior megalolenticonus persistent fetal vasculature coloboma	synonym	edit1
+UK_US_SPELLING	MONDO:0043143	microphthalmia microtia fetal akinesia	fetal akinesia with characteristic facial appearance, severe microphthalmia, microtia, and truncus arteriosus	foetal akinesia with characteristic facial appearance, severe microphthalmia, microtia, and truncus arteriosus	synonym	edit1
+UK_US_SPELLING	MONDO:0043143	microphthalmia microtia fetal akinesia	foetal akinesia with characteristic facial appearance, severe microphthalmia, microtia, and truncus arteriosus	fetal akinesia with characteristic facial appearance, severe microphthalmia, microtia, and truncus arteriosus	synonym	edit1
+UK_US_SPELLING	MONDO:0007680	multinodular goiter-cystic kidney-polydactyly syndrome	multinodular goiter - cystic kidney - polydactyly	multinodular goitre - cystic kidney - polydactyly	synonym	edit1
+UK_US_SPELLING	MONDO:0007680	multinodular goiter-cystic kidney-polydactyly syndrome	multinodular goitre - cystic kidney - polydactyly	multinodular goiter - cystic kidney - polydactyly	synonym	edit1
+UK_US_SPELLING	MONDO:0005313	necrotizing enterocolitis	necrotizing enterocolitis in fetus or newborn	necrotizing enterocolitis in foetus or newborn	synonym	edit1
+UK_US_SPELLING	MONDO:0005313	necrotizing enterocolitis	necrotizing enterocolitis in foetus or newborn	necrotizing enterocolitis in fetus or newborn	synonym	edit1
+UK_US_SPELLING	MONDO:0043154	neonatal ovarian cyst	fetal ovarian cyst	foetal ovarian cyst	synonym	edit1
+UK_US_SPELLING	MONDO:0043154	neonatal ovarian cyst	foetal ovarian cyst	fetal ovarian cyst	synonym	edit1
+UK_US_SPELLING	MONDO:0006869	nodular goiter	nodular goiter (disease)	nodular goitre (disease)	synonym	edit1
+UK_US_SPELLING	MONDO:0006869	nodular goiter	nodular goitre (disease)	nodular goiter (disease)	synonym	edit1
+UK_US_SPELLING	MONDO:0009369	non-immune hydrops fetalis	non-immune fetal hydrops	non-immune foetal hydrops	synonym	edit1
+UK_US_SPELLING	MONDO:0009369	non-immune hydrops fetalis	non-immune foetal hydrops	non-immune fetal hydrops	synonym	edit1
+UK_US_SPELLING	MONDO:0001658	nontoxic goiter	euthyroid goiter	euthyroid goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0001658	nontoxic goiter	euthyroid goitre	euthyroid goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0010691	Norrie disease	fetal iritis syndrome	foetal iritis syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0010691	Norrie disease	foetal iritis syndrome	fetal iritis syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0008490	otospondylomegaepiphyseal dysplasia, autosomal dominant	Pierre Robin syndrome with fetal chondrodysplasia	Pierre Robin syndrome with foetal chondrodysplasia	synonym	edit1
+UK_US_SPELLING	MONDO:0008490	otospondylomegaepiphyseal dysplasia, autosomal dominant	Pierre Robin syndrome with fetal chondrodysplasia Stickler syndrome, Nonocular type	Pierre Robin syndrome with foetal chondrodysplasia Stickler syndrome, Nonocular type	synonym	edit1
+UK_US_SPELLING	MONDO:0008490	otospondylomegaepiphyseal dysplasia, autosomal dominant	Pierre Robin syndrome with fetal chondrodysplasia Stickler syndrome, Nonocular type, formerly	Pierre Robin syndrome with foetal chondrodysplasia Stickler syndrome, Nonocular type, formerly	synonym	edit1
+UK_US_SPELLING	MONDO:0008490	otospondylomegaepiphyseal dysplasia, autosomal dominant	Pierre Robin syndrome with foetal chondrodysplasia	Pierre Robin syndrome with fetal chondrodysplasia	synonym	edit1
+UK_US_SPELLING	MONDO:0008490	otospondylomegaepiphyseal dysplasia, autosomal dominant	Pierre Robin syndrome with foetal chondrodysplasia Stickler syndrome, Nonocular type	Pierre Robin syndrome with fetal chondrodysplasia Stickler syndrome, Nonocular type	synonym	edit1
+UK_US_SPELLING	MONDO:0008490	otospondylomegaepiphyseal dysplasia, autosomal dominant	Pierre Robin syndrome with foetal chondrodysplasia Stickler syndrome, Nonocular type, formerly	Pierre Robin syndrome with fetal chondrodysplasia Stickler syndrome, Nonocular type, formerly	synonym	edit1
+UK_US_SPELLING	MONDO:0010134	Pendred syndrome	autosomal recessive sensorineural hearing impairment and goiter	autosomal recessive sensorineural hearing impairment and goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0010134	Pendred syndrome	autosomal recessive sensorineural hearing impairment and goitre	autosomal recessive sensorineural hearing impairment and goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0010134	Pendred syndrome	deafness with goiter	deafness with goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0010134	Pendred syndrome	deafness with goitre	deafness with goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0006663	perinatal asphyxia	fetal asphyxia	foetal asphyxia	synonym	edit1
+UK_US_SPELLING	MONDO:0006663	perinatal asphyxia	foetal asphyxia	fetal asphyxia	synonym	edit1
+UK_US_SPELLING	MONDO:0009965	Perlman syndrome	renal hamartomas, nephroblastomatosis and fetal gigantism	renal hamartomas, nephroblastomatosis and foetal gigantism	synonym	edit1
+UK_US_SPELLING	MONDO:0022430	persistent fetal circulation syndrome	persistent fetal circulation	persistent foetal circulation	synonym	edit1
+UK_US_SPELLING	MONDO:0022430	persistent fetal circulation syndrome	persistent foetal circulation	persistent fetal circulation	synonym	edit1
+UK_US_SPELLING	MONDO:0019631	persistent hyperplastic primary vitreous	persistent fetal vasculature syndrome	persistent foetal vasculature syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0019631	persistent hyperplastic primary vitreous	persistent foetal vasculature syndrome	persistent fetal vasculature syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0019326	phakomatosis cesiomarmorata	phakomatosis cesiomarmorata	phakomatosis caesiomarmorata	synonym	edit1
+UK_US_SPELLING	MONDO:0008233	pheochromocytoma	pheochromocytoma	phaeochromocytoma	synonym	edit1
+UK_US_SPELLING	MONDO:0005918	placenta praevia	placenta praevia	placenta previa	synonym	edit1
+UK_US_SPELLING	MONDO:0007382	Ramos-Arroyo syndrome	congenital corneal anaesthesia with retinal abnormalities, deafness, unusual facies, persistent ductus arteriosus, and intellectual disability	congenital corneal anesthesia with retinal abnormalities, deafness, unusual facies, persistent ductus arteriosus, and intellectual disability	synonym	edit1
+UK_US_SPELLING	MONDO:0007382	Ramos-Arroyo syndrome	congenital corneal anaesthesia with retinal abnormalities, deafness, unusual facies, persistent ductus arteriosus, and mental retardation	congenital corneal anesthesia with retinal abnormalities, deafness, unusual facies, persistent ductus arteriosus, and mental retardation	synonym	edit1
+UK_US_SPELLING	MONDO:0007382	Ramos-Arroyo syndrome	congenital corneal anesthesia with retinal abnormalities, deafness, unusual facies, persistent ductus arteriosus, and intellectual disability	congenital corneal anaesthesia with retinal abnormalities, deafness, unusual facies, persistent ductus arteriosus, and intellectual disability	synonym	edit1
+UK_US_SPELLING	MONDO:0800042	restrictive dermopathy 1	fetal hypokinesia sequence due to restrictive dermopathy	foetal hypokinesia sequence due to restrictive dermopathy	synonym	edit1
+UK_US_SPELLING	MONDO:0800042	restrictive dermopathy 1	foetal hypokinesia sequence due to restrictive dermopathy	fetal hypokinesia sequence due to restrictive dermopathy	synonym	edit1
+UK_US_SPELLING	MONDO:0019978	Robinow syndrome	fetal face syndrome	foetal face syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0019978	Robinow syndrome	foetal face syndrome	fetal face syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0100121	SCN4A-related myopathy, autosomal recessive	congenital myopathy with severe fetal hypokinesia	congenital myopathy with severe foetal hypokinesia	synonym	edit1
+UK_US_SPELLING	MONDO:0100121	SCN4A-related myopathy, autosomal recessive	congenital myopathy with severe foetal hypokinesia	congenital myopathy with severe fetal hypokinesia	synonym	edit1
+UK_US_SPELLING	MONDO:0014886	severe growth deficiency-strabismus-extensive dermal melanocytosis-intellectual disability syndrome	neurodevelopmental disorder with microcephaly and gray sclerae	neurodevelopmental disorder with microcephaly and grey sclerae	synonym	edit1
+UK_US_SPELLING	MONDO:0014886	severe growth deficiency-strabismus-extensive dermal melanocytosis-intellectual disability syndrome	neurodevelopmental disorder with microcephaly and grey sclerae	neurodevelopmental disorder with microcephaly and gray sclerae	synonym	edit1
+UK_US_SPELLING	MONDO:0018767	severe primary trimethylaminuria	fish odor syndrome	fish odour syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018767	severe primary trimethylaminuria	fish odour syndrome	fish odor syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0009477	Stromme syndrome	lethal fetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	lethal foetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0009477	Stromme syndrome	lethal foetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	lethal fetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018034	thalidomide embryopathy	fetal thalidomide syndrome	foetal thalidomide syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0018034	thalidomide embryopathy	foetal thalidomide syndrome	fetal thalidomide syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0004460	thyroid gland fetal adenoma	thyroid fetal adenoma	thyroid foetal adenoma	synonym	edit1
+UK_US_SPELLING	MONDO:0004460	thyroid gland fetal adenoma	thyroid foetal adenoma	thyroid fetal adenoma	synonym	edit1
+UK_US_SPELLING	MONDO:0001252	toxic multinodular goitre	Toxic goiter	Toxic goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0001252	toxic multinodular goitre	Toxic goitre	Toxic goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0001252	toxic multinodular goitre	toxic nodular goiter	toxic nodular goitre	synonym	edit1
+UK_US_SPELLING	MONDO:0001252	toxic multinodular goitre	toxic nodular goitre	toxic nodular goiter	synonym	edit1
+UK_US_SPELLING	MONDO:0011182	trimethylaminuria	fish odour syndrome	fish odor syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0019805	twin to twin transfusion syndrome	fetal transfusion syndrome	foetal transfusion syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0019805	twin to twin transfusion syndrome	foetal transfusion syndrome	fetal transfusion syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016010	vitamin K-antagonist embryofetopathy	fetal anticoagulant syndrome	foetal anticoagulant syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016010	vitamin K-antagonist embryofetopathy	fetal Coumadin syndrome	foetal Coumadin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016010	vitamin K-antagonist embryofetopathy	fetal warfarin syndrome	foetal warfarin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016010	vitamin K-antagonist embryofetopathy	foetal anticoagulant syndrome	fetal anticoagulant syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016010	vitamin K-antagonist embryofetopathy	foetal Coumadin syndrome	fetal Coumadin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0016010	vitamin K-antagonist embryofetopathy	foetal warfarin syndrome	fetal warfarin syndrome	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	disease of vitreous humor	disease of vitreous humour	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	disease of vitreous humour	disease of vitreous humor	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	disease or disorder of vitreous humor	disease or disorder of vitreous humour	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	disease or disorder of vitreous humour	disease or disorder of vitreous humor	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	disorder of vitreous humor	disorder of vitreous humour	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	disorder of vitreous humour	disorder of vitreous humor	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	vitreous humor disease	vitreous humour disease	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	vitreous humor disease or disorder	vitreous humour disease or disorder	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	vitreous humour disease	vitreous humor disease	synonym	edit1
+UK_US_SPELLING	MONDO:0004860	vitreous disorder	vitreous humour disease or disorder	vitreous humor disease or disorder	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	fetal adenocarcinoma	foetal adenocarcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	fetal lung adenocarcinoma	foetal lung adenocarcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	foetal adenocarcinoma	fetal adenocarcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	foetal lung adenocarcinoma	fetal lung adenocarcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	pulmonary adenocarcinoma of fetal type	pulmonary adenocarcinoma of foetal type	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	pulmonary adenocarcinoma of foetal type	pulmonary adenocarcinoma of fetal type	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	well-differentiated fetal lung adenocarcinoma	well-differentiated foetal lung adenocarcinoma	synonym	edit1
+UK_US_SPELLING	MONDO:0017292	well-differentiated fetal adenocarcinoma of the lung	well-differentiated foetal lung adenocarcinoma	well-differentiated fetal lung adenocarcinoma	synonym	edit1

--- a/scratch/misspelling-synonyms-audit/classify.py
+++ b/scratch/misspelling-synonyms-audit/classify.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Classify each flagged near-duplicate by WHAT the single edit is, so genuine
+typos separate from legitimate variants (UK/US spelling, c/k, disk/disc,
+acronym/subtype codes, morphology)."""
+import re, sys, unicodedata
+from collections import Counter
+
+def acc(s): return "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+
+# UK/US and transliteration normalizations; if both sides equal after these,
+# the difference is a legitimate spelling-convention variant, not a typo.
+US_RULES = [
+    (r"foetal", "fetal"), (r"oe", "e"), (r"ae", "e"), (r"our\b", "or"),
+    (r"isation", "ization"), (r"ise\b", "ize"), (r"ising\b", "izing"),
+    (r"isers?\b", "izer"), (r"yse\b", "yze"), (r"ysing\b", "yzing"),
+    (r"aluminium", "aluminum"), (r"grey", "gray"), (r"sulph", "sulf"),
+    (r"tumour", "tumor"), (r"humour", "humor"), (r"goitre", "goiter"),
+    (r"centre", "center"), (r"fibre", "fiber"), (r"litre", "liter"),
+    (r"haem", "hem"), (r"leuco", "leuko"), (r"oestr", "estr"),
+    (r"caec", "cec"), (r"anaesth", "anesth"), (r"paediatr", "pediatr"),
+    (r"gynaec", "gynec"), (r"orthopaed", "orthoped"), (r"praevia", "previa"),
+    (r"naev", "nev"), (r"coeli", "celi"), (r"amoeb", "ameb"), (r"caen", "cen"),
+]
+def us(s):
+    s = acc(s).lower()
+    for a, b in US_RULES:
+        s = re.sub(a, b, s)
+    return re.sub(r"[^a-z0-9]+", "", s)
+
+def caps_tokens(s):
+    """Return set of all-caps acronym tokens (>=2 upper chars) in original text."""
+    return set(re.findall(r"\b[A-Z][A-Z0-9]+\b", s))
+
+def single_edit_chars(a, b):
+    """Chars involved in the minimal edit between lowercased a,b (assumes dist<=1
+    or transposition on the collapsed forms)."""
+    a2 = re.sub(r"[^a-z0-9]+", "", acc(a).lower())
+    b2 = re.sub(r"[^a-z0-9]+", "", acc(b).lower())
+    if len(a2) == len(b2):
+        diff = [(x, y) for x, y in zip(a2, b2) if x != y]
+        return set(ch for pair in diff for ch in pair), a2, b2
+    longer, shorter = (a2, b2) if len(a2) > len(b2) else (b2, a2)
+    i = 0
+    while i < len(shorter) and shorter[i] == longer[i]:
+        i += 1
+    return (set([longer[i]]) if i < len(longer) else set()), a2, b2
+
+def classify(term_label, suspect, closest, is_label):
+    # 1) UK/US spelling convention
+    if us(suspect) == us(closest):
+        return "UK_US_SPELLING"
+    chars, a2, b2 = single_edit_chars(suspect, closest)
+    # 2) disk/disc
+    if ("disk" in suspect.lower()) != ("disk" in closest.lower()) and \
+       ("disc" in suspect.lower()) != ("disc" in closest.lower()):
+        return "DISK_DISC"
+    # 3) c<->k substitution (phako/phaco, pycno/pykno, malako/malaco)
+    if chars <= set("ck"):
+        return "C_K_VARIANT"
+    # 4) edit inside an all-caps acronym token that differs -> different code
+    ct_s, ct_c = caps_tokens(suspect), caps_tokens(closest)
+    if ct_s != ct_c:
+        # the differing caps tokens are short codes (TRH/TRF, ASL/ASA, DEB/DDEB)
+        sym = (ct_s | ct_c) - (ct_s & ct_c)
+        if any(len(t) <= 6 for t in sym):
+            return "ACRONYM_CODE"
+    # 5) single trailing type letter/number (subtype code): e.g. "fever A"/"fever C",
+    #    "Ib"/"Ic"; differing char is a lone letter after a space/digit
+    if chars and chars <= set("abcdefghi") and len(chars) <= 2:
+        # check if the differing letter is a standalone type token in either
+        toks_s = suspect.lower().split()
+        toks_c = closest.lower().split()
+        if any(len(t) <= 2 and t.strip("()") in chars for t in toks_s + toks_c):
+            return "SUBTYPE_CODE"
+    # 6) i<->y (piri/pyri) common latinate variant
+    if chars <= set("iy"):
+        return "I_Y_VARIANT"
+    return "TYPO"
+
+def main():
+    rows = []
+    with open("candidates.tsv", encoding="utf-8") as fh:
+        next(fh)
+        for line in fh:
+            p = line.rstrip("\n").split("\t")
+            if len(p) < 6: continue
+            mid, label, suspect, closest, is_label, kind = p[:6]
+            cat = classify(label, suspect, closest, is_label == "label")
+            rows.append((cat, mid, label, suspect, closest, is_label, kind))
+    counts = Counter(r[0] for r in rows)
+    print("=== category counts ===", file=sys.stderr)
+    for c, n in counts.most_common():
+        print(f"{n:5d}  {c}", file=sys.stderr)
+    # write categorized output, TYPO first
+    order = {"TYPO":0}
+    rows.sort(key=lambda r: (order.get(r[0], 9), r[0], not (r[5]=="label"), r[2].lower()))
+    with open("classified.tsv", "w", encoding="utf-8") as out:
+        out.write("category\tmondo_id\tterm_label\tsuspect_synonym\tclosest_correct\tmatch\tedit\n")
+        for r in rows:
+            out.write("\t".join(r) + "\n")
+
+if __name__ == "__main__":
+    main()

--- a/scratch/misspelling-synonyms-audit/detect_misspellings.py
+++ b/scratch/misspelling-synonyms-audit/detect_misspellings.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Detect probable *unmarked* misspelling synonyms in mondo.obo.
+
+Strategy: within each MONDO class, a misspelling synonym is a near-duplicate
+(edit distance 1, or a single adjacent transposition) of the class's own label
+or another correctly-spelled synonym -- AFTER normalizing away legitimate
+lexical variation (UK/US spelling, punctuation/hyphenation, roman<->arabic
+numerals, singular/plural). If two names are identical after aggressive
+normalization, the difference is a legitimate variant, NOT a typo.
+
+Over-normalization only ever removes candidates (false negatives), never adds
+false positives, so we normalize aggressively for the "is it explained?" test.
+"""
+import re
+import sys
+import unicodedata
+from collections import defaultdict
+
+def strip_accents(s: str) -> str:
+    return "".join(c for c in unicodedata.normalize("NFKD", s)
+                   if not unicodedata.combining(c))
+
+OBO = sys.argv[1] if len(sys.argv) > 1 else "mondo.obo"
+
+# ---- parse ----
+terms = []  # list of dict(id, name, obsolete, synonyms=[(text,scope,stype)])
+cur = None
+syn_re = re.compile(r'^synonym:\s+"((?:[^"\\]|\\.)*)"\s+(\S+)(?:\s+(\S+))?')
+
+with open(OBO, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if line == "[Term]":
+            cur = {"id": None, "name": None, "obsolete": False, "synonyms": []}
+            terms.append(cur)
+            continue
+        if line.startswith("[") and line != "[Term]":
+            cur = None  # e.g. [Typedef]
+            continue
+        if cur is None:
+            continue
+        if line.startswith("id: "):
+            cur["id"] = line[4:].strip()
+        elif line.startswith("name: "):
+            cur["name"] = line[6:].strip()
+        elif line.startswith("is_obsolete: true"):
+            cur["obsolete"] = True
+        elif line.startswith("synonym: "):
+            m = syn_re.match(line)
+            if not m:
+                continue
+            text = m.group(1).replace('\\"', '"')
+            scope = m.group(2)
+            third = m.group(3)
+            # third is a synonym-type id only if it does NOT start with '['
+            stype = third if (third and not third.startswith("[")) else None
+            cur["synonyms"].append((text, scope, stype))
+
+terms = [t for t in terms if t["id"] and t["id"].startswith("MONDO:")]
+print(f"parsed {len(terms)} MONDO terms", file=sys.stderr)
+
+# ---- normalization ----
+ROMAN = {"i":"1","ii":"2","iii":"3","iv":"4","v":"5","vi":"6","vii":"7",
+         "viii":"8","ix":"9","x":"10","xi":"11","xii":"12"}
+
+# UK/US and common spelling-convention normalizations (applied to lowered text).
+_SUBS = [
+    ("haemat", "hemat"), ("haem", "hem"), ("aemia", "emia"),
+    ("oesophag", "esophag"), ("oedema", "edema"), ("coeliac", "celiac"),
+    ("paediat", "pediat"), ("paed", "ped"), ("gynaec", "gynec"),
+    ("orthopaed", "orthoped"), ("anaem", "anem"), ("leukaem", "leukem"),
+    ("tumour", "tumor"), ("colour", "color"), ("behaviour", "behavior"),
+    ("fibre", "fiber"), ("centre", "center"),
+    ("isation", "ization"), ("ise", "ize"), ("yse", "yze"),
+    # NB: no bare "oe"/"ae"/"ph" rules -- they fire mid-word (cardioectodermal,
+    # hemangioendothelioma) and, interacting with hyphenation, create spurious
+    # differences (false positives). Specific medical digraph rules above suffice.
+]
+
+_SUFFIX_PATS = [
+    r"(osis|oses)$", r"(iasis|iases)$", r"(omata|oma)$", r"(itides|itis)$",
+    r"(ae|a)$",                     # vagina/vaginae, vertebra/vertebrae
+    r"(i|us)$",                     # nevus/nevi
+    r"(ic|al|ar|ous|ary|ial)$",     # adjective<->noun (urethra/urethral, pelvis/pelvic)
+    r"(es|s)$",                     # generic plural
+]
+
+def _canon_word(w: str) -> str:
+    """Canonicalize a single word by stripping at most one inflectional/
+    derivational suffix, then any remaining trailing vowels, so legitimate
+    variants (Latin plurals, noun/adjective pairs) collapse to a common stem.
+    Only used for the 'is this difference legitimate?' equality test, so
+    over-collapsing only ever drops candidates (never adds false positives)."""
+    if len(w) < 4:
+        return w
+    for pat in _SUFFIX_PATS:
+        new = re.sub(pat, "", w)
+        if new != w and len(new) >= 3:
+            w = new
+            break
+    if len(w) > 4:
+        w = re.sub(r"[aeiou]+$", "", w)
+    return w
+
+def _prep(s: str) -> str:
+    s = strip_accents(s).lower().strip()
+    for a, b in _SUBS:
+        s = s.replace(a, b)
+    return s
+
+def norm_word(s: str) -> str:
+    """Per-word morphological normal form (hyphen == space). Catches internal
+    Latin-plural / noun-adjective variants like 'vaginal cancer'/'vagina cancer'."""
+    s = _prep(s)
+    words = re.findall(r"[a-z0-9]+", s)
+    return "".join(_canon_word(ROMAN.get(w, w)) for w in words)
+
+def norm_concat(s: str) -> str:
+    """Separator-agnostic normal form (hyphen == space == nothing). Catches
+    spacing/hyphenation and concatenation variants like 'Adams-Stokes'/'Adams
+    Stokes' and 'argininosuccinicaciduria'/'argininosuccinic aciduria'."""
+    s = _prep(s)
+    s = re.sub(r"[^a-z0-9]+", "", s)  # drop ALL separators -> one token
+    return _canon_word(s)
+
+def norm_forms(s: str):
+    return (norm_word(s), norm_concat(s))
+
+def norm_light(s: str) -> str:
+    """Light normalization for the typo edit-distance test."""
+    s = s.lower().strip()
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+# ---- damerau-levenshtein with early cutoff ----
+def dl_dist(a: str, b: str, cutoff: int = 2) -> int:
+    la, lb = len(a), len(b)
+    if abs(la - lb) > cutoff:
+        return cutoff + 1
+    prev2 = None
+    prev = list(range(lb + 1))
+    for i in range(1, la + 1):
+        cur = [i] + [0] * lb
+        rowmin = cur[0]
+        for j in range(1, lb + 1):
+            cost = 0 if a[i-1] == b[j-1] else 1
+            v = min(prev[j] + 1, cur[j-1] + 1, prev[j-1] + cost)
+            if (i > 1 and j > 1 and a[i-1] == b[j-2] and a[i-2] == b[j-1]):
+                v = min(v, prev2[j-2] + 1)
+            cur[j] = v
+            if v < rowmin:
+                rowmin = v
+        if rowmin > cutoff:
+            return cutoff + 1
+        prev2, prev = prev, cur
+    return prev[lb]
+
+def is_transposition(a: str, b: str) -> bool:
+    if len(a) != len(b):
+        return False
+    diff = [i for i in range(len(a)) if a[i] != b[i]]
+    return len(diff) == 2 and diff[1] == diff[0] + 1 and a[diff[0]] == b[diff[1]] and a[diff[1]] == b[diff[0]]
+
+def edit_char_classes(a: str, b: str):
+    """Return set of chars involved in the single edit (for filtering digit/roman edits)."""
+    # crude: symmetric difference of char multisets at aligned positions
+    chars = set()
+    # substitution case (equal length)
+    if len(a) == len(b):
+        for x, y in zip(a, b):
+            if x != y:
+                chars.add(x); chars.add(y)
+    else:
+        # indel: the extra char(s)
+        longer, shorter = (a, b) if len(a) > len(b) else (b, a)
+        # find first mismatch
+        i = 0
+        while i < len(shorter) and shorter[i] == longer[i]:
+            i += 1
+        if i < len(longer):
+            chars.add(longer[i])
+    return chars
+
+DIGIT_ROMAN = set("0123456789")
+
+candidates = []  # (term_id, term_name, syn_text, closest_name, closest_is_label, dist, kind)
+
+for t in terms:
+    if t["obsolete"]:
+        continue
+    label = t["name"]
+    if not label:
+        continue
+    # reference names = label + all synonyms (we compare a syn against the OTHERS)
+    ref = [("__label__", label)]
+    for (text, scope, stype) in t["synonyms"]:
+        ref.append((stype, text))
+
+    # precompute both normal forms for every ref
+    ref_norm = [(tag, txt, norm_word(txt), norm_concat(txt)) for (tag, txt) in ref]
+
+    for (text, scope, stype) in t["synonyms"]:
+        # skip already-typed non-plain synonyms and short/abbrev-like
+        if stype in ("MISSPELLING", "ABBREVIATION", "DEPRECATED", "EXCLUDE"):
+            continue
+        light = norm_light(text)
+        if len(light) < 6:
+            continue
+        # subtype numbering tail (e.g. "... 2A2", "type 1A"): captured for filtering
+        m_tail = re.search(r"[0-9]+[a-z]*$", light)
+        light_tail = m_tail.group(0) if m_tail else ""
+        sw, sc = norm_forms(text)
+        if not sc:
+            continue
+        # 1) explained as legitimate variant? either normal form matches a ref
+        explained = False
+        for (tag, rtxt, rw, rc) in ref_norm:
+            if rtxt == text:
+                continue
+            if rw == sw or rc == sc:
+                explained = True
+                break
+        if explained:
+            continue
+        # 2) typo test vs each other ref (light-normalized)
+        best = None
+        for (tag, rtxt, rw, rc) in ref_norm:
+            if rtxt == text:
+                continue
+            rlight = norm_light(rtxt)
+            if rlight == light:
+                continue
+            # reject subtype numbering differences (2A2 vs 2A2A, 1 vs 1A)
+            m_rtail = re.search(r"[0-9]+[a-z]*$", rlight)
+            rtail = m_rtail.group(0) if m_rtail else ""
+            if light_tail != rtail:
+                continue
+            d = dl_dist(light, rlight, cutoff=1)
+            transp = False
+            if d > 1:
+                transp = is_transposition(light, rlight)
+                if not transp:
+                    continue
+            # filter: edits that are purely digit/roman changes = different entity
+            ec = edit_char_classes(light, rlight)
+            if ec & DIGIT_ROMAN:
+                continue
+            # filter: differ only by trailing 's' handled by strong-norm plural already,
+            # but light strings may still: skip pure plural
+            if light.rstrip("s") == rlight.rstrip("s"):
+                continue
+            kind = "transpose" if transp else "edit1"
+            cand = (len(rlight), tag == "__label__", rtxt, kind)
+            if best is None or (cand[1] and not best[1]):  # prefer label match
+                best = cand
+        if best is not None:
+            _, is_label, closest, kind = best
+            candidates.append((t["id"], label, text, closest, is_label, kind))
+
+print(f"found {len(candidates)} candidate unmarked misspellings", file=sys.stderr)
+
+# de-dup and sort: label-matches first (highest confidence)
+candidates.sort(key=lambda c: (not c[4], c[1].lower()))
+with open("candidates.tsv", "w", encoding="utf-8") as out:
+    out.write("mondo_id\tterm_label\tsuspect_synonym\tclosest_correct_name\tclosest_is_label\tedit_kind\n")
+    for c in candidates:
+        out.write("\t".join([c[0], c[1], c[2], c[3], "label" if c[4] else "synonym", c[5]]) + "\n")
+
+print("wrote candidates.tsv", file=sys.stderr)

--- a/scratch/misspelling-synonyms-audit/finalize_typos.py
+++ b/scratch/misspelling-synonyms-audit/finalize_typos.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Final refinement: from classified TYPO rows, dedupe unordered pairs, drop
+per-word plural morphology and subtype/complementation codes, split off UK/US
+& umlaut-transliteration variants, and emit a clean genuine-typo table."""
+import re, sys, unicodedata
+
+def acc(s): return "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+def key(s): return re.sub(r"[^a-z0-9]+","", acc(s).lower())
+def words(s): return re.findall(r"[a-z0-9]+", acc(s).lower())
+
+def per_word_plural(a, b):
+    wa, wb = words(a), words(b)
+    if len(wa) != len(wb): return False
+    diffs = [(x, y) for x, y in zip(wa, wb) if x != y]
+    if len(diffs) != 1: return False
+    x, y = diffs[0]
+    return x == y + "s" or y == x + "s" or \
+           (x.endswith("es") and x[:-2] == y) or (y.endswith("es") and y[:-2] == x) or \
+           (x.endswith("es") and x[:-2]+"is" == y) or (y.endswith("es") and y[:-2]+"is" == x)
+
+def subtype_code(a, b):
+    ka, kb = key(a), key(b)
+    # differing char adjacent to a digit (M6a/M6b, 1A/1B, 6/6A, 3/3a, type2a/2b)
+    n = min(len(ka), len(kb))
+    i = 0
+    while i < n and ka[i] == kb[i]: i += 1
+    # look at a small window around first divergence
+    win = (ka[max(0,i-1):i+2] + kb[max(0,i-1):i+2])
+    if any(c.isdigit() for c in win):
+        return True
+    # complementation/group letter codes on same class: cblA/cblB, group b/c, Etfa/Etfb
+    wa, wb = words(a), words(b)
+    if len(wa) == len(wb):
+        diffs = [(x, y) for x, y in zip(wa, wb) if x != y]
+        if len(diffs) == 1:
+            x, y = diffs[0]
+            if len(x) == len(y) and len(x) <= 4 and x[:-1] == y[:-1] and x[-1] != y[-1]:
+                return True  # short code token differing only in last letter
+    return False
+
+# umlaut/eponym transliteration (o-umlaut->oe/o, etc.) and remaining UK/US
+TRANSLIT = [(r"oe","o"),(r"ae","a"),(r"ue","u")]
+UK2 = [(r"smoulder","smolder"),(r"ageing","aging"),(r"signalling","signaling"),
+       (r"sabre","saber"),(r"oestr","estr"),(r"foetal","fetal")]
+def translit_variant(a, b):
+    def n(s):
+        s = acc(s).lower()
+        for x,y in UK2: s = re.sub(x,y,s)
+        return re.sub(r"[^a-z0-9]+","",s)
+    if n(a) == n(b): return True
+    # umlaut pair: one has oe/ae/ue where other has o/a/u (Schoenberg/Schonberg,
+    # Koenig/Konig, Moebius/Mobius, Loeffler/Loffler, Froehlich/Frohlich)
+    def deumlaut(s):
+        s = acc(s).lower()
+        for x,y in TRANSLIT: s = re.sub(x,y,s)
+        return re.sub(r"[^a-z0-9]+","",s)
+    return deumlaut(a) == deumlaut(b)
+
+rows = []
+with open("classified.tsv", encoding="utf-8") as fh:
+    next(fh)
+    for line in fh:
+        p = line.rstrip("\n").split("\t")
+        if len(p) < 7 or p[0] != "TYPO": continue
+        rows.append(p[1:6])  # mid,label,suspect,closest,match
+
+seen = set(); typo = []; dropped = {"plural":[], "subtype":[], "translit":[]}
+for mid, label, suspect, closest, match in rows:
+    pair = tuple(sorted((key(suspect), key(closest))))
+    if (mid, pair) in seen: continue
+    seen.add((mid, pair))
+    if per_word_plural(suspect, closest): dropped["plural"].append((label,suspect,closest)); continue
+    if subtype_code(suspect, closest): dropped["subtype"].append((label,suspect,closest)); continue
+    if translit_variant(suspect, closest): dropped["translit"].append((label,suspect,closest)); continue
+    lk = key(label)
+    if key(closest) == lk: correct, wrong, anch = closest, suspect, "label"
+    elif key(suspect) == lk: correct, wrong, anch = suspect, closest, "label"
+    else: correct, wrong, anch = closest, suspect, "synonym"
+    typo.append((mid, label, correct, wrong, anch))
+
+typo.sort(key=lambda r: (r[4] != "label", r[1].lower()))
+print(f"genuine TYPO: {len(typo)} (label={sum(1 for r in typo if r[4]=='label')}, "
+      f"synonym={sum(1 for r in typo if r[4]=='synonym')})", file=sys.stderr)
+for k,v in dropped.items(): print(f"dropped[{k}]: {len(v)}", file=sys.stderr)
+with open("typos_final.tsv","w",encoding="utf-8") as out:
+    out.write("mondo_id\tterm_label\tcorrect_form\tmisspelled_synonym\tanchor\n")
+    for r in typo: out.write("\t".join(r)+"\n")
+with open("dropped_translit.tsv","w",encoding="utf-8") as out:
+    out.write("term_label\tform_a\tform_b\n")
+    for l,a,b in dropped["translit"]: out.write(f"{l}\t{a}\t{b}\n")

--- a/scratch/misspelling-synonyms-audit/step2_candidates.tsv
+++ b/scratch/misspelling-synonyms-audit/step2_candidates.tsv
@@ -1,0 +1,251 @@
+mondo_id	correct_term	proposed_misspelling_synonym
+MONDO:0004979	asthma 	asma
+MONDO:0004979	asthma 	athsma
+MONDO:0004979	asthma 	asthama
+MONDO:0004979	asthma 	ashma
+MONDO:0004979	asthma 	astma
+MONDO:0005015	diabetes 	diabetis
+MONDO:0005015	diabetes 	diabeties
+MONDO:0005015	diabetes 	diabetus
+MONDO:0005015	diabetes 	diabetees
+MONDO:0005015	diabetes 	diabetes melitus
+MONDO:0005015	diabetes 	diabetis mellitus
+MONDO:0005249	pneumonia 	newmonia
+MONDO:0005249	pneumonia 	pnumonia
+MONDO:0005249	pneumonia 	pnemonia
+MONDO:0005249	pneumonia 	pneumona
+MONDO:0005249	pneumonia 	neumonia
+MONDO:0004975	Alzheimer disease 	alzeimers disease
+MONDO:0004975	Alzheimer disease 	altzheimers disease
+MONDO:0004975	Alzheimer disease 	alzhiemer disease
+MONDO:0004975	Alzheimer disease 	alzeimer disease
+MONDO:0004975	Alzheimer disease 	alzheimers desease
+MONDO:0005180	Parkinson disease 	parkinsons disease
+MONDO:0005180	Parkinson disease 	parkison disease
+MONDO:0005180	Parkinson disease 	parkinson's desease
+MONDO:0005180	Parkinson disease 	parkingson disease
+MONDO:0004355	leukemia 	leukimia
+MONDO:0004355	leukemia 	lukemia
+MONDO:0004355	leukemia 	leukema
+MONDO:0004355	leukemia 	luekemia
+MONDO:0004355	leukemia 	leukiemia
+MONDO:0005083	psoriasis 	soriasis
+MONDO:0005083	psoriasis 	psorisis
+MONDO:0005083	psoriasis 	sorisis
+MONDO:0005083	psoriasis 	psoriaisis
+MONDO:0005083	psoriasis 	psriasis
+MONDO:0004980	eczema 	exczema
+MONDO:0004980	eczema 	ekzema
+MONDO:0004980	eczema 	eczma
+MONDO:0004980	eczema 	exzema
+MONDO:0004980	eczema 	eggzema
+MONDO:0004277	gonorrhea 	gonorreah
+MONDO:0004277	gonorrhea 	gonorhea
+MONDO:0004277	gonorrhea 	gonorrea
+MONDO:0004277	gonorrhea 	gonnorhea
+MONDO:0004277	gonorrhea 	gonhorrea
+MONDO:0004277	gonorrhea 	gonorreaha
+MONDO:0005976	syphilis 	syphillis
+MONDO:0005976	syphilis 	siphilis
+MONDO:0005976	syphilis 	syphilus
+MONDO:0005976	syphilis 	sifilis
+MONDO:0005976	syphilis 	syphlis
+MONDO:0005976	syphilis 	syphillus
+MONDO:0004872	hemorrhoid 	hemroid
+MONDO:0004872	hemorrhoid 	hemorroid
+MONDO:0004872	hemorrhoid 	hemorhoid
+MONDO:0004872	hemorrhoid 	hemmoroid
+MONDO:0004872	hemorrhoid 	haemorroid
+MONDO:0001673	diarrhea 	diarhea
+MONDO:0001673	diarrhea 	diarrea
+MONDO:0001673	diarrhea 	diahrrea
+MONDO:0001673	diarrhea 	diarreah
+MONDO:0001673	diarrhea 	diarhoea
+MONDO:0005578	arthritis 	arthritus
+MONDO:0005578	arthritis 	arthiritis
+MONDO:0005578	arthritis 	athritis
+MONDO:0005578	arthritis 	arthrytis
+MONDO:0005578	arthritis 	arthirtis
+MONDO:0005277	migraine 	migrane
+MONDO:0005277	migraine 	migraene
+MONDO:0005277	migraine 	migrain
+MONDO:0005277	migraine 	migrainne
+MONDO:0005277	migraine 	migreine
+MONDO:0005090	schizophrenia 	schizophernia
+MONDO:0005090	schizophrenia 	skitzophrenia
+MONDO:0005090	schizophrenia 	schitzophrenia
+MONDO:0005090	schizophrenia 	schizofrenia
+MONDO:0005090	schizophrenia 	schizoprenia
+MONDO:0018076	tuberculosis 	tuberculosus
+MONDO:0018076	tuberculosis 	tubercolosis
+MONDO:0018076	tuberculosis 	tubersculosis
+MONDO:0018076	tuberculosis 	tuburculosis
+MONDO:0005546	fibromyalgia 	fibromialgia
+MONDO:0005546	fibromyalgia 	fibromyaglia
+MONDO:0005546	fibromyalgia 	fibermyalgia
+MONDO:0005546	fibromyalgia 	fibromyalga
+MONDO:0005027	epilepsy 	epilepsi
+MONDO:0005027	epilepsy 	epillepsy
+MONDO:0005027	epilepsy 	epalepsy
+MONDO:0005027	epilepsy 	epilipsy
+MONDO:0005027	epilepsy 	epelepsy
+MONDO:0005301	multiple sclerosis 	multiple schlerosis
+MONDO:0005301	multiple sclerosis 	multiple sclerois
+MONDO:0005301	multiple sclerosis 	multiple sclorosis
+MONDO:0021108	meningitis 	meningitus
+MONDO:0021108	meningitis 	menningitis
+MONDO:0021108	meningitis 	meningites
+MONDO:0021108	meningitis 	meningtis
+MONDO:0003781	bronchitis 	bronchitus
+MONDO:0003781	bronchitis 	broncitis
+MONDO:0003781	bronchitis 	brochitis
+MONDO:0003781	bronchitis 	bronchities
+MONDO:0002251	hepatitis 	hepititis
+MONDO:0002251	hepatitis 	hepatitus
+MONDO:0002251	hepatitis 	hepetitis
+MONDO:0002251	hepatitis 	hepatities
+MONDO:0005155	cirrhosis 	cirosis
+MONDO:0005155	cirrhosis 	cirrosis
+MONDO:0005155	cirrhosis 	cirrohsis
+MONDO:0005155	cirrhosis 	sirrhosis
+MONDO:0005155	cirrhosis 	cirhosis
+MONDO:0005041	glaucoma 	glacoma
+MONDO:0005041	glaucoma 	glaukoma
+MONDO:0005041	glaucoma 	glacuoma
+MONDO:0005041	glaucoma 	glaocoma
+MONDO:0005298	osteoporosis 	osteoperosis
+MONDO:0005298	osteoporosis 	osteoporosos
+MONDO:0005298	osteoporosis 	ostioporosis
+MONDO:0005298	osteoporosis 	osteoprosis
+MONDO:0005298	osteoporosis 	osteporosis
+MONDO:0005812	influenza 	influensa
+MONDO:0005812	influenza 	influena
+MONDO:0005812	influenza 	infuenza
+MONDO:0005812	influenza 	influeza
+MONDO:0004619	measles 	measels
+MONDO:0004619	measles 	meesles
+MONDO:0004619	measles 	meazles
+MONDO:0004619	measles 	measales
+MONDO:0005649	appendicitis 	appendicitus
+MONDO:0005649	appendicitis 	apendicitis
+MONDO:0005649	appendicitis 	appendisitis
+MONDO:0005649	appendicitis 	appendicites
+MONDO:0004235	diverticulitis 	diverticulitus
+MONDO:0004235	diverticulitis 	divirticulitis
+MONDO:0004235	diverticulitis 	diverticulits
+MONDO:0024333	sciatica 	syatica
+MONDO:0024333	sciatica 	siatica
+MONDO:0024333	sciatica 	schiatica
+MONDO:0024333	sciatica 	siyatica
+MONDO:0024333	sciatica 	sciatca
+MONDO:0005133	endometriosis 	endometriosus
+MONDO:0005133	endometriosis 	endometreosis
+MONDO:0005133	endometriosis 	endrometriosis
+MONDO:0005133	endometriosis 	endometrios
+MONDO:0008383	rheumatoid arthritis 	rheumetoid arthritis
+MONDO:0008383	rheumatoid arthritis 	rhumatoid arthritis
+MONDO:0008383	rheumatoid arthritis 	rheumatiod arthritis
+MONDO:0008383	rheumatoid arthritis 	rheumotoid arthritis
+MONDO:0005105	melanoma 	melanona
+MONDO:0005105	melanoma 	melenoma
+MONDO:0005105	melanoma 	melanomia
+MONDO:0005105	melanoma 	melinoma
+MONDO:0001627	dementia 	dementiia
+MONDO:0001627	dementia 	dimentia
+MONDO:0001627	dementia 	dementa
+MONDO:0001627	dementia 	demensia
+MONDO:0002280	anemia 	anemea
+MONDO:0002280	anemia 	anemya
+MONDO:0002280	anemia 	anaemea
+MONDO:0002280	anemia 	aneamia
+MONDO:0005392	scoliosis 	scoleosis
+MONDO:0005392	scoliosis 	scholiosis
+MONDO:0005392	scoliosis 	scoliois
+MONDO:0005392	scoliosis 	skoliosis
+MONDO:0011849	psoriatic arthritis 	psoriatic arthritus
+MONDO:0011849	psoriatic arthritis 	soriatic arthritis
+MONDO:0007661	Tourette syndrome 	tourettes syndrome
+MONDO:0007661	Tourette syndrome 	tourrette syndrome
+MONDO:0007661	Tourette syndrome 	torettes syndrome
+MONDO:0005011	Crohn disease 	chrons disease
+MONDO:0005011	Crohn disease 	chron disease
+MONDO:0005011	Crohn disease 	crohns desease
+MONDO:0005011	Crohn disease 	crohn's desease
+MONDO:0005130	celiac disease 	celiacs disease
+MONDO:0005130	celiac disease 	cileac disease
+MONDO:0005130	celiac disease 	coeliacs disease
+MONDO:0005393	gout 	goute
+MONDO:0005609	shingles 	shingels
+MONDO:0005077	pertussis 	pertusis
+MONDO:0005077	pertussis 	pertussus
+MONDO:0005077	pertussis 	pertusiss
+MONDO:0018660	hemophilia 	hemophelia
+MONDO:0018660	hemophilia 	hemofilia
+MONDO:0018660	hemophilia 	haemophelia
+MONDO:0018660	hemophilia 	hemophillia
+MONDO:0005068	myocardial infarction 	myocardial infarcation
+MONDO:0005068	myocardial infarction 	myocardial infartion
+MONDO:0005068	myocardial infarction 	myocardial infraction
+MONDO:0005420	hypothyroidism 	hypthyroidism
+MONDO:0005420	hypothyroidism 	hypothroidism
+MONDO:0005420	hypothyroidism 	hypothyrodism
+MONDO:0004425	hyperthyroidism 	hyperthroidism
+MONDO:0004425	hyperthyroidism 	hyperthyrodism
+MONDO:0008608	Down syndrome 	downs syndrome
+MONDO:0008608	Down syndrome 	down's syndrom
+MONDO:0009061	cystic fibrosis 	sistic fibrosis
+MONDO:0009061	cystic fibrosis 	cystic fibrossis
+MONDO:0005159	prostate cancer 	prostrate cancer
+MONDO:0010200	Wilson disease 	wilsons disease
+MONDO:0010200	Wilson disease 	wilson's desease
+MONDO:0005700	varicella 	varicela
+MONDO:0005700	varicella 	varacella
+MONDO:0016218	Guillain-Barre syndrome 	guillian-barre syndrome
+MONDO:0016218	Guillain-Barre syndrome 	gullian-barre syndrome
+MONDO:0016218	Guillain-Barre syndrome 	guillian barre syndrome
+MONDO:0016218	Guillain-Barre syndrome 	gullain-barre syndrome
+MONDO:0016218	Guillain-Barre syndrome 	guillaine-barre syndrome
+MONDO:0016218	Guillain-Barre syndrome 	gillian-barre syndrome
+MONDO:0020066	Ehlers-Danlos syndrome 	ehler-danlos syndrome
+MONDO:0020066	Ehlers-Danlos syndrome 	elhers-danlos syndrome
+MONDO:0020066	Ehlers-Danlos syndrome 	ehlers danlos syndrom
+MONDO:0020066	Ehlers-Danlos syndrome 	ehlers-danos syndrome
+MONDO:0004976	amyotrophic lateral sclerosis 	amyotropic lateral sclerosis
+MONDO:0004976	amyotrophic lateral sclerosis 	amytrophic lateral sclerosis
+MONDO:0004976	amyotrophic lateral sclerosis 	amyotrophic lateral sclerosus
+MONDO:0011382	sickle cell anemia 	sicle cell anemia
+MONDO:0011382	sickle cell anemia 	sickel cell anemia
+MONDO:0011382	sickle cell anemia 	sikle cell anemia
+MONDO:0012727	Kawasaki disease 	kawaski disease
+MONDO:0012727	Kawasaki disease 	kawasaky disease
+MONDO:0012727	Kawasaki disease 	kawazaki disease
+MONDO:0010030	Sjogren syndrome 	sjogrens syndrome
+MONDO:0010030	Sjogren syndrome 	showgren syndrome
+MONDO:0010030	Sjogren syndrome 	sjorgens syndrome
+MONDO:0010030	Sjogren syndrome 	sjogren's syndrom
+MONDO:0010030	Sjogren syndrome 	shogren syndrome
+MONDO:0007739	Huntington disease 	huntingtons disease
+MONDO:0007739	Huntington disease 	huntingdon disease
+MONDO:0007739	Huntington disease 	hutington disease
+MONDO:0007739	Huntington disease 	huntinton disease
+MONDO:0010679	Duchenne muscular dystrophy 	duchennes muscular dystrophy
+MONDO:0010679	Duchenne muscular dystrophy 	duchene muscular dystrophy
+MONDO:0010679	Duchenne muscular dystrophy 	duchenne muscular dystropy
+MONDO:0010679	Duchenne muscular dystrophy 	duschenne muscular dystrophy
+MONDO:0010100	Tay-Sachs disease 	taysachs disease
+MONDO:0010100	Tay-Sachs disease 	tay-sach disease
+MONDO:0010100	Tay-Sachs disease 	tay-sachs desease
+MONDO:0010100	Tay-Sachs disease 	taysachs desease
+MONDO:0006497	cerebral palsy 	cerebal palsy
+MONDO:0006497	cerebral palsy 	cerebral palsey
+MONDO:0006497	cerebral palsy 	cerebral paulsy
+MONDO:0006497	cerebral palsy 	celebral palsy
+MONDO:0005700	chickenpox 	chiken pox
+MONDO:0005700	chickenpox 	chikenpox
+MONDO:0004980	eczema 	exczema
+MONDO:0004980	eczema 	ekzema
+MONDO:0004980	eczema 	eczma
+MONDO:0004980	eczema 	exzema
+MONDO:0004980	eczema 	eggzema
+MONDO:0005609	shingles 	shingels
+MONDO:0005609	shingles 	shinges

--- a/scratch/misspelling-synonyms-audit/step2_check.py
+++ b/scratch/misspelling-synonyms-audit/step2_check.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Step 2: check curated common disease misspellings against MONDO.
+Report those ABSENT from MONDO (candidates to add), with the MONDO id of the
+correct term."""
+import re, unicodedata, sys
+def acc(s): return "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+def norm(s): return re.sub(r"\s+"," ", acc(s).lower().strip())
+
+name2id={}; allnames=set()
+syn_re=re.compile(r'^synonym:\s+"((?:[^"\\]|\\.)*)"')
+cur=None; cid=None; clabel=None
+with open("mondo.obo") as f:
+    for line in f:
+        line=line.rstrip("\n")
+        if line=="[Term]": cur=True; cid=None; clabel=None; continue
+        if line.startswith("[") and line!="[Term]": cur=None; continue
+        if not cur: continue
+        if line.startswith("id: "): cid=line[4:].strip()
+        elif line.startswith("name: "):
+            clabel=line[6:].strip()
+            if cid and cid.startswith("MONDO:"):
+                allnames.add(norm(clabel)); name2id.setdefault(norm(clabel),(cid,clabel))
+        elif line.startswith("synonym: "):
+            m=syn_re.match(line)
+            if m and cid and cid.startswith("MONDO:"):
+                s=norm(m.group(1).replace('\\"','"'))
+                allnames.add(s)
+                # map a synonym to its MONDO class+label so seed terms that are
+                # synonyms (eczema, shingles) still resolve to a MONDO id
+                name2id.setdefault(s,(cid,clabel))
+
+# curated seed: (correct term as it appears in MONDO, [common misspellings])
+SEED = [
+ ("asthma", ["asma","athsma","asthama","ashma","astma"]),
+ ("diabetes mellitus", []),
+ ("diabetes", ["diabetis","diabeties","diabetus","diabetees","diabetes melitus","diabetis mellitus"]),
+ ("pneumonia", ["newmonia","pnumonia","pnemonia","pneumonia ","pneumona","neumonia"]),
+ ("Alzheimer disease", ["alzeimers disease","altzheimers disease","alzhiemer disease","alzeimer disease","alzheimers desease"]),
+ ("Parkinson disease", ["parkinsons disease","parkison disease","parkinson's desease","parkingson disease"]),
+ ("leukemia", ["leukimia","lukemia","leukema","luekemia","leukiemia"]),
+ ("psoriasis", ["soriasis","psorisis","sorisis","psoriaisis","psriasis"]),
+ ("eczema", ["exczema","ekzema","eczma","exzema","eggzema"]),
+ ("gonorrhea", ["gonorreah","gonorhea","gonorrea","gonnorhea","gonhorrea","gonorreaha"]),
+ ("syphilis", ["syphillis","siphilis","syphilus","sifilis","syphlis","syphillus"]),
+ ("hemorrhoid", ["hemroid","hemorroid","hemorhoid","hemmoroid","haemorroid"]),
+ ("diarrhea", ["diarhea","diarrea","diahrrea","diarreah","diarhoea"]),
+ ("arthritis", ["arthritus","arthiritis","athritis","arthrytis","arthirtis"]),
+ ("migraine", ["migrane","migraene","migrain","migrainne","migreine"]),
+ ("schizophrenia", ["schizophernia","skitzophrenia","schitzophrenia","schizofrenia","schizoprenia"]),
+ ("tuberculosis", ["tuberculosus","tubercolosis","tubersculosis","tuburculosis"]),
+ ("fibromyalgia", ["fibromialgia","fibromyaglia","fibermyalgia","fibromyalga"]),
+ ("epilepsy", ["epilepsi","epillepsy","epalepsy","epilipsy","epelepsy"]),
+ ("multiple sclerosis", ["multiple schlerosis","multiple sclerois","multiple sclorosis"]),
+ ("meningitis", ["meningitus","menningitis","meningites","meningtis"]),
+ ("bronchitis", ["bronchitus","broncitis","brochitis","bronchities"]),
+ ("hepatitis", ["hepititis","hepatitus","hepetitis","hepatities"]),
+ ("cirrhosis", ["cirosis","cirrosis","cirrohsis","sirrhosis","cirhosis"]),
+ ("glaucoma", ["glacoma","glaukoma","glacuoma","glaocoma"]),
+ ("osteoporosis", ["osteoperosis","osteoporosos","ostioporosis","osteoprosis","osteporosis"]),
+ ("influenza", ["influensa","influena","infuenza","influeza"]),
+ ("measles", ["measels","meesles","meazles","measales"]),
+ ("appendicitis", ["appendicitus","apendicitis","appendisitis","appendicites"]),
+ ("diverticulitis", ["diverticulitus","divirticulitis","diverticulits"]),
+ ("sciatica", ["syatica","siatica","schiatica","siyatica","sciatca"]),
+ ("endometriosis", ["endometriosus","endometreosis","endrometriosis","endometrios"]),
+ ("rheumatoid arthritis", ["rheumetoid arthritis","rhumatoid arthritis","rheumatiod arthritis","rheumotoid arthritis"]),
+ ("melanoma", ["melanona","melenoma","melanomia","melinoma"]),
+ ("dementia", ["dementiia","dimentia","dementa","demensia"]),
+ ("anemia", ["anemea","anemya","anaemea","aneamia"]),
+ ("vertigo", ["vertico","vertago"]),
+ ("chlamydia", ["clamidia","chlamidia","clamydia","chlymidia","chalmydia"]),
+ ("herpes", ["herpies","herpese","hurpes"]),
+ ("HIV infection", []),
+ ("scoliosis", ["scoleosis","scholiosis","scoliois","skoliosis"]),
+ ("psoriatic arthritis", ["psoriatic arthritus","soriatic arthritis"]),
+ ("Tourette syndrome", ["tourettes syndrome","tourrette syndrome","torettes syndrome","tourette's syndrome"]),
+ ("Crohn disease", ["chrons disease","chron disease","crohns desease","crohn's desease"]),
+ ("celiac disease", ["celiacs disease","cileac disease","coeliacs disease"]),
+ ("gout", ["goute"]),
+ ("shingles", ["shingels"]),
+ ("pertussis", ["pertusis","pertussus","pertusiss"]),
+ ("hemophilia", ["hemophelia","hemofilia","haemophelia","hemophillia"]),
+ ("leukemia, acute lymphoblastic", []),
+ ("myocardial infarction", ["myocardial infarcation","myocardial infartion","myocardial infraction"]),
+ ("hypothyroidism", ["hypthyroidism","hypothroidism","hypothyroidism ","hypothyrodism"]),
+ ("hyperthyroidism", ["hyperthroidism","hyperthyrodism"]),
+ ("Down syndrome", ["downs syndrome","down's syndrom"]),
+ ("cystic fibrosis", ["cystic fibrosis ","sistic fibrosis","cystic fibrossis"]),
+ ("prostate cancer", ["prostrate cancer"]),
+ ("Achilles tendinitis", ["achilles tendonitis","achiles tendinitis"]),
+ ("Wilson disease", ["wilsons disease","wilson's desease"]),
+ ("varicella", ["varicela","varacella"]),
+ # notoriously-misspelled eponymous / hard names
+ ("Guillain-Barre syndrome", ["guillian-barre syndrome","gullian-barre syndrome","guillian barre syndrome","gullain-barre syndrome","guillaine-barre syndrome","gillian-barre syndrome"]),
+ ("Ehlers-Danlos syndrome", ["ehler-danlos syndrome","elhers-danlos syndrome","ehlers danlos syndrom","ehler danlos syndrome","ehlers-danos syndrome"]),
+ ("amyotrophic lateral sclerosis", ["amyotropic lateral sclerosis","amytrophic lateral sclerosis","amyotrophic lateral sclerosus"]),
+ ("sickle cell anemia", ["sicle cell anemia","sickel cell anemia","sikle cell anemia"]),
+ ("Kawasaki disease", ["kawaski disease","kawasaky disease","kawazaki disease"]),
+ ("Sjogren syndrome", ["sjogrens syndrome","showgren syndrome","sjorgens syndrome","sjogren's syndrom","shogren syndrome"]),
+ ("Huntington disease", ["huntingtons disease","huntingdon disease","hutington disease","huntinton disease"]),
+ ("Duchenne muscular dystrophy", ["duchennes muscular dystrophy","duchene muscular dystrophy","duchenne muscular dystropy","duschenne muscular dystrophy"]),
+ ("Tay-Sachs disease", ["tay sachs disease","taysachs disease","tay-sach disease","tay-sachs desease","taysachs desease"]),
+ ("cerebral palsy", ["cerebal palsy","cerebral palsey","cerebral paulsy","celebral palsy"]),
+ ("hypertension", ["hypertention","hyertension","hypertentions"]),
+ ("chickenpox", ["chiken pox","chikenpox"]),
+ ("eczema", ["exczema","ekzema","eczma","exzema","eggzema"]),
+ ("shingles", ["shingels","shinges"]),
+]
+
+rows=[]
+for correct,misspellings in SEED:
+    ident=name2id.get(norm(correct))
+    for ms in misspellings:
+        if norm(ms) in allnames: continue    # already present
+        rows.append((correct, ident[0] if ident else "?", ms))
+# only keep ones whose correct term resolves in MONDO
+rows=[r for r in rows if r[1]!="?"]
+print(f"absent common misspellings (correct term in MONDO): {len(rows)}\n")
+cur=None
+for correct,mid,ms in rows:
+    if correct!=cur: print(f"\n{correct}  [{mid}]"); cur=correct
+    print(f"    + {ms}")
+# also flag seeds whose 'correct' didn't resolve (so I can fix the seed)
+missing=[c for c,_ in SEED if norm(c) not in name2id]
+if missing: print("\n[seed correct-terms NOT found as a MONDO label]:", missing)

--- a/scratch/misspelling-synonyms-audit/typos_final.tsv
+++ b/scratch/misspelling-synonyms-audit/typos_final.tsv
@@ -1,0 +1,139 @@
+mondo_id	term_label	correct_form	misspelled_synonym	anchor
+MONDO:0008306	ABri amyloidosis	ABri amyloidosis	Bri amyloidosis	label
+MONDO:0008830	aspartylglucosaminuria	aspartylglucosaminuria	Aspartylglycosaminuria	label
+MONDO:0019187	Axenfeld-Rieger syndrome	Axenfeld-Rieger syndrome	Axenfeldt-Rieger syndrome	label
+MONDO:0007339	blepharocheilodontic syndrome	blepharo-cheilo-dontic syndrome	blepharo-cheilo-odontic syndrome	label
+MONDO:0022013	Boerhaave syndrome	Boerhaave syndrome	Boerhave syndrome	label
+MONDO:0100492	Bonnevie-Ullrich syndrome	Bonnevie-Ullrich syndrome	Bonnevie-Ulrich syndrome	label
+MONDO:0008904	camptomelic syndrome, long-limb type	Camptomelic syndrome long limb type	campomelic syndrome long limb type	label
+MONDO:0007542	Camurati-Engelmann disease	Camurati-Engelmann disease	Camurati-Englemann disease	label
+MONDO:0003736	cancerophobia	cancerophobia	Cancerphobia	label
+MONDO:0007432	cerebral arteriopathy with subcortical infarcts and leukoencephalopathy	cerebral arteriopathy with subcortical infarcts and leukoencephalopathy	cerebral arteriopathy with subcortical infaracts and leukoencephalopathy	label
+MONDO:0019149	cholesteryl ester storage disease	cholesteryl ester storage disease	cholesterol ester storage disease	label
+MONDO:0019809	congenital aortic valve insufficiency	congenital aortic valve insufficiency	Congential aortic valve insufficiency	label
+MONDO:0017463	congenital pseudoarthrosis of the femur	congenital pseudoarthrosis of the femur	congenital pseudarthrosis of the femur	label
+MONDO:0017464	congenital pseudoarthrosis of the fibula	congenital pseudoarthrosis of the fibula	congenital pseudarthrosis of the fibula	label
+MONDO:0015525	congenital pseudoarthrosis of the limbs	congenital pseudoarthrosis of the limbs	congenital pseudarthrosis of the limbs	label
+MONDO:0017465	congenital pseudoarthrosis of the radius	congenital pseudoarthrosis of the radius	congenital pseudarthrosis of the radius	label
+MONDO:0017462	congenital pseudoarthrosis of the tibia	congenital pseudoarthrosis of the tibia	congenital pseudarthrosis of the tibia	label
+MONDO:0017466	congenital pseudoarthrosis of the ulna	congenital pseudoarthrosis of the ulna	congenital pseudarthrosis of the ulna	label
+MONDO:0008338	contractures, pterygia, and spondylocarpotarsal fusion syndrome 1A	contractures, pterygia, and spondylocarpotarsal fusion syndrome 1A	contractures, pterygia, and spondylocarpostarsal fusion syndrome 1A	label
+MONDO:0005413	cystic fibrosis associated meconium ileus	cystic fibrosis associated meconium ileus	cystic fibrosis associated meconium ileum	label
+MONDO:0005029	essential thrombocythemia	essential thrombocythemia	essential thrombocytemia	label
+MONDO:0060589	facial palsy, congenital, with ptosis and velopharyngeal dysfunction	facial palsy, congenital, with ptosis and velopharyngeal dysfunction	facial palsy, congenitla, with ptosis and velopharyngeal dysfunction	label
+MONDO:0013601	gluthathione peroxidase deficiency	gluthathione peroxidase deficiency	glutathione peroxidase deficiency	label
+MONDO:0010768	gonadoblastoma	gonadoblastoma	gonad blastoma	label
+MONDO:0021022	hereditary hyperekplexia	hereditary hyperekplexia	hereditary hyperexplexia	label
+MONDO:0016344	hydranencephaly	hydranencephaly	Hydroanencephaly	label
+MONDO:0033547	Li-Ghorbani-Weisz-Hubshman syndrome	Li-Ghorbani-Weisz-Hubshman syndrome	Li-Ghorgani-Weisz-Hubshman syndrome	label
+MONDO:0018856	lichen amyloidosis	lichen amyloidosis	lichen amyloidosus	label
+MONDO:0007899	lichen sclerosus et atrophicus	lichen sclerosus et atrophicus	lichen sclerosis et atrophicus	label
+MONDO:0009530	lipoid proteinosis	lipoid proteinosis	lipid proteinosis	label
+MONDO:0005060	liposarcoma	liposarcoma	lip sarcoma	label
+MONDO:0004332	lung hilum cancer	lung hilum cancer	lung hilus cancer	label
+MONDO:0004499	lung hilum carcinoma	lung hilum carcinoma	lung hilus carcinoma	label
+MONDO:0003639	lung hilum neoplasm	lung hilum neoplasm	lung hilus neoplasm	label
+MONDO:0004387	luteoma of pregnancy	luteoma of pregnancy	leuteoma of pregnancy	label
+MONDO:0010476	neurodegeneration with brain iron accumulation 5	neurodegeneration with brain iron accumulation 5	neurodegeneration with brain iron accululation 5	label
+MONDO:0031010	odontochondrodysplasia 2 with hearing loss and diabetes	odontochondrodysplasia 2 with hearing loss and diabetes	ondontochondrodysplasia 2 with hearing loss and diabetes	label
+MONDO:0008975	otospondylomegaepiphyseal dysplasia	otospondylomegaepiphyseal dysplasia	otospondylmegaepiphyseal dysplasia	label
+MONDO:0700088	paroxysmal nonkinesigenic dyskinesia	paroxysmal nonkinesigenic dyskinesia	Paroxysomal nonkinesigenic dyskinesia	label
+MONDO:0001042	patellar tendinitis	patellar tendinitis	patellar tendonitis	label
+MONDO:0007564	pilomatrixoma	pilomatrixoma	pilomatricoma	label
+MONDO:0015388	polyrrhinia	polyrrhinia	Polyrhinia	label
+MONDO:0017416	postpoliomyelitis syndrome	postpoliomyelitis syndrome	postpoliomyelitic syndrome	label
+MONDO:0009726	proteosome-associated autoinflammatory syndrome	proteosome-associated autoinflammatory syndrome	proteasome-associated autoinflammatory syndrome	label
+MONDO:0006969	sialadenitis	sialadenitis	sialoadenitis	label
+MONDO:0005095	spondyloarthropathy	spondyloarthropathy	spondylarthropathy	label
+MONDO:0006988	sulfhemoglobinemia	sulfhemoglobinemia	Sulfemoglobinemia	label
+MONDO:0010434	synovial sarcoma	synovial sarcoma	Synovialosarcoma	label
+MONDO:0004857	tendinitis	tendinitis	tendonitis	label
+MONDO:0006469	tibial adamantinoma	tibial adamantinoma	tibia adamantinoma	label
+MONDO:0001039	tonsillitis	tonsillitis	tonsilitis	label
+MONDO:0019085	vernal keratoconjunctivitis	vernal keratoconjunctivitis	Vernal Keratonconjunctivitis	label
+MONDO:0001569	acoustic neuroma	acoustic neurilemoma	acoustic neurilemmoma	synonym
+MONDO:0011786	allergic rhinitis	perennial allergic rhinitis	Perenial allergic rhinitis	synonym
+MONDO:0015045	alpha-heavy chain disease	Mediterraneanl lymphoma	Mediterranean lymphoma	synonym
+MONDO:0007104	amyotrophic lateral sclerosis-parkinsonism-dementia complex	Lytigo-Bodig disease	Lytico-Bodig disease	synonym
+MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	epidermolytic palmoplantar keratoderma wooly hair and dilated cardiomyopathy	epidermolytic palmoplantar keratoderma woolly hair and dilated cardiomyopathy	synonym
+MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	keratoderma with wooly hair type II	keratoderma with woolly hair type II	synonym
+MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	palmoplantar keratoderma with left ventricular cardiomyopathy and wooly hair	palmoplantar keratoderma with left ventricular cardiomyopathy and woolly hair	synonym
+MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	wooly hair - palmoplantar keratoderma - dilated cardiomyopathy	woolly hair - palmoplantar keratoderma - dilated cardiomyopathy	synonym
+MONDO:0011581	arrhythmogenic cardiomyopathy with wooly hair and keratoderma	wooly hair-palmoplantar hyperkeratosis-dilated cardiomyopathy syndrome	woolly hair-palmoplantar hyperkeratosis-dilated cardiomyopathy syndrome	synonym
+MONDO:0012506	arrhythmogenic right ventricular dysplasia 11	arrhythmogenic right ventricular dysplasia 11 with mild palmoplantar keratoderma and wooly hair	arrhythmogenic right ventricular dysplasia 11 with mild palmoplantar keratoderma and woolly hair	synonym
+MONDO:0007158	arthrogryposis- oculomotor limitation-electroretinal anomalies syndrome	arthrogryposis with oculomotor limitation and electroretinal abnormalities	Arthogryposis with oculomotor limitation and electroretinal abnormalities	synonym
+MONDO:0022535	autonomic facial cephalgia	Carotidynia	Carotodynia	synonym
+MONDO:0008312	autosomal dominant prognathism	Hapsburg jaw	Habsburg jaw	synonym
+MONDO:0020717	autosomal dominant wooly hair	wooly hair, autosomal dominant	woolly hair, autosomal dominant	synonym
+MONDO:0007191	Behcet disease	Behcet syndrome	Bechet syndrome	synonym
+MONDO:0007339	blepharocheilodontic syndrome	Elschnig syndrome	Elsching syndrome	synonym
+MONDO:0024472	boutonneuse fever	Kenyan tick typhus	Kenya tick typhus	synonym
+MONDO:0014355	cardiomyopathy, dilated, with wooly hair, keratoderma, and tooth agenesis	dilated cardiomyopathy with wooly hair, keratoderma, and tooth agenesis	dilated cardiomyopathy with woolly hair, keratoderma, and tooth agenesis	synonym
+MONDO:0019165	central precocious puberty	gonadotropin-dependent precocious puberty	gonadotropin-dependant precocious puberty	synonym
+MONDO:0015274	chronic beryllium disease	Beryllliosis	berylliosis	synonym
+MONDO:0012833	Crouzon syndrome-acanthosis nigricans syndrome	Crouzonodermoskeletal syndrome	Crouzon-dermoskeletal syndrome	synonym
+MONDO:0003963	diffuse infiltrative lymphocytosis syndrome	diffuse infiltra. lymph. syndrome	diffuse infiltra. lymph. sydrome	synonym
+MONDO:0009297	familial renal glucosuria	Renal Glycosuria	renal glucosuria	synonym
+MONDO:0003962	Froelich syndrome	Froelich's syndrome	Froehlich's syndrome	synonym
+MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant pituitary gland somatotropinoma	malignant pituitary gland Somatotrophinoma	synonym
+MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant pituitary somatotropinoma	malignant pituitary Somatotrophinoma	synonym
+MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant somatotropinoma of pituitary	malignant Somatotrophinoma of pituitary	synonym
+MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant somatotropinoma of pituitary gland	malignant Somatotrophinoma of pituitary gland	synonym
+MONDO:0003828	growth hormone-producing pituitary gland carcinoma	malignant somatotropinoma of the pituitary gland	malignant Somatotrophinoma of the pituitary gland	synonym
+MONDO:0008437	hereditary spastic paraplegia 3A	spastic paraplegia 3a, autosomal dominant	spastic paraplegia 3, autosomal dominant	synonym
+MONDO:0012528	hypogonadotropic hypogonadism 4 with or without anosmia	Kallmann syndrome 4	Kallman syndrome 4	synonym
+MONDO:0014390	hypotrichosis 13	hypotrichosis with wooly hair	hypotrichosis with woolly hair	synonym
+MONDO:0011452	hypotrichosis 7	woolly hair, autosomal recessive 2 with or without hypotrichosis	wooly hair, autosomal recessive 2 with or without hypotrichosis	synonym
+MONDO:0008686	isolated familial wooly hair disorder	familial wooly hair (autosomal recessive)	familial woolly hair (autosomal recessive)	synonym
+MONDO:0008686	isolated familial wooly hair disorder	familial wooly hair syndrome	familial woolly hair syndrome	synonym
+MONDO:0008686	isolated familial wooly hair disorder	hereditary wooly hair (autosomal dominant)	hereditary woolly hair (autosomal dominant)	synonym
+MONDO:0008686	isolated familial wooly hair disorder	hereditary wooly hair syndrome	hereditary woolly hair syndrome	synonym
+MONDO:0008686	isolated familial wooly hair disorder	wooly hair	woolly hair	synonym
+MONDO:0008686	isolated familial wooly hair disorder	wooly hair syndrome	woolly hair syndrome	synonym
+MONDO:0008686	isolated familial wooly hair disorder	wooly hair, autosomal dominant	woolly hair, autosomal dominant	synonym
+MONDO:0018971	isolated oxycephaly	hypsocephaly	hypsicephaly	synonym
+MONDO:0009394	juvenile Paget disease	hyperostosis corticalis deformans juvenilis	hyperostosid corticalis deformans juvenilis	synonym
+MONDO:0007899	lichen sclerosus et atrophicus	lichen sclerosus	lichen sclerosis	synonym
+MONDO:0004332	lung hilum cancer	malignant lung hilus neoplasm	malignant lung hilum neoplasm	synonym
+MONDO:0004332	lung hilum cancer	malignant neoplasm of lung hilus	malignant neoplasm of lung hilum	synonym
+MONDO:0005834	lymphogranuloma venereum	lymphogranuloma inguinale	lymph granuloma inguinale	synonym
+MONDO:0019245	lysosomal lipid storage disorder	lipoid storage disease	lipid storage disease	synonym
+MONDO:0009552	mal de Meleda	keratosis palmoplantaris transgrediens of Siemens	keratosis palmoplantaris transgradiens of Siemens	synonym
+MONDO:0020541	maligant granulosa cell tumor of ovary	malignant granulosa cell tumour of the ovary	Maligant granulosa cell tumour of the ovary	synonym
+MONDO:0017827	malignant peripheral nerve sheath tumor	malignant neurilemoma	malignant neurilemmoma	synonym
+MONDO:0009571	Meckel syndrome, type 1	Dysencephalia Splanchnocystica	Dysencephalia splachnocystica	synonym
+MONDO:0017575	mitochondrial neurogastrointestinal encephalomyopathy	Mitochondrial Neurogastrointestinal Encephalopathy	mitochondrial Neurogastrointestingal encephalopathy	synonym
+MONDO:0001000	mixed mineral dust pneumoconiosis	mineral dust pneumoconiosis	mineral duct pneumoconiosis	synonym
+MONDO:0011017	Naxos disease	keratoderma with wooly hair type I	keratoderma with woolly hair type I	synonym
+MONDO:0011017	Naxos disease	keratosis palmoplantaris arrythmogenic cardiomyopathy wooly hair	keratosis palmoplantaris arrythmogenic cardiomyopathy woolly hair	synonym
+MONDO:0011017	Naxos disease	wooly hair palmoplantar keratoderma cardiac abnormalities	woolly hair palmoplantar keratoderma cardiac abnormalities	synonym
+MONDO:0010476	neurodegeneration with brain iron accumulation 5	static encephalopathy Of childhood with neurodegeneration In adulthood	static encephalopathy of childhood with neurdegeneration in adulthood	synonym
+MONDO:0008093	nevus, epidermal	nevus sebaceous or wooly hair nevus, somatic	nevus sebaceous or woolly hair nevus, somatic	synonym
+MONDO:0010104	non-eruption of teeth-maxillary hypoplasia-genu valgum syndrome	multiple none-erupting teeth, maxillo-zygomatical hypoplasia and other congenital defects	multiple non-erupting teeth, maxillo-zygomatical hypoplasia and other congenital defects	synonym
+MONDO:0007856	palmoplantar keratoderma-esophageal carcinoma syndrome	Howell-Evans syndrome	howel-Evans syndrome	synonym
+MONDO:0002470	photosensitive trichothiodystrophy	trichothiodystrophy with congenital ichtyosis	trichothiodystrophy with congenital ichthyosis	synonym
+MONDO:0007564	pilomatrixoma	benign pilomatrixoma	benign pilomatricoma	synonym
+MONDO:0007564	pilomatrixoma	calcifying Epitherlioma of Malherbe	calcifying epithelioma of Malherbe	synonym
+MONDO:0016620	primary hypertrophic osteoarthropathy	hypertropic osteoarthropathy, primary	hypertrophic osteoarthropathy, primary	synonym
+MONDO:0010911	prolactin-producing pituitary gland adenoma	lactotroph adenoma	lactotrope adenoma	synonym
+MONDO:0004574	pyridoxine deficiency anemia	pyridoxine Deficincy	pyridoxine deficiency	synonym
+MONDO:0011970	rolandic epilepsy-paroxysmal exercise-induced dystonia-writer's cramp syndrome	epilepsy, ROLANDIC, with paroxysmal exercise-induced dystonia and writer'S cramp	epilepsy, rolandic, with paroxysmal exercise-induce dystonia and writer's cramp	synonym
+MONDO:0018304	Schnitzler syndrome	chronic urticaria with gammopathy	chronic urticaria with gammapathy	synonym
+MONDO:0002546	schwannoma	neurolemmoma	neurilemmoma	synonym
+MONDO:0018484	semicircular canal dehiscence syndrome	Minorbs syndrome	Minor's syndrome	synonym
+MONDO:0009833	Shwachman-Diamond syndrome	Schwachman-Diamond syndrome	Schwachmann-Diamond syndrome	synonym
+MONDO:0011882	skin fragility-woolly hair-palmoplantar keratoderma syndrome	skin fragility woolly hair syndrome	skin fragility wooly hair syndrome	synonym
+MONDO:0000485	spasmodic dystonia	adductor spasmodic dysphonia	abductor spasmodic dysphonia	synonym
+MONDO:0009669	spinal muscular atrophy, type 1	Werdnig-Hoffmann Disease	Werdnig-Hoffman disease	synonym
+MONDO:0010068	spondyloepimetaphyseal dysplasia, sponastrime type	spondylar and nasal changes with triations of the metaphyses (SPONASTRIME) dysplasia	spondylar and nasal changes with striations of the metaphyses (SPONASTRIME) dysplasia	synonym
+MONDO:0021783	streptococcal sore throat	Strep throat	Strept throat	synonym
+MONDO:0019611	TSH-secreting pituitary adenoma	thyrotroph adenoma	thyrotrope adenoma	synonym
+MONDO:0014765	wooly hair, autosomal recessive 3	KRT25 wooly hair (disease)	KRT25 woolly hair (disease)	synonym
+MONDO:0014765	wooly hair, autosomal recessive 3	wooly hair (disease) caused by mutation in KRT25	woolly hair (disease) caused by mutation in KRT25	synonym
+MONDO:0014765	wooly hair, autosomal recessive 3	wooly hair, autosomal recessive type 3	woolly hair, autosomal recessive type 3	synonym
+MONDO:0010207	wooly hair-hypotrichosis-everted lower lip-outstanding ears syndrome	woolly hair hypotrichosis everted lower lip and outstanding ears	wooly hair hypotrichosis everted lower lip and outstanding ears	synonym
+MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	keratoderma with wooly hair type IV	keratoderma with woolly hair type IV	synonym
+MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	palmoplantar keratoderma and wooly hair	palmoplantar keratoderma and woolly hair	synonym
+MONDO:0014492	wooly hair-palmoplantar keratoderma syndrome	wooly hair-palmoplantar hyperkeratosis syndrome	woolly hair-palmoplantar hyperkeratosis syndrome	synonym
+MONDO:0018892	Wyburn-Mason syndrome	bonnet-Dechaume-Blanc syndrome	bonnet-Decaume-Blanc syndrome	synonym
+MONDO:0018821	X-linked female restricted facial dysmorphism-short stature-choanal atresia-intellectual disability	X-linked facial dysmorphism-short stature-choanal atrsia-intellectual disability syndrome limited to females	X-linked facial dysmorphism-short stature-choanal atresia-intellectual disability syndrome limited to females	synonym


### PR DESCRIPTION
## Summary

Adds an analysis report + machine-readable TSVs under `scratch/misspelling-synonyms-audit/` from a two-part audit of MONDO synonyms and misspellings (against release `2026-07-06`). This PR **does not modify the ontology** — it only adds the report/data so curators can decide what to action.

## Background

MONDO defines a `MISSPELLING` synonym type, but only **2 of 95,023** synonyms currently use it (`holocarboxylase synthase deficiency`, `intellectual disability, XMEN-linked 88`). So the misspelling population is essentially entirely unmarked.

## What's in the report

**Step 1 — synonyms that are misspellings but not typed `MISSPELLING`.** A within-class near-duplicate scan (normalizing away accents, UK/US spelling, punctuation, roman↔arabic numerals, and Latin/plural/adjective morphology) surfaced **852 untyped near-duplicates**, auto-classified as:

| Category | Count | Interpretation |
|---|--:|---|
| Genuine typo | **138** | candidates for `MISSPELLING` |
| UK/US spelling | 265 | candidates for `OMO:0003005` (UK spelling) |
| sibling acronym / subtype codes | 111 | not typos |
| `disk`/`disc`, `c`/`k`, `i`/`y` | 101 | valid variants |

Highlights: the `wooly`→`woolly` hair cluster (~30 synonyms), `mineral duct`→dust pneumoconiosis, `Strept throat`, `sydrome`, `Maligant`, ~20 unambiguous label-level typos, and one **primary label** that is itself misspelled (`proteosome-associated autoinflammatory syndrome` → proteasome).

**Step 2 — common misspellings NOT yet in MONDO.** 250 candidate misspellings across 62 high-prevalence diseases, each confirmed absent from all ~143k MONDO names, with the correct term's MONDO ID captured (e.g. `prostrate cancer`, `chrons disease`, `diabetis`, `guillian-barre`, `asma`, `siphilis`).

## Files

- `README.md` — full write-up, method, and recall limitations
- `typos_final.tsv` — 138 unmarked genuine typos already in MONDO
- `classified.tsv` — all 852 near-duplicates with their category
- `step2_candidates.tsv` — 250 common misspellings absent from MONDO
- `*.py` — reproducible detection/classification scripts (input: `mondo.obo`)

## Caveats

- Step 1 is high-precision / bounded-recall: it only finds a typo when MONDO also carries the correct spelling on the same class, within one edit / one transposition.
- Step 2's seed is hand-curated; frequency should be validated against search-log / "did-you-mean" data before any bulk add.
- The "genuine typo" bucket still contains a handful of borderline accepted-variant spellings (e.g. `pseudarthrosis`, `tendonitis`) that are curator judgment calls.

Tracking issue with curator assignment to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJFxjwqHd2sUxoQbvZDTc3)_