### PR TITLE
 update qc-clingen sparql

### DIFF
--- a/src/sparql/qc/mondo/qc-clingen.sparql
+++ b/src/sparql/qc/mondo/qc-clingen.sparql
@@ -10,22 +10,26 @@ prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 # description: This QC check ensures that no class ever has two clingen labels, and that there are only exact preferred labels
 
-SELECT ?entity ?property ?value
+SELECT DISTINCT ?entity ?property ?value
 WHERE {
  {
   ?ax owl:annotatedSource ?entity ;
          owl:annotatedProperty ?property ;
-         OMO:0002001 <https://w3id.org/information-resource-registry/clingen> .
+         OMO:0002001 ?clingen1 .
   ?ax2 owl:annotatedSource ?entity ;
          owl:annotatedProperty ?property ;
          owl:annotatedTarget ?value ;
-         OMO:0002001 <https://w3id.org/information-resource-registry/clingen> .
+         OMO:0002001 ?clingen2 .
+  FILTER(STR(?clingen1) = "https://w3id.org/information-resource-registry/clingen")
+  FILTER(STR(?clingen2) = "https://w3id.org/information-resource-registry/clingen")
   FILTER(?ax!=?ax2)
   FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))	
   } UNION {
     ?ax owl:annotatedSource ?entity ;
          owl:annotatedProperty ?property ;
-         OMO:0002001 <https://w3id.org/information-resource-registry/clingen> .
+         owl:annotatedTarget ?value ;
+         OMO:0002001 ?clingen1 .
+    FILTER(STR(?clingen1) = "https://w3id.org/information-resource-registry/clingen")
     FILTER(?property!=oboInOwl:hasExactSynonym)
     FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))	
   }

--- a/src/sparql/qc/mondo/qc-clingen.sparql
+++ b/src/sparql/qc/mondo/qc-clingen.sparql
@@ -10,26 +10,25 @@ prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 # description: This QC check ensures that no class ever has two clingen labels, and that there are only exact preferred labels
 
-SELECT DISTINCT ?entity ?property ?value
+SELECT ?entity ?property ?value
 WHERE {
  {
   ?ax owl:annotatedSource ?entity ;
          owl:annotatedProperty ?property ;
-         OMO:0002001 ?clingen1 .
+         OMO:0002001 "https://w3id.org/information-resource-registry/clingen" .
+
   ?ax2 owl:annotatedSource ?entity ;
          owl:annotatedProperty ?property ;
          owl:annotatedTarget ?value ;
-         OMO:0002001 ?clingen2 .
-  FILTER(STR(?clingen1) = "https://w3id.org/information-resource-registry/clingen")
-  FILTER(STR(?clingen2) = "https://w3id.org/information-resource-registry/clingen")
+         OMO:0002001 "https://w3id.org/information-resource-registry/clingen" .
+
   FILTER(?ax!=?ax2)
   FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))	
   } UNION {
     ?ax owl:annotatedSource ?entity ;
          owl:annotatedProperty ?property ;
-         owl:annotatedTarget ?value ;
-         OMO:0002001 ?clingen1 .
-    FILTER(STR(?clingen1) = "https://w3id.org/information-resource-registry/clingen")
+         OMO:0002001 "https://w3id.org/information-resource-registry/clingen" .
+
     FILTER(?property!=oboInOwl:hasExactSynonym)
     FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/MONDO_"))	
   }


### PR DESCRIPTION
close #10545

I asked Claude to update the qc-clingen sparql and check it using my PR term. The updated sparql seems to work now and it found a few more terms that have more than one preferred label. I updated those terms to make sure there are only only preferred label per term. Details below:

The corrected query ran successfully over the full PR #10544 file (exit 0) — it works. Here are the results.

✅ Confirmation for your PR term

MONDO:0100083 → 2 violations — both ClinGen preferred labels are correctly flagged:
- "RUNX1-related hereditary thrombocytopenia and hematological cancer predisposition syndrome"
- "hereditary thrombocytopenia and hematological cancer predisposition syndrome associated with RUNX1"

So the fix does exactly what #10545 asks: it now catches the two-ClinGen-label case that PR #10544 slipped through.

Full blast radius — 7 violations across 4 terms

Running it over the whole ontology also surfaced 3 pre-existing violations the broken check never caught:
<img width="1034" height="161" alt="Screenshot 2026-08-13 at 3 38 40 PM" src="https://github.com/user-attachments/assets/f6232bb3-57a5-4a27-a153-f8b43023d75f" />

This also confirms both rules of the check now fire: block 1 (two ClinGen labels) and block 2 (ClinGen preferred label must be an exact synonym — MONDO:0975761 has it on a narrow synonym).

⚠️ Key implication before committing/merging the QC fix

These 3 other terms are already in master, so once this corrected check is active, CI's ontology_qc will fail on them too — the QC-fix PR cannot go green until those pre-existing violations are also resolved (or the terms fixed in the same/parallel PR). So the fix "works" — arguably too well until the backlog is cleaned up. Worth noting in #10545 and coordinating with the Mondo team on how to handle the 3 pre-existing cases.